### PR TITLE
Test for both formats of Content-Encoding header

### DIFF
--- a/lib/response/generic.js
+++ b/lib/response/generic.js
@@ -105,7 +105,7 @@ internals.Generic.prototype._transmit = function (request, callback) {
             return send();
         }
 
-        if (!self._headers['content-encoding']) {
+        if (!self._headers['Content-Encoding'] && !self._headers['content-encoding']) {
             var negotiator = new Negotiator(request.raw.req);
             var encoding = negotiator.preferredEncoding(['gzip', 'deflate', 'identity']);
             if (['gzip', 'deflate'].indexOf(encoding) !== -1) {

--- a/lib/response/stream.js
+++ b/lib/response/stream.js
@@ -128,7 +128,7 @@ internals.Stream.prototype._transmit = function (request, callback) {
     var self = this;
 
     var encoder = null;
-    if (!this._headers['content-encoding']) {
+    if (!this._headers['Content-Encoding'] && !this._headers['content-encoding']) {
         var negotiator = new Negotiator(request.raw.req);
         var encoding = negotiator.preferredEncoding(['gzip', 'deflate', 'identity']);
         if (encoding === 'deflate' || encoding === 'gzip') {

--- a/test/integration/gzip.js
+++ b/test/integration/gzip.js
@@ -40,6 +40,19 @@ describe('Payload', function () {
 
     server.route(postHandler);
 
+    var getHandler = {
+        method: 'GET',
+        path: '/',
+        config: {
+            handler: function (req) {
+
+                req.reply('{"test":"true"}');
+            }
+        }
+    };
+
+    server.route(getHandler);
+
     before(function (done) {
 
         server.start(function () {
@@ -121,7 +134,7 @@ describe('Payload', function () {
         });
     });
 
-    it('returns a gzip response when accept-encoding: gzip is requested', function (done) {
+    it('returns a gzip response on a post request when accept-encoding: gzip is requested', function (done) {
 
         var rawBody = '{"test":"true"}';
 
@@ -135,7 +148,21 @@ describe('Payload', function () {
         });
     });
 
-    it('returns a gzip response when accept-encoding: * is requested', function (done) {
+    it('returns a gzip response on a get request when accept-encoding: gzip is requested', function (done) {
+
+        var rawBody = '{"test":"true"}';
+
+        Request.get({ url: uri, headers: { 'accept-encoding': 'gzip' } }, function (err, res, body) {
+
+            Zlib.gzip(rawBody, function (err, zippedBody) {
+
+                expect(body).to.equal(zippedBody.toString());
+                done();
+            });
+        });
+    });
+
+    it('returns a gzip response on a post request when accept-encoding: * is requested', function (done) {
 
         var rawBody = '{"test":"true"}';
 
@@ -149,7 +176,21 @@ describe('Payload', function () {
         });
     });
 
-    it('returns a deflate response when accept-encoding: deflate is requested', function (done) {
+    it('returns a gzip response on a get request when accept-encoding: * is requested', function (done) {
+
+        var rawBody = '{"test":"true"}';
+
+        Request.get({ url: uri, headers: { 'accept-encoding': '*' } }, function (err, res, body) {
+
+            Zlib.gzip(rawBody, function (err, zippedBody) {
+
+                expect(body).to.equal(zippedBody.toString());
+                done();
+            });
+        });
+    });
+
+    it('returns a deflate response on a post request when accept-encoding: deflate is requested', function (done) {
 
         var rawBody = '{"test":"true"}';
 
@@ -163,7 +204,21 @@ describe('Payload', function () {
         });
     });
 
-    it('returns a gzip response when accept-encoding: gzip,q=1; deflate,q=.5 is requested', function (done) {
+    it('returns a deflate response on a get request when accept-encoding: deflate is requested', function (done) {
+
+        var rawBody = '{"test":"true"}';
+
+        Request.get({ url: uri, headers: { 'accept-encoding': 'deflate' } }, function (err, res, body) {
+
+            Zlib.deflate(rawBody, function (err, zippedBody) {
+
+                expect(body).to.equal(zippedBody.toString());
+                done();
+            });
+        });
+    });
+
+    it('returns a gzip response on a post request when accept-encoding: gzip,q=1; deflate,q=.5 is requested', function (done) {
 
         var rawBody = '{"test":"true"}';
 
@@ -177,7 +232,21 @@ describe('Payload', function () {
         });
     });
 
-    it('returns a deflate response when accept-encoding: deflate,q=1; gzip,q=.5 is requested', function (done) {
+    it('returns a gzip response on a get request when accept-encoding: gzip,q=1; deflate,q=.5 is requested', function (done) {
+
+        var rawBody = '{"test":"true"}';
+
+        Request.get({ url: uri, headers: { 'accept-encoding': 'gzip,q=1; deflate,q=.5' } }, function (err, res, body) {
+
+            Zlib.gzip(rawBody, function (err, zippedBody) {
+
+                expect(body).to.equal(zippedBody.toString());
+                done();
+            });
+        });
+    });
+
+    it('returns a deflate response on a post request when accept-encoding: deflate,q=1; gzip,q=.5 is requested', function (done) {
 
         var rawBody = '{"test":"true"}';
 
@@ -191,7 +260,21 @@ describe('Payload', function () {
         });
     });
 
-    it('returns a gzip response when accept-encoding: deflate, gzip is requested', function (done) {
+    it('returns a deflate response on a get request when accept-encoding: deflate,q=1; gzip,q=.5 is requested', function (done) {
+
+        var rawBody = '{"test":"true"}';
+
+        Request.get({ url: uri, headers: { 'accept-encoding': 'deflate,q=1; gzip,q=.5' } }, function (err, res, body) {
+
+            Zlib.deflate(rawBody, function (err, zippedBody) {
+
+                expect(body).to.equal(zippedBody.toString());
+                done();
+            });
+        });
+    });
+
+    it('returns a gzip response on a post request when accept-encoding: deflate, gzip is requested', function (done) {
 
         var rawBody = '{"test":"true"}';
 
@@ -205,11 +288,36 @@ describe('Payload', function () {
         });
     });
 
-    it('returns an identity response when accept-encoding is missing', function (done) {
+    it('returns a gzip response on a get request when accept-encoding: deflate, gzip is requested', function (done) {
+
+        var rawBody = '{"test":"true"}';
+
+        Request.get({ url: uri, headers: { 'accept-encoding': 'deflate, gzip' } }, function (err, res, body) {
+
+            Zlib.gzip(rawBody, function (err, zippedBody) {
+
+                expect(body).to.equal(zippedBody.toString());
+                done();
+            });
+        });
+    });
+
+    it('returns an identity response on a post request when accept-encoding is missing', function (done) {
 
         var rawBody = '{"test":"true"}';
 
         Request.post({ url: uri, headers: {}, body: rawBody }, function (err, res, body) {
+
+            expect(body).to.equal(rawBody);
+            done();
+        });
+    });
+
+    it('returns an identity response on a get request when accept-encoding is missing', function (done) {
+
+        var rawBody = '{"test":"true"}';
+
+        Request.get({ url: uri, headers: {}}, function (err, res, body) {
 
             expect(body).to.equal(rawBody);
             done();


### PR DESCRIPTION
Due to some inconsistencies in how headers are formatted through the code, I added an extra check for 'Content-Encoding' as well as 'content-encoding' when determining if the response should be compressed.

This came up due to wanting to manually gzip a response in a handler, and manually setting the 'Content-Encoding' header. If I used the proper format, the existing code would compress my already compressed response.

I feel this is a band-aid to a bigger issue, that is inconsistent header formatting in what is being checked for and what is being added as headers.

I also added tests for GET requests in the gzip integration test, as well was removed a duplicate test near the end.
