### PR TITLE
Update docs/Reference.md

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -11,7 +11,7 @@
     - [Format](#format)
       - [Error Format](#error-format)
       - [Payload Format](#payload-format)
-    - [Files](#files)
+    - [Static Files](#static-files)
     - [Views](#views)
     - [Monitor](#monitor)
     - [Authentication](#authentication)
@@ -232,6 +232,14 @@ var options = {
 };
 ```
 
+### Static Files
+
+**hapi** provides built-in support for serving static files and directories as described in [File](#file) and [Directory](#directory).
+When these handlers are provided with relative paths, the `files.relativeTo` server option determines how these paths are resolved
+and defaults to _'routes'_:
+- _'routes'_ - relative paths are resolved based on the location of the files in which the server's _'route()'_ method is called. This means the location of the source code determines the location of the static resources when using relative paths.
+- _'process'_ - relative paths are resolved using the active process path (_'process.cwd()'_).
+
 
 ### Views
 
@@ -253,15 +261,6 @@ To enable Views support, Hapi must be given an options object with a non-null `v
 - `allowAbsolutePaths` - the flag to set if absolute template paths passed to .view() should be allowed.
 - `allowInsecureAccess` - the flag to set if `../` should be allowed in the template paths passed to `.view()`.
 - `compileOptions` - the options object passed to the engine's compile function (compile(string, options)).
-
-
-### Files
-
-**hapi** provides built-in support for serving static files and directories as described in [File](#file) and [Directory](#directory).
-When these handlers are provided with relative paths, the `files.relativeTo` server option determines how these paths are resolved
-and defaults to _'routes'_:
-- _'routes'_ - relative paths are resolved based on the location of the files in which the server's _'route()'_ method is called. This means the location of the source code determines the location of the static resources when using relative paths.
-- _'process'_ - relative paths are resolved using the active process path (_'process.cwd()'_).
 
 
 ### Monitor


### PR DESCRIPTION
Changed header 'Files' to 'Static Files' mostly to make the link work, but also because Static Files is a clearer description of the topic.

Moved the paragraph about static files above the paragraph about views, to make it the same order as in the toc.
