### PR TITLE
Only set access-control-allow-origin if the origin header value matches (or '*' is allowed)

### DIFF
--- a/lib/response/headers.js
+++ b/lib/response/headers.js
@@ -61,13 +61,9 @@ exports.cors = function (response, request) {
         if (origin &&
             (allowOrigin.indexOf(origin) !== -1 || allowOrigin.indexOf('*') !== -1)) {
 
-            allowOrigin = origin;
-        }
-        else {
-            allowOrigin = allowOrigin.join(' ');
+            response.header('access-control-allow-origin', origin);
         }
 
-        response.header('access-control-allow-origin', allowOrigin);
     }
 
     response.header('access-control-max-age', request.server.settings.cors.maxAge);


### PR DESCRIPTION
I don't necessarily want to make known which origins are allowed for a private service. I could see allowing '*' to always be sent as a sign that this is a public service so this diff might not be the perfect (ish) solution.
