### PR TITLE
Update README.md, switch nodei.co to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Node version: **0.10** required
 [![Build Status](https://secure.travis-ci.org/spumko/hapi.png)](http://travis-ci.org/spumko/hapi)
 <img src="https://raw.github.com/olivierlacan/shields/master/coveralls/coveralls_100.png" />
 
-[![NPM](http://nodei.co/npm/hapi.png)](http://nodei.co/npm/hapi/)
+[![NPM](https://nodei.co/npm/hapi.png?downloads=true&stars=true)](https://nodei.co/npm/hapi/)
 
 ## Getting started
 


### PR DESCRIPTION
nodei.co has been switched to ssl, GitHub/Fastly cache http images even when they're told not to; plus, you can try out the _download count_ and _star count_ beta features too.
