### PR TITLE
updates plugin.views Reference.md entry to a clear and working example

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -3065,7 +3065,9 @@ exports.register = function (plugin, options, next) {
 
     plugin.views({
         engines: {
-            jade: require('jade')
+            html: { 
+              module: require('handlebars') 
+            }
         },
         path: './templates'
     });


### PR DESCRIPTION
The current example for setting plugin-specific views engines breaks because `require('jade')` returns an object (and so extends and invalidates the options that get passed to `pack.views`). It also does not clearly show that "jade" refers to the file extension and not the module itself:

``` javascript
exports.register = function (plugin, options, next) {

    plugin.views({
        engines: {
            jade: require('jade') 
        },
        path: './templates'
    });

    next();
};
```

I'm proposing a simple change to the following, which tries to clarify that "html" refers to the file extension of the view template and also shows a working example that follows the guidelines specified in the docs:

``` javascript
exports.register = function (plugin, options, next) {

    plugin.views({
        engines: {
            html: { 
              module: require('handlebars') 
            }
        },
        path: './templates'
    });

    next();
};
```
