### PR TITLE
Removing listeners on domain when exiting

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -118,6 +118,7 @@ internals.Ext.runProtected = function (log, tags, next, setup) {        // setup
 
         isFinished = true;
 
+        domain.removeAllListeners();
         domain.exit();
         return next.apply(null, arguments);
     };


### PR DESCRIPTION
Strangely, domain doesn't remove the listeners on its own: https://github.com/joyent/node/blob/v0.10.9-release/lib/domain.js#L69
