### PR TITLE
support binding hapi to an ephemeral port.  closes #219

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -385,6 +385,7 @@ If an error occurs as a result of one the requests to an endpoint it will be inc
 ## Server Events
 
 The server object emits the following events:
+- _'bound'_ - emitted when the server is bound.  Includes hostname and port as arguments.
 - _'response'_ - emitted after a response is sent back. Includes the request object as value.
 - _'tail'_ - emitted when a request finished processing, including any registered tails as described in [Request Tails](#request-tails).
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -59,7 +59,7 @@ module.exports = internals.Server = function (/* host, port, options */) {      
 
     this.settings = Utils.applyToDefaults(Defaults.server, args.options);
     this.settings.host = args.host ? args.host.toLowerCase() : 'localhost';
-    this.settings.port = args.port || (this.settings.tls ? 443 : 80);
+    this.settings.port = typeof args.port !== 'undefined' ? args.port : (this.settings.tls ? 443 : 80);
     this.settings.nickname = this.settings.host + ':' + this.settings.port;
     this.settings.uri = (this.settings.tls ? 'https://' : 'http://') + this.settings.host + ':' + this.settings.port;
 
@@ -245,9 +245,17 @@ internals.Server.prototype._match = function (method, path) {
 // Start server listener
 
 internals.Server.prototype.start = function () {
-
-    this.listener.listen(this.settings.port, this.settings.host);
-    Log.event('info', this.settings.nickname + ': Instance started at ' + this.settings.uri);
+    var self = this
+    this.listener.listen(this.settings.port, this.settings.host, function() {
+      // what port was actually bound?  for binding of ephemeral ports, this may be different than what
+      // was specified ('0').
+      var port = self.listener.address().port;
+      // update the uri with what was actually bound
+      self.settings.uri = (self.settings.tls ? 'https://' : 'http://') + self.settings.host + ':' + port;
+      Log.event('info', self.settings.nickname + ': Instance started at ' + self.settings.uri);
+      // emit a bound event on the server object, reports port actually bound.
+      self.emit('bound', self.settings.host, port);
+    });
 };
 
 


### PR DESCRIPTION
allows port to be specified as a zero, adds a `bound` event, and delays logging of server startup until it has actually bound the port in question
