### PR TITLE
remove connection event listeners when server stops

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -246,7 +246,7 @@ internals.Server.prototype._stop = function (options, callback) {
     }, options.timeout);
 
     self.listener.close(function () {
-
+        self.listener.removeAllListeners()
         clearTimeout(timeoutId);
         callback();
     });

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -154,4 +154,18 @@ describe('Server', function () {
             });
         });
     });
+    it('removes connection event listeners after it stops', function (done) {
+
+        var server = Hapi.createServer(0);
+        server.start(function () {
+            server.stop(function () {
+                server.start(function () {
+                    server.stop(function () {
+                        expect(server.listeners('connection').length).to.be.eql(0);
+                        done();
+                    });
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
if you start and stop an hapi server for more than 10 times you'll get a warning that the number of event listeners has grown beyond the default limit.

 I think we should just remove all listeners after closing the connection.
