### PR TITLE
Use configuration objects to register helpers

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -25,7 +25,7 @@
         - [`server.auth.strategy(name, scheme, [mode], [options])`](#serverauthstrategyname-scheme-mode-options)
         - [`server.ext(event, method, [options])`](#serverextevent-method-options)
             - [Request lifecycle](#request-lifecycle)
-        - [`server.helper(name, method, [options])`](#serverhelpername-method-options)
+        - [`server.helper(config)`](#serverhelper)
         - [`server.inject(options, callback)`](#serverinjectoptions-callback)
     - [`Server` events](#server-events)
 - [Request object](#request-object)
@@ -84,7 +84,7 @@
         - [`plugin.dependency(deps, [after])`](#plugindependencydeps-after)
         - [`plugin.after(method)`](#pluginaftermethod)
         - [`plugin.views(options)`](#pluginviewsoptions)
-        - [`plugin.helper(name, method, [options])`](#pluginhelpername-method-options)
+        - [`plugin.helper()`](#pluginhelper)
         - [`plugin.helpers`](#pluginhelpers)
         - [`plugin.cache(options)`](#plugincacheoptions)
         - [`plugin.require(name, options, callback)`](#pluginrequirename-options-callback)
@@ -284,7 +284,7 @@ Each instance of the `Server` object have the following properties:
 
 - `app` - application-specific state. Provides a safe place to store application data without potential conflicts with **hapi**.
   Should not be used by plugins which should use `plugins[name]`.
-- `helpers` - helper functions registered with [`server.helper()`](#serverhelpername-method-options).
+- `helpers` - helper functions registered with [`server.helper()`](#serverhelper).
 - `info` - server information:
     - `port` - the port the server was configured to (before `start()`) or bound to (after `start()`).
     - `host` - the hostname the server was configured to (defaults to `'0.0.0.0'` if no host was provided).
@@ -705,7 +705,7 @@ those methods are called in parallel. `pre` can be assigned a mixed array of:
         - `'log'` - logs the error but continues processing the request. If `assign` is used, the error will be assigned.
         - `'ignore'` - takes no special action. If `assign` is used, the error will be assigned.
 - functions - same as including an object with a single `method` key.
-- strings - special short-hand notation for [registered server helpers](#serverhelpername-method-options) using the format 'name(args)'
+- strings - special short-hand notation for [registered server helpers](#serverhelper) using the format 'name(args)'
   (e.g. `'user(params.id)'`) where:
     - 'name' - the helper name. The name is also used as the default value of `assign`.
     - 'args' - the helper arguments (excluding `next`) where each argument is a property of `request`.
@@ -1051,13 +1051,13 @@ Each incoming request passes through a pre-defined set of steps, along with opti
 - Wait for tails
 - Emits `'tail'` event
 
-#### `server.helper(name, method, [options])`
+#### `server.helper(config)`
 
 Registers a server helper function. Server helpers are functions registered with the server and used throughout the application as
 a common utility. Their advantage is in the ability to configure them to use the built-in cache and shared across multiple request
 handlers without having to create a common module.
 
-Helpers are registered via `server.helper(name, method, [options])` where:
+Helpers are registered via `server.helper(config)` where `config` is an object with the keys:
 
 - `name` - a unique helper name used to invoke the method via `server.helpers[name]`. When configured with caching enabled,
   `server.helpers[name].cache.drop(arg1, arg2, ..., argn, callback)` can be used to clear the cache for a given key.
@@ -1083,6 +1083,8 @@ Helpers are registered via `server.helper(name, method, [options])` where:
      `null` if no key can be generated). Note that when the `generateKey` method is invoked, the arguments list will include
      the `next` argument which must not be used in calculation of the key.
 
+`config` can also be an array of helper configuration objects to register multiple helpers in one call.
+
 ```javascript
 var Hapi = require('hapi');
 var server = new Hapi.Server();
@@ -1094,7 +1096,7 @@ var add = function (a, b, next) {
     next(a + b);
 };
 
-server.helper('sum', add, { cache: { expiresIn: 2000 } });
+server.helper({ name: 'sum', method: add, options: { cache: { expiresIn: 2000 } } });
 
 server.helpers.sum(4, 5, function (result) {
 
@@ -1114,12 +1116,16 @@ var addArray = function (array, next) {
     next(sum);
 };
 
-server.helper('sumObj', addArray, {
+server.helper({
+  name: 'sumObj', 
+  method: addArray, 
+  options: {
     cache: { expiresIn: 2000 },
     generateKey: function (array) {
 
         return array.join(',');
     }
+  }
 });
 
 server.helpers.sumObj([5, 6], function (result) {
@@ -2491,16 +2497,19 @@ exports.register = function (plugin, options, next) {
 };
 ```
 
-#### `plugin.helper(name, method, [options])`
+#### `plugin.helper(config)`
 
-Registers a server helper function with all the pack's servers as described in [`server.helper()`](#serverhelpername-method-options)
+Registers a server helper function with all the pack's servers as described in [`server.helper()`](#serverhelper)
 
 ```javascript
 exports.register = function (plugin, options, next) {
 
-    plugin.helper('user', function (id, next) {
+    plugin.helper({
+      name: 'user', 
+      method: function (id, next) {
 
         next({ id: id });
+      }
     });
 
     next();
@@ -2509,14 +2518,17 @@ exports.register = function (plugin, options, next) {
 
 #### `plugin.helpers`
 
-Provides access to the helper methods registered with [`plugin.helper()`](#pluginhelpername-method-options)
+Provides access to the helper methods registered with [`plugin.helper()`](#pluginhelper)
 
 ```javascript
 exports.register = function (plugin, options, next) {
 
-    plugin.helper('user', function (id, next) {
+    plugin.helper({ 
+      name: 'user', 
+      method: function (id, next) {
 
         next({ id: id });
+      }
     });
 
     plugin.helpers.user(5, function (result) {

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -287,9 +287,9 @@ internals.Pack.prototype._register = function (plugin, options, callback, _depen
         env.views = new Views.Manager(options, root._requireFunc);
     };
 
-    root.helper = function (name, method, options) {
+    root.helper = function (configs) {
 
-        return self._helper(name, method, options);
+        return self._helper(configs);
     };
 
     root.cache = function (options) {
@@ -635,87 +635,100 @@ internals.Pack.prototype._provisionCache = function (options, type, name, segmen
 };
 
 
-internals.Pack.prototype._helper = function (name, method, options) {
+internals.Pack.prototype._helper = function (configs) {
 
     var self = this;
 
-    Utils.assert(typeof method === 'function', 'method must be a function');
-    Utils.assert(typeof name === 'string', 'name must be a string');
-    Utils.assert(name.match(/^\w+$/), 'Invalid name:', name);
-    Utils.assert(!this._helpers[name], 'Helper function name already exists');
+    //name, method, options
 
-    var schemaError = Schema.helper(options);
-    Utils.assert(!schemaError, 'Invalid helper options for', name, ':', schemaError);
+    Utils.assert(configs, 'Helper config must exist');
+    Utils.assert(typeof configs === 'object', 'Helper configuration must be an object or array');
 
-    var settings = Utils.clone(options || {});
-    settings.generateKey = settings.generateKey || internals.generateKey;
+    configs = (Array.isArray(configs) ? configs : [configs]);
+    configs.forEach(function (config) {
 
-    // Create helper
+        var method = config.method;
+        var name = config.name;
+        var options = config.options;
 
-    var cache = null;
-    if (settings.cache) {
-        cache = this._provisionCache(settings.cache, 'helper', name, settings.cache.segment);
-    }
+        Utils.assert(typeof method === 'function', 'method must be a function');
+        Utils.assert(typeof name === 'string', 'name must be a string');
+        Utils.assert(name.match(/^\w+$/), 'Invalid name:', name);
+        Utils.assert(!self._helpers[name], 'Helper function name already exists');
 
-    var helper = function (/* arguments, next */) {
+        var schemaError = Schema.helper(options);
+        Utils.assert(!schemaError, 'Invalid helper options for', name, ':', schemaError);
 
-        // Prepare arguments
+        var settings = Utils.clone(options || {});
+        settings.generateKey = settings.generateKey || internals.generateKey;
 
-        var args = arguments;
-        var lastArgPos = args.length - 1;
-        var helperNext = args[lastArgPos];
+        // Create helper
 
-        // Wrap method for Cache.Stale interface 'function (next) { next(err, value); }'
+        var cache = null;
+        if (settings.cache) {
+            cache = self._provisionCache(settings.cache, 'helper', name, settings.cache.segment);
+        }
 
-        var generateFunc = function (next) {
+        var helper = function (/* arguments, next */) {
 
-            args[lastArgPos] = function (result) {
+            // Prepare arguments
 
-                if (result instanceof Error) {
-                    return next(result);
-                }
+            var args = arguments;
+            var lastArgPos = args.length - 1;
+            var helperNext = args[lastArgPos];
 
-                return next(null, result);
+            // Wrap method for Cache.Stale interface 'function (next) { next(err, value); }'
+
+            var generateFunc = function (next) {
+
+                args[lastArgPos] = function (result) {
+
+                    if (result instanceof Error) {
+                        return next(result);
+                    }
+
+                    return next(null, result);
+                };
+
+                method.apply(null, args);
             };
 
-            method.apply(null, args);
-        };
+            if (!cache) {
+                return generateFunc(function (err, result) {
 
-        if (!cache) {
-            return generateFunc(function (err, result) {
-
-                helperNext(err || result);
-            });
-        }
-
-        var key = settings.generateKey.apply(null, args);
-        if (key === null) {                             // Value can be ''
-            self.log(['hapi', 'helper', 'key', 'error'], { name: name, args: args });
-        }
-
-        cache.getOrGenerate(key, generateFunc, function (err, value, cached, report) {
-
-            return helperNext(err || value);
-        });
-    };
-
-    if (cache) {
-        helper.cache = {
-            drop: function (/* arguments, callback */) {
-
-                var dropCallback = arguments[arguments.length - 1];
-
-                var key = settings.generateKey.apply(null, arguments);
-                if (key === null) {                             // Value can be ''
-                    return Utils.nextTick(dropCallback)(Boom.badImplementation('Invalid helper key'));
-                }
-
-                return cache.drop(key, dropCallback);
+                    helperNext(err || result);
+                });
             }
-        };
-    }
 
-    this._helpers[name] = helper;
+            var key = settings.generateKey.apply(null, args);
+            if (key === null) {                             // Value can be ''
+                self.log(['hapi', 'helper', 'key', 'error'], { name: name, args: args });
+            }
+
+            cache.getOrGenerate(key, generateFunc, function (err, value, cached, report) {
+
+                return helperNext(err || value);
+            });
+        };
+
+        if (cache) {
+            helper.cache = {
+                drop: function (/* arguments, callback */) {
+
+                    var dropCallback = arguments[arguments.length - 1];
+
+                    var key = settings.generateKey.apply(null, arguments);
+                    if (key === null) {                             // Value can be ''
+                        return Utils.nextTick(dropCallback)(Boom.badImplementation('Invalid helper key'));
+                    }
+
+                    return cache.drop(key, dropCallback);
+                }
+            };
+        }
+
+        self._helpers[name] = helper;
+    });
 };
 
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -474,7 +474,7 @@ internals.Server.prototype.inject = function (options, callback) {
 };
 
 
-internals.Server.prototype.helper = function (name, method, options) {
+internals.Server.prototype.helper = function (configs) {
 
-    return this.pack._helper(name, method, options);
+    return this.pack._helper(configs);
 };

--- a/test/integration/cache.js
+++ b/test/integration/cache.js
@@ -23,13 +23,19 @@ describe('Cache', function () {
 
     var server = new Hapi.Server(0, { debug: false, cache: [{ engine: 'memory', name: 'secondary' }] });
 
-    server.helper('profile', function (id, next) {
-        
-        next({
-            'id': 'fa0dbda9b1b',
-            'name': 'John Doe'
-        });
-    }, { cache: { expiresIn: 120000 } });
+    server.helper({
+        name: 'profile', 
+        method: function (id, next) {
+
+            next({
+                'id': 'fa0dbda9b1b',
+                'name': 'John Doe'
+            });
+        }, 
+        options: { 
+            cache: { expiresIn: 120000 } 
+        }
+    });
     
     var profileHandler = function (request, reply) {
 

--- a/test/integration/handler.js
+++ b/test/integration/handler.js
@@ -283,9 +283,12 @@ describe('Handler', function () {
 
         var server = new Hapi.Server();
 
-        server.helper('user', function (id, next) {
+        server.helper({
+            name: 'user', 
+            method: function (id, next) {
 
-            return next({ id: id, name: 'Bob' });
+                return next({ id: id, name: 'Bob' });
+            }
         });
 
         server.route({
@@ -313,14 +316,20 @@ describe('Handler', function () {
 
         var server = new Hapi.Server();
 
-        server.helper('user', function (id, next) {
+        server.helper({
+            name: 'user', 
+            method: function (id, next) {
 
-            return next({ id: id, name: 'Bob' });
+                return next({ id: id, name: 'Bob' });
+            }
         });
 
-        server.helper('name', function (user, next) {
+        server.helper({
+            name: 'name', 
+            method: function (user, next) {
 
-            return next(user.name);
+                return next(user.name);
+            }
         });
 
         server.route({

--- a/test/integration/helper.js
+++ b/test/integration/helper.js
@@ -36,7 +36,7 @@ describe('Helper', function () {
             return next({ id: id, gen: gen++ });
         };
 
-        server.helper('test', helper, { cache: { expiresIn: 1000 } });
+        server.helper({ name: 'test', method: helper, options: { cache: { expiresIn: 1000 } } });
 
         server.helpers.test(1, function (result) {
 
@@ -58,7 +58,7 @@ describe('Helper', function () {
             return next({ id: id, gen: gen++ });
         };
 
-        server.helper('dropTest', helper, { cache: { expiresIn: 1000 } });
+        server.helper({ name: 'dropTest', method: helper, options: { cache: { expiresIn: 1000 } } });
 
         server.helpers.dropTest(2, function (result) {
 
@@ -84,7 +84,7 @@ describe('Helper', function () {
             return next({ id: id, gen: gen++ });
         };
 
-        server.helper('dropErrTest', helper, { cache: { expiresIn: 1000 } });
+        server.helper({ name: 'dropErrTest', method: helper, options: { cache: { expiresIn: 1000 } } });
 
         server.helpers.dropErrTest.cache.drop(function () {}, function (err) {
 

--- a/test/integration/pack.js
+++ b/test/integration/pack.js
@@ -66,10 +66,16 @@ describe('Pack', function () {
                 sodd.route({ method: 'GET', path: '/sodd', handler: function (request, reply) { reply('sodd'); } });
 
                 memoryx.state('sid', { encoding: 'base64' });
-                plugin.helper('test', function (next) {
+                plugin.helper({ 
+                    name: 'test', 
+                    method: function (next) {
 
                     next('123');
-                }, { cache: { expiresIn: 1000 } });
+                    }, 
+                    options: { 
+                        cache: { expiresIn: 1000 } 
+                    }
+                });
 
                 server2.helpers.test(function (result) {
 


### PR DESCRIPTION
Here's a proposal:
Looking at `server.helper`, it seems like it could easily accept an object like this:

``` js
{
    name: 'parseData'
    method: function (data, next) {
         next(JSON.parse(data))
    },
    options: {
        expiresIn: 10000
   }
}
```

This would allow to register an array of helper config, just like adding an array of route config.

I've updated the tests and the docs. The logic of adding the helpers is very close to the ones used to add routes.

Main problems:
- Breaking change
- The configuration validation doesn't seem very hapi-esque
- Didn't convert the examples yet
