### PR TITLE
Add better error message for wrong param type for port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -58,7 +58,7 @@ module.exports = internals.Server = function (/* host, port, options */) {      
         var type = typeof arguments[a];
         var key = argMap[type];
         
-        if(args[key] && type === "string" && a === 1){
+        if(args[key] && a === 1 && !isNaN(parseInt(arguments[a], 10))){
             Utils.assert(type === "number", "Bad server constructor arguments: port arg must be a number type: ", arguments[a]);
         }
         


### PR DESCRIPTION
Convenience error for clearly conveying that the port should be of type "number"
