### PR TITLE
be more careful about options in _provisionCache

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -685,7 +685,7 @@ internals.Pack.prototype._applySync = function (servers, func, args) {
 
 internals.Pack.prototype._provisionCache = function (options, type, name, segment) {
 
-    Utils.assert(typeof options === 'object', 'Invalid cache policy options');
+    Utils.assert(options && typeof options === 'object', 'Invalid cache policy options');
     Utils.assert(name, 'Invalid cache policy name');
     Utils.assert(['helper', 'route', 'plugin', 'server'].indexOf(type) !== -1, 'Unknown cache policy type:', type);
 


### PR DESCRIPTION
I just spent the better part of an hour tracking down a bug, only to find it was due to the difference between server.cache and plugin.cache. Turns out if you call 

``` js
var cache = plugin.cache('name', { /* options */ });
```

Nothing complains, despite the string `'name'` being sent as the options object to _provisionCache. This means that the ttl ends up defaulting to 0 and your cache basically doesn't store anything. This quick little change at least made it so it would catch my boneheaded mistake if I do it again in the future.
