### PR TITLE
Only emit vary origin for CORS wildcard mode

### DIFF
--- a/lib/response/headers.js
+++ b/lib/response/headers.js
@@ -59,13 +59,16 @@ exports.cors = function (response, request) {
             response.header('access-control-allow-origin', '*');
         }
         else {
-            response.header('vary', 'origin', true);
-
-            if (internals.matchOrigin(request.headers.origin, cors)) {
-                response.header('access-control-allow-origin', request.headers.origin);
-            }
-            else if (cors._origin.qualifiedString && cors.isOriginExposed) {
+            if (cors._origin.qualifiedString && cors.isOriginExposed) {
                 response.header('access-control-allow-origin', cors._origin.qualifiedString);
+            }
+            else if (internals.matchOrigin(request.headers.origin, cors)) {
+                response.header('access-control-allow-origin', request.headers.origin);
+                response.header('vary', 'origin', true);
+            }
+            else {
+                // Need to provide vary for misses to prevent improper caching of misses
+                response.header('vary', 'origin', true);
             }
         }
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -164,7 +164,10 @@ module.exports = internals.Server = function (/* host, port, options */) {      
                     }
                 }
 
-                this.settings.cors._origin.qualifiedString = this.settings.cors._origin.qualified.join(' ');
+                // If there are any wildcards then we have to work in vary origin mode
+                if (!this.settings.cors._origin.wildcards.length) {
+                    this.settings.cors._origin.qualifiedString = this.settings.cors._origin.qualified.join(' ');
+                }
             }
         }
     }


### PR DESCRIPTION
If wildcards are not set then the server will respond with a static origin
list per the spec. This behavior can be disabled with the isOriginExposed
flag, effectively forcing wildcard-type behavior.

If wildcards are defined, other the simple *, all requests will have the vary
origin response applied to them.
