### PR TITLE
added payload support for HTTP TRACE

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -103,7 +103,8 @@ exports.cors = {
         'POST',
         'PUT',
         'DELETE',
-        'OPTIONS'
+        'OPTIONS',
+        'TRACE'
     ],
     additionalMethods: [],
     exposedHeaders: [

--- a/lib/payload.js
+++ b/lib/payload.js
@@ -28,7 +28,7 @@ exports.read = function (request, next) {
             return next();
         }
 
-        level = request.route.payload.mode || (request.route.validate.payload || ['post', 'put', 'patch'].indexOf(request.method) !== -1 ? 'parse' : 'stream');
+        level = request.route.payload.mode || (request.route.validate.payload || ['post', 'put', 'patch', 'trace'].indexOf(request.method) !== -1 ? 'parse' : 'stream');
         if (level === 'stream') {
             return next();
         }

--- a/lib/route.js
+++ b/lib/route.js
@@ -67,7 +67,7 @@ exports = module.exports = internals.Route = function (options, server, env) {
     if (!this.settings.payload.mode &&
         this.settings.method !== '*') {
 
-        this.settings.payload.mode = (this.settings.validate.payload || ['post', 'put', 'patch'].indexOf(this.settings.method) !== -1 ? 'parse' : 'stream');
+        this.settings.payload.mode = (this.settings.validate.payload || ['post', 'put', 'patch', 'trace'].indexOf(this.settings.method) !== -1 ? 'parse' : 'stream');
     }
 
     Utils.assert(!this.settings.validate.payload || !this.settings.payload.mode || this.settings.payload.mode === 'parse', 'Route payload must be set to \'parse\' when payload validation enabled');


### PR DESCRIPTION
Not sure I've covered everything necessary to fully add support for payloads for TRACE requests but it appears to work in my tests. Closes #988 
