### PR TITLE
Remove duplicate closing of code block

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -521,7 +521,6 @@ server.on('request', function (request, event, tags) {
     }
 });
 ```
-```
 
 The _'response'_ and _'tail'_ events includes the request object:
 ```javascript


### PR DESCRIPTION
A codeblock gets closed twice, which caused the next text to be wrapped in a code block
