### PR TITLE
specify hoek minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
-    "hoek": "1.x.x",
+    "hoek": "^1.4.x",
     "boom": "2.x.x",
     "joi": "2.x.x",
     "catbox": "1.x.x",


### PR DESCRIPTION
for instance, `hoek.once` is not available for 1.3.0.

the problem is when you already have hoek version 1.3.0 in your node_modules, and then you install hapi. Because hapi depends on hoek@1.x.x, npm won't install latest hoek in hapi's node_modules (and we don't want to use latest because in the future this hapi version might not work with the latest hoek).
what do you think?

maybe we should do it for other packages?
