### PR TITLE
Allow opting out of response encoding

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -182,7 +182,7 @@ internals.transmit = function (response, request, callback) {
     // Content encoding
 
     var encoder = null;
-    if (!response.headers['content-encoding']) {
+    if (response.settings.encoding !== false && !response.headers['content-encoding']) {
         var negotiator = new Negotiator(request.raw.req);
         var encoding = negotiator.preferredEncoding(['gzip', 'deflate', 'identity']);
         if (encoding === 'deflate' || encoding === 'gzip') {


### PR DESCRIPTION
It can be desirable to avoid adding Content-Encoding in certain
situations. In particular, it may be more important to preserve
the Content-Length for showing progress on large file
downloads.
