### PR TITLE
No longer throws an error in request.log when debugging and data is null

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -194,7 +194,8 @@ internals.Request.prototype.log = function (tags, data, timestamp) {
     this._logger.push(item);
     this.server.emit('request', this, item, tagsMap);
 
-    if (this.server.listeners('request').length == 1 &&                 // Pack always listening
+    if (data &&
+        this.server.listeners('request').length === 1 &&                 // Pack always listening
         this.server.settings.debug &&
         this.server.settings.debug.request &&
         Utils.intersect(tagsMap, this.server.settings.debug.request).length) {

--- a/test/unit/request.js
+++ b/test/unit/request.js
@@ -146,6 +146,20 @@ describe('Request', function () {
             expect(request.getLog().length).to.be.above(7);
             done();
         });
+
+        it('doesn\'t throw an error when logging without data and debug is configured', function (done) {
+
+            var debugServer = new Hapi.server({ debug: { request: ['uncaught'] }});
+            var request = new Request(debugServer, _req, _res);
+
+            var fn = function () {
+
+                request.log('uncaught', null, Date.now());
+            };
+
+            expect(fn).to.not.throw(Error);
+            done();
+        });
     });
 
     describe('path normalization', function () {


### PR DESCRIPTION
Closes #749
