### PR TITLE
Set Joi's global setting through server config

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -177,6 +177,8 @@ When creating a server instance, the following options configure the server's be
     - `additionalExposedHeaders` - a strings array of additional headers to `exposedHeaders`. Use this to keep the default headers in place.
     - `credentials` - if `true`, allows user credentials to be sent ('Access-Control-Allow-Credentials'). Defaults to `false`.
 <p></p>
+- `validate` - configures one or more global options for the validation. The settings are described in the [Joi](http://github.com/spumko/joi) module.
+<p></p>
 - `debug` - controls the error types sent to the console:
     - `request` - a string array of request log tags to be displayed via `console.error()` when the events are logged via `request.log()`. Defaults
       to uncaught errors thrown in external code (these errors are handled automatically and result in an Internal Server Error (500) error response.

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -82,7 +82,8 @@ exports.server = {
 
     cors: false,                                    // CORS headers on responses and OPTIONS requests (defaults: exports.cors): false -> null, true -> defaults, {} -> override defaults
     views: null,                                    // Views engine
-    auth: {}                                        // Authentication
+    auth: {},                                       // Authentication
+    validate: {}
 };
 
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -25,6 +25,7 @@ exports.server = function (options) {
 internals.serverSchema = {
     app: T.Object().nullOk(),
     auth: T.Object().allow(false).allow(true),
+    validate: T.Object().nullOk(),
     cache: [T.String().nullOk(), T.Object({
         engine: [T.String().required(), T.Object().required()],
         partition: T.String(),

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,7 @@ var Os = require('os');
 var Shot = require('shot');
 var Boom = require('boom');
 var Catbox = require('catbox');
+var Joi = require('joi');
 var Auth = require('./auth');
 var Defaults = require('./defaults');
 var DTrace = require('./dtrace');
@@ -97,6 +98,10 @@ module.exports = internals.Server = function (/* host, port, options */) {      
     this.plugins = {};                                      // Registered plugin APIs by plugin name
     this.app = {};                                          // Place for application-specific state without conflicts with hapi, should not be used by plugins
     this.helpers = this.pack._helpers;                      // Helper functions
+
+    // Apply Joi's settings
+
+    Joi.settings = Utils.applyToDefaults(Joi.settings, this.settings.validate);
 
     // Generate CORS headers
 

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -2,6 +2,7 @@
 
 var Lab = require('lab');
 var Net = require('net');
+var Joi = require('joi');
 var Hapi = require('../..');
 
 
@@ -195,6 +196,30 @@ describe('Server', function () {
                 });
             });
         });
+    });
+
+    it('sets Joi\'s settings', function (done) {
+
+        var config = {
+            validate: {
+                saveConversions: true
+            }
+        };
+
+        expect(Joi.settings.saveConversions).to.equal(false);
+
+        var server = new Hapi.Server('0.0.0.0', 0, config);
+        server.start(function () {
+
+            expect(Joi.settings.saveConversions).to.equal(true);
+            Joi.settings.saveConversions = false;
+
+            server.stop(function () {
+
+                done();
+            });
+        });
+
     });
 
 });


### PR DESCRIPTION
Allows to set Joi's global settings using a `validate` key in the server configuration options.
Useful for the next release of Joi which has options to allow extra keys and strip extra keys.
