### PR TITLE
Use native Array.isArray() instead of "instanceof Array"

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -44,7 +44,7 @@ var config = [{
 exports = module.exports = internals.Composer = function (manifest) {
 
     this.settings = Utils.clone(manifest);
-    if (this.settings instanceof Array === false) {
+    if (Array.isArray(this.settings) === false) {
         this.settings = [this.settings];
     }
 

--- a/lib/files.js
+++ b/lib/files.js
@@ -57,7 +57,7 @@ exports.directoryHandler = function (route, options) {
 
     Utils.assert(options, 'Options must exist');
     Utils.assert(typeof options === 'object' && options.path, 'Options must be an object with a path');
-    Utils.assert(typeof options.path === 'function' || typeof options.path === 'string' || options.path instanceof Array, 'options.path must be a function, a string, or an array of strings');
+    Utils.assert(typeof options.path === 'function' || typeof options.path === 'string' || Array.isArray(options.path), 'options.path must be a function, a string, or an array of strings');
     Utils.assert(route.path[route.path.length - 1] === '}', 'The route path must end with a parameter');
     Utils.assert(route.params.length === 1, 'The route path must include one and only one parameter');
 
@@ -84,7 +84,7 @@ exports.directoryHandler = function (route, options) {
     };
 
     var normalized = [];
-    if (settings.path instanceof Array) {
+    if (Array.isArray(settings.path)) {
         settings.path.forEach(function (path) {
 
             Utils.assert(path && typeof path === 'string', 'Directory path array must only contain strings');

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -113,7 +113,7 @@ internals.Pack.prototype.register = function (plugin/*, [options], callback */) 
     var callback = (arguments.length === 3 ? arguments[2] : arguments[1]);
     var permissions = internals.defaultPermissions;
 
-    if (options instanceof Array) {
+    if (Array.isArray(options)) {
         permissions = Utils.applyToDefaults(permissions, options[0] || {});
         options = options[1] || null;
     }
@@ -223,7 +223,7 @@ internals.Pack.prototype._register = function (plugin, permissions, options, cal
 
     root.log = function (tags, data, timestamp) {
 
-        tags = (tags instanceof Array ? tags : [tags]);
+        tags = (Array.isArray(tags) ? tags : [tags]);
         var now = (timestamp ? (timestamp instanceof Date ? timestamp.getTime() : timestamp) : Date.now());
 
         var event = {
@@ -286,7 +286,7 @@ internals.Pack.prototype._register = function (plugin, permissions, options, cal
             var options = (arguments.length === 3 ? arguments[1] : null);
             var requireCallback = (arguments.length === 3 ? arguments[2] : arguments[1]);
 
-            Utils.assert(options instanceof Array === false, 'Cannot override root permissions');
+            Utils.assert(Array.isArray(options) === false, 'Cannot override root permissions');
 
             self._require(name, permissions, options, requireCallback, root._requireFunc);
         };
@@ -311,7 +311,7 @@ internals.Pack.prototype._select = function (labels, subset) {
 
     var self = this;
 
-    Utils.assert(!labels || typeof labels === 'string' || labels instanceof Array, 'Bad labels object type (string or array required)');
+    Utils.assert(!labels || typeof labels === 'string' || Array.isArray(labels), 'Bad labels object type (string or array required)');
 
     var ids = [];
     if (labels) {
@@ -365,7 +365,7 @@ internals.Pack.prototype.require = function (name/*, [options], callback*/) {
     var callback = (arguments.length === 3 ? arguments[2] : arguments[1]);
     var permissions = internals.defaultPermissions;
 
-    if (options instanceof Array) {
+    if (Array.isArray(options)) {
         permissions = Utils.applyToDefaults(permissions, options[0] || {});
         options = options[1] || null;
     }
@@ -392,7 +392,7 @@ internals.Pack.prototype._require = function (name, permissions, options, callba
         if (typeof name === 'string') {
             registrations.push({ name: name, options: options, permissions: permissions });
         }
-        else if (name instanceof Array) {
+        else if (Array.isArray(name)) {
             name.forEach(function (item) {
 
                 registrations.push({ name: item, options: null, permissions: permissions });
@@ -407,7 +407,7 @@ internals.Pack.prototype._require = function (name, permissions, options, callba
                     permissions: permissions
                 };
 
-                if (reg.options instanceof Array) {
+                if (Array.isArray(reg.options)) {
                     reg.permissions = Utils.applyToDefaults(reg.permissions, reg.options[0] || {});
                     reg.options = reg.options[1] || null;
                 }
@@ -517,7 +517,7 @@ internals.Pack.prototype.allow = function (permissions) {
         register: function (name, options, callback) {
 
             var pluginPermissions = rights;
-            if (options instanceof Array) {
+            if (Array.isArray(options)) {
                 pluginPermissions = Utils.applyToDefaults(pluginPermissions, options[0] || {});
                 options = options[1] || null;
             }
@@ -527,7 +527,7 @@ internals.Pack.prototype.allow = function (permissions) {
         require: function (name, options, callback) {
 
             var pluginPermissions = rights;
-            if (options instanceof Array) {
+            if (Array.isArray(options)) {
                 pluginPermissions = Utils.applyToDefaults(pluginPermissions, options[0] || {});
                 options = options[1] || null;
             }

--- a/lib/payload.js
+++ b/lib/payload.js
@@ -50,7 +50,7 @@ exports.read = function (request, next) {
     var mime = contentType.split(';')[0].trim().toLowerCase();
 
     if (request.route.payload.allow &&
-        ((request.route.payload.allow instanceof Array && request.route.payload.allow.indexOf(mime) === -1) ||
+        ((Array.isArray(request.route.payload.allow) && request.route.payload.allow.indexOf(mime) === -1) ||
         request.route.payload.allow !== mime)) {
 
         return next(new Boom(415));     // Unsupported Media Type
@@ -230,7 +230,7 @@ internals.parse = function (payload, mime, headers, callback) {
             if (!data.hasOwnProperty(name)) {
                 data[name] = value;
             }
-            else if (data[name] instanceof Array) {
+            else if (Array.isArray(data[name])) {
                 data[name].push(value);
             }
             else {

--- a/lib/request.js
+++ b/lib/request.js
@@ -175,7 +175,7 @@ internals.Request.prototype._setMethod = function (method) {
 
 internals.Request.prototype.log = function (tags, data, timestamp) {
 
-    tags = (tags instanceof Array ? tags : [tags]);
+    tags = (Array.isArray(tags) ? tags : [tags]);
 
     // Prepare log item
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -83,7 +83,7 @@ internals.Router.prototype.add = function (configs, env) {
     Utils.assert(configs, 'Routes configs must exist');
     Utils.assert(typeof configs === 'object', 'Route configuration must be an object or array');
 
-    configs = (configs instanceof Array ? configs : [configs]);
+    configs = (Array.isArray(configs) ? configs : [configs]);
     configs.forEach(function (config) {
 
         var route = new Route(config, self.server, env);                              // Do no use config beyond this point, use route members

--- a/lib/server.js
+++ b/lib/server.js
@@ -258,7 +258,7 @@ internals.Server.prototype._stop = function (options, callback) {
 
 internals.Server.prototype.log = function (tags, data, timestamp) {
 
-    tags = (tags instanceof Array ? tags : [tags]);
+    tags = (Array.isArray(tags) ? tags : [tags]);
     var now = (timestamp ? (timestamp instanceof Date ? timestamp.getTime() : timestamp) : Date.now());
 
     var event = {

--- a/lib/state.js
+++ b/lib/state.js
@@ -49,7 +49,7 @@ exports.parseCookies = function (request, next) {
             var value = $2 || $3;
 
             if (state[name]) {
-                if (state[name] instanceof Array === false) {
+                if (Array.isArray(state[name]) === false) {
                     state[name] = [state[name]];
                 }
 
@@ -92,7 +92,7 @@ exports.parseCookies = function (request, next) {
 
             // Single value
 
-            if (value instanceof Array === false) {
+            if (Array.isArray(value) === false) {
                 unsign(name, value, definition, function (err, unsigned) {
 
                     if (err) {
@@ -292,12 +292,12 @@ exports.generateSetCookieHeader = function (cookies, definitions, callback) {
     definitions = definitions || {};
 
     if (!cookies ||
-        (cookies instanceof Array && !cookies.length)) {
+        (Array.isArray(cookies) && !cookies.length)) {
 
         return Utils.nextTick(callback)(null, []);
     }
 
-    if (cookies instanceof Array === false) {
+    if (Array.isArray(cookies) === false) {
         cookies = [cookies];
     }
 


### PR DESCRIPTION
Parts of the code base where still using instanceof Array. Switched all the found cases to Array.isArray() which is faster for v8 and instanceof Array only checks to left hand inheritance chain to see if the object was made with the Array constructor, this could cause failure in edge cases and when used with the vm module.
