### PR TITLE
Fixed jade compile issues and updated tests to verify fix.

### DIFF
--- a/examples/views/jade/index.js
+++ b/examples/views/jade/index.js
@@ -29,7 +29,7 @@ internals.main = function () {
 
     var options = {
         views: {
-            engines: { html: 'jade' },
+            engines: { jade: 'jade' },
             path: __dirname + '/templates',
             compileOptions: {
                 pretty: true

--- a/lib/views.js
+++ b/lib/views.js
@@ -212,7 +212,7 @@ internals.Manager.prototype.render = function (filename, context, options) {
 
         var fullPath = (isAbsolutePath ? template : Path.join(settings.basePath || '', settings.path || '', template));
 
-        settings.compileOptions.template = fullPath;            // Pass the template to Jade via this copy of compileOptions
+        settings.compileOptions.filename = fullPath;            // Pass the template to Jade via this copy of compileOptions
 
         // Read file
 

--- a/test/unit/templates/valid/layout.jade
+++ b/test/unit/templates/valid/layout.jade
@@ -1,0 +1,3 @@
+html
+    body
+    block content

--- a/test/unit/templates/valid/testMulti.jade
+++ b/test/unit/templates/valid/testMulti.jade
@@ -1,3 +1,4 @@
-html
-  body
+extends layout
+
+block content
     p= message


### PR DESCRIPTION
Currently on master if try out the jade view example located in `examples/views/jade` you will loading the index view triggers a 500 error.

The first issue is the example is trying to load `.html` as jade files.

The second issue is associated with the use of `extends` in the example, to enable using shared layouts.

The message for this error is as follows:

```
Error: the "filename" option is required to use "extends" with "relative" paths
```

I have resolved this by updating the attribute used to pass the template filename to jade `lib/views.js`

Lastly I added a shared layout to the existing jade template test to ensure this doesn't crop up again.

Thanks
