### PR TITLE
Document validation option in settings

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -259,6 +259,8 @@ When creating a server instance, the following options configure the server's be
 - `maxSockets` - sets the number of sockets available per outgoing host connection. `null` means use node.js default value.
     Impacts all outgoing client connections using the defualt HTTP/HTTPS agent. Defaults to `Infinity`.
 
+- `validation` - options to pass to [Joi](http://github.com/spumko/joi). Useful to set global options such as `stripUnknown` or `abortEarly` (the complete list is available [here](https://github.com/spumko/joi#validatevalue-schema-options)). Defaults to `undefined`.
+
 - <a name="server.config.views"></a>`views` - enables support for view rendering (using templates to generate responses). Disabled by default.
   To enable, set to an object with the following options:
     - `engines` - (required) an object where each key is a file extension (e.g. 'html', 'jade'), mapped to the npm module name (string) used for


### PR DESCRIPTION
I couldn't find any docs on the very useful `validation` option in the server's settings. I don't know if it's intentional or not, but in case it's not here's some docs.
