### PR TITLE
Assert that hapi is being run with a compatible version of node

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,8 @@
-// Export public modules
+if(parseInt(process.version.split(".")[1],10) < 10) {
+    throw new Error("hapi requires node v0.10 or above");
+}
 
+// Export public modules
 exports.error = exports.Error = exports.boom = exports.Boom = require('boom');
 exports.Server = require('./server');
 exports.response = require('./response');


### PR DESCRIPTION
I missed this in the documentation, and even if I hadn't I might have activated/installed the wrong version. This'll save people time tracking down why it's not working :)
