### PR TITLE
Fixing failing test

### DIFF
--- a/test/integration/serverTimeout.js
+++ b/test/integration/serverTimeout.js
@@ -174,7 +174,7 @@ describe('Server Timeout', function () {
 
         var req = Http.request(options, function (res) {
 
-            expect(timer.elapsed()).to.be.at.least(100);
+            expect(timer.elapsed()).to.be.at.least(98);
             expect(res.statusCode).to.equal(200);
             done();
         });


### PR DESCRIPTION
Closes #499

The point of the elapsed time check is to make sure that it takes longer than the server timeout to respond.
