### PR TITLE
Cleaning up blanket regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "sinon": "1.x.x",
     "handlebars": ">= 1.0.8",
     "jade": "~0.28.1",
-    "blanket": "1.0.4",
+    "blanket": "1.0.x",
     "travis-cov": "0.2.x"
   },
   "scripts": {
     "test": "make test && make test-cov && make unit",
-    "blanket": { "pattern": "//^((?!\/node_modules\/)(?!\/test\/).)*$/", "data-cover-flags": { "branchTracking": true } },
+    "blanket": { "pattern": "//^((?!\/node_modules\/)(?!\/test\/helpers\/)(?!\/test\/unit\/)(?!\/test\/integration\/).)*$/ig", "onlyCwd": true, "data-cover-flags": { "branchTracking": true } },
     "travis-cov": { "threshold": 100 }
   },
   "licenses": [


### PR DESCRIPTION
After next blanket version is published this should fix symlinked modules from being included in coverage report.
