### PR TITLE
Support for Access-Control-Expose-Headers in the CORS options

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -473,6 +473,8 @@ CORS implementation that sets very liberal restrictions on cross-origin access b
 - `additionalHeaders` - an array of additional headers to `headers`. Use this to keep the default headers in place.
 - `methods` - overrides the array of allowed methods ('Access-Control-Allow-Methods'). Defaults to _'GET, HEAD, POST, PUT, DELETE, OPTIONS'_.
 - `additionalMethods` - an array of additional methods to `methods`. Use this to keep the default methods in place.
+- `exposedHeaders` - overrides the array of exposed headers ('Access-Control-Expose-Headers'). Defaults to _'WWW-Authenticate, Server-Authorization'_.
+- `additionalExposedHeaders` - an array of additional headers to `exposedHeaders`. Use this to keep the default headers in place.
 - `credentials` - if true, allows user credentials to be sent ('Access-Control-Allow-Credentials'). Defaults to false.
 
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -99,6 +99,11 @@ exports.cors = {
         'OPTIONS'
     ],
     additionalMethods: [],
+    exposedHeaders: [
+        'WWW-Authenticate', 
+        'Server-Authorization'
+    ],
+    additionalExposedHeaders: [],
     credentials: false
 };
 

--- a/lib/response/headers.js
+++ b/lib/response/headers.js
@@ -71,6 +71,7 @@ exports.cors = function (response, request) {
     response.header('Access-Control-Max-Age', request.server.settings.cors.maxAge);
     response.header('Access-Control-Allow-Methods', request.server.settings.cors._methods);
     response.header('Access-Control-Allow-Headers', request.server.settings.cors._headers);
+    response.header('Access-Control-Expose-Headers', request.server.settings.cors._exposedHeaders);
 
     if (request.server.settings.cors.credentials) {
         response.header('Access-Control-Allow-Credentials', 'true');

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -105,6 +105,8 @@ internals.serverSchema = {
         additionalHeaders: T.Array(),
         methods: T.Array(),
         additionalMethods: T.Array(),
+        exposedHeaders: T.Array(),
+        additionalExposedHeaders: T.Array(),
         credentials: T.Boolean()
     }).nullOk().allow(false).allow(true),
     router: T.Object({

--- a/lib/server.js
+++ b/lib/server.js
@@ -104,6 +104,7 @@ module.exports = internals.Server = function (/* host, port, options */) {      
     if (this.settings.cors) {
         this.settings.cors._headers = (this.settings.cors.headers || []).concat(this.settings.cors.additionalHeaders || []).join(', ');
         this.settings.cors._methods = (this.settings.cors.methods || []).concat(this.settings.cors.additionalMethods || []).join(', ');
+        this.settings.cors._exposedHeaders = (this.settings.cors.exposedHeaders || []).concat(this.settings.cors.additionalExposedHeaders || []).join(', ');
     }
 
     // Initialize Views

--- a/test/integration/proxy.js
+++ b/test/integration/proxy.js
@@ -221,6 +221,7 @@ describe('Proxy', function () {
             expect(res.headers.custom1).to.equal('custom header value 1');
             expect(res.headers['x-custom2']).to.equal('custom header value 2');
             expect(res.headers['access-control-allow-headers']).to.equal('Authorization, Content-Type, If-None-Match');
+            expect(res.headers['access-control-expose-headers']).to.equal('WWW-Authenticate, Server-Authorization');
             done();
         });
     });


### PR DESCRIPTION
Added options to CORS to include custom Access-Control-Expose-Headers. It's using the same mechanisms as headers and methods options (a main one with default, in this case to 'WWW-Authenticate, Server-Authorization', and an additional one to add instead of override).

These headers are necessary when making a CORS request to force the getReponseHeader() method of the XmlHttpRequest2 object:

"Access-Control-Expose-Headers (optional) - The XmlHttpRequest2 object has a getResponseHeader() method that returns the value of a particular response header. During a CORS request, the getResponseHeader() method can only access simple response headers. Simple response headers are defined as follows:
- Cache-Control
- Content-Language
- Content-Type
- Expires
- Last-Modified
- Pragma

If you want clients to be able to access other headers, you have to use the Access-Control-Expose-Headers header. The value of this header is a comma-delimited list of response headers you want to expose to the client." (http://www.html5rocks.com/en/tutorials/cors/#toc-handling-a-simple-request)

The real testing of this feature is hard because it depends on an implementation of XmlHttpRequest2 to make sure that the headers which are specified are truly exposed because this "blindness" is only due to XmlHttpRequest2. Still, I added a test for existence of the default exposed headers where I found the test for existence of the default headers.

The choice of the default exposed headers was made to match what's needed by Hawk.
