### PR TITLE
Improve server constructor argument validation error reporting

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -58,7 +58,7 @@ module.exports = internals.Server = function (/* host, port, options */) {      
         var type = typeof arguments[a];
         var key = argMap[type];
         Utils.assert(key, 'Bad server constructor arguments: no match for arg type:', type);
-        Utils.assert(!args[key], 'Bad server constructor arguments: duplicated arg type:', type);
+        Utils.assert(!args[key], 'Bad server constructor arguments: duplicated arg type:', type, '(values: `' + args[key] +  '`, `' + arguments[a] + '`)');
         args[key] = arguments[a];
     }
 


### PR DESCRIPTION
Again, not sure if you guys will appreciate this change or not, but I found the error message a bit cryptic when I accidentally passed the wrong type in to the server constructor (port was a string).

Possibly it is just because I'm unfamiliar with that idiom of argument parsing (presumably it is to allow arguments in any order?), but I reckon I'd have diagnosed the problem more easily if the error message contained the values that were in error.

Just thought I'd offer this change in case it saves someone else time in the future, although I totally understand if you don't want to go down the route of optimising error messages for user stupidity! :)
