### PR TITLE
Fix bug where /docs crashes if no POST routes are defined 

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -81,7 +81,7 @@ internals.getIndexResponse = function(server) {
     var routes = [].concat(server._routes.post, server._routes.get);
 
     routes = routes.filter(function(route) {
-        return route !== null && route.path !== internals.config.docsEndpoint;
+        return route !== null && route !== undefined && route.path !== internals.config.docsEndpoint;
     });
 
     routes.sort(function(route1, route2) {


### PR DESCRIPTION
`server._routes.post` is `undefined` if not post routes are specified.
