### PR TITLE
fix ext plugin sort to account for out of order priority definitions

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -135,9 +135,15 @@ internals.Ext.prototype.sort = function (event) {
     var ancestors = internals.getAncestors(graph);
     var sorted = internals.topoSort(ancestors, exts.length);
 
+    var priorityIndex = {};
+    exts.forEach(function (ext) {
+
+        priorityIndex[ext.priority] = ext;
+    });
+
     this._events[event] = sorted.map(function (value) {
 
-        return exts[value];
+        return priorityIndex[value];
     });
 };
 
@@ -177,19 +183,17 @@ internals.getGraph = function (exts) {
         }
     }
 
-    console.log(graph);
-    console.log(graphAfters);
-
     // Expand intermediary graph
 
     Object.keys(graph).forEach(function (node) {
+
         var expandedGroups = [];
         for (var groupIndex in graph[node]) {
             var group = graph[node][groupIndex];
             groups[group] = groups[group] || [];
             groups[group].forEach(function (d) {
                 expandedGroups.push(d);
-            })
+            });
         }
         graph[node] = expandedGroups;
     });


### PR DESCRIPTION
tests pass for me, LMK if other edge cases occur
