### PR TITLE
Fix multipart encoding #771

### DIFF
--- a/lib/payload.js
+++ b/lib/payload.js
@@ -139,7 +139,7 @@ exports.read = function (request, next) {
 
             // Set parser
 
-            internals.parse(payload.toString('utf8'), req.headers, function (err, result) {
+            internals.parse(payload, req.headers, function (err, result) {
 
                 if (err) {
                     return finish(err);
@@ -167,7 +167,7 @@ internals.isGzip = function (compareBuf) {
 };
 
 
-internals.parse = function (result, headers, callback) {
+internals.parse = function (payload, headers, callback) {
 
     callback = Utils.nextTick(callback);
 
@@ -179,7 +179,7 @@ internals.parse = function (result, headers, callback) {
     // Text
 
     if (mime.match(/^text\/.+$/)) {
-        return callback(result);
+        return callback(payload.toString('utf8'));
     }
 
     // JSON
@@ -189,7 +189,7 @@ internals.parse = function (result, headers, callback) {
         var error = null;
 
         try {
-            obj = JSON.parse(result);
+            obj = JSON.parse(payload.toString('utf8'));
         }
         catch (exp) {
             error = Boom.badRequest('Invalid request payload format');
@@ -201,7 +201,7 @@ internals.parse = function (result, headers, callback) {
     // Form-encoded
 
     if (mime === 'application/x-www-form-urlencoded') {
-        return callback(null, Querystring.parse(result));
+        return callback(null, Querystring.parse(payload.toString('utf8')));
     }
 
     // Multipart
@@ -237,7 +237,7 @@ internals.parse = function (result, headers, callback) {
         });
 
         form.writeHeaders(headers);
-        form.write(new Buffer(result));
+        form.write(new Buffer(payload));
         return;
     }
 


### PR DESCRIPTION
Formidable gets the payload buffer after .toString('utf-8') has been called on it. This works for text, but not for binary data in a multipart request. I changed the payload.parse method to pass the 'raw' payload buffer to formidable and updated the test. The test now passes a stream to form-data, so that it encodes the binary data as file in the multipart request and formidable recognizes it as such. The test then compares the filesize and the actual file contents of the source file and the written tmp file. Would be nice if you can take a look at it.
