### PR TITLE
Arguments fix

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -616,8 +616,9 @@ Server.prototype.addRoute = function (config) {
 
         return function () {
 
-            var args = Array.prototype.slice.call(arguments);
-            var next = args[args.length - 1];                 // Does not modify 'arguments'
+            var args = Array.prototype.slice.call(arguments);   // Covert arguments to instanceof Array
+
+            var next = args[args.length - 1];
             var params = args.slice(0, args.length - 1);
             func(this.req, this.res, next, params);
         };
@@ -722,7 +723,7 @@ exports.addRoutes = function (arg0, arg1) { // [defaultInstances,] routes
 
     // Handle optional arguments
 
-    var args = Array.prototype.slice.call(arguments);
+    var args = Array.prototype.slice.call(arguments);   // Covert arguments to instanceof Array
 
     var defaultInstances = (args.length === 2 ? (args[0] instanceof Array ? args[0] : [args[0]]) : null);
     var routes = (args.length === 2 ? args[1] : args[0]);


### PR DESCRIPTION
Fixed the following error when trying to perform a http request to a Hapi endpoint.
ERROR: Uncaught exception: TypeError: Object #<Object> has no method 'slice'

By default, (arguments instanceof Array) returns false.
