### PR TITLE
Fix query(string) regression

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -158,7 +158,7 @@ Utils.inherits(internals.Request, Events.EventEmitter);
 internals.Request.prototype._setUrl = function (url) {
 
     this.url = Url.parse(url, false);
-    this.query = Qs.parse(this.url.query) || {};
+    this.query = this.url.query = Qs.parse(this.url.query) || {};
     this.path = this.url.pathname;          // pathname excludes query
 
     if (this.path &&


### PR DESCRIPTION
introduced by yours truly in #1301

i found this trying to leverage travelogue ... turns out plugins and what-not are interested in `url.query` :astonished:

sorry ya'll.
