### PR TITLE
Adding graceful shutdown from QUIT signal event

### DIFF
--- a/bin/hapi
+++ b/bin/hapi
@@ -27,6 +27,14 @@ composer.compose(function (err) {
     composer.start(function (err) {
 
         Hapi.utils.assert(!err, 'Failed starting server: ' + (err && err.message));
+
+        process.on('SIGQUIT', function () {                                             // Use kill -s QUIT {pid} to kill the server gracefully
+
+            http.stop(function () {
+
+                process.exit();
+            });
+        });
     });
 });
 


### PR DESCRIPTION
kill -s QUIT {pid} will now wait until all connections are complete before shutting down the server
