### PR TITLE
Error when hawk payload validation is required but the request contains no hash

### DIFF
--- a/lib/auth/hawk.js
+++ b/lib/auth/hawk.js
@@ -31,7 +31,9 @@ exports = module.exports = internals.Scheme = function (server, options) {
 internals.Scheme.prototype.authenticate = function (request, callback) {
 
     Hawk.server.authenticate(request.raw.req, this.settings.getCredentialsFunc, this.settings.hawk, function (err, credentials, artifacts) {
-
+        if (artifacts && !artifacts.hash) {
+            artifacts.hash = '';
+        }
         return callback(err, credentials, { artifacts: artifacts });
     });
 };

--- a/test/integration/auth.js
+++ b/test/integration/auth.js
@@ -827,6 +827,21 @@ describe('Auth', function () {
                 done();
             });
         });
+
+        it('returns an error with payload validation when the payload hash is not included and payload validation is required', function (done) {
+
+            var payload = 'Here is my payload';
+            var authHeader = Hawk.client.header('http://example.com:8080/hawkPayload', 'POST', { credentials: credentials.john.cred });
+
+            var request = { method: 'POST', url: 'http://example.com:8080/hawkPayload', headers: { authorization: authHeader.field }, payload: payload };
+
+            server.inject(request, function (res) {
+
+                expect(res.statusCode).to.equal(401);
+                expect(res.result.message).to.equal('Payload is invalid');
+                done();
+            });
+        });
     });
 
     describe('Bewit', function () {


### PR DESCRIPTION
When hawk authentication and payload verification are required
authenticatePayload with throw an error if artifacts.hash is
undefined.

I'm not sure if this is the right way to fix it, but the test case shows the issue.

Thanks :)

//cc @zaach
