### PR TITLE
use .isBoom instead of instanceof Boom

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -71,7 +71,7 @@ exports._generate = function (result, onSend) {
             response = new internals.Buffer(result);
         }
         else if (result.isHapiResponse ||
-                result instanceof Boom) {
+                result.isBoom) {
 
             response = result;
         }


### PR DESCRIPTION
For some reason, the existing check was causing a custom authentication plugin to not passing along a status code. I was able to trace it back to this check. 

Despite using Boom to create the error, and the isBoom property being set to true, instanceof Boom was false. 

Changing this check to use .isBoom instead resulted in the expected behavior.
