### PR TITLE
add failureResponse option to proxy handler

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -412,15 +412,14 @@ The following options are available when adding a route:
                 - `err` - internal error condition.
                 - `uri` - the absolute proxy URI.
                 - `headers` - optional object where each key is an HTTP request header and the value is the header content.
-        - `postResponse` - a custom function for processing the response from the upstream service before sending to the client. Useful for
+        - `preResponse` - a custom function for processing the response from the upstream service before sending to the client. Useful for
           custom error handling of responses from the proxied endpoint or other payload manipulation. Function signature is
-          `function(request, reply, res, settings, ttl)` where:
-              - `request` - is the incoming `request` object.
-              - `reply()` - the continuation function.
+          `function(err, res, request, reply, settings, ttl)` where:
+              - `err` - is any error returned from attempting to contact the upstream proxy
               - `res` - the node response object received from the upstream service. `res` is a readable stream (use the
                 [**nipple**](https://github.com/spumko/nipple) module `parse` method to easily convert it to a Buffer or string).
-                Note: the postResponse function will also be called in the event of an error making a request to the upstream host.
-                You should check for `res.isBoom` to see if the response is an error and handle it appropriately.
+              - `request` - is the incoming `request` object.
+              - `reply()` - the continuation function.
               - `settings` - the proxy handler configuration.
               - `ttl` - the upstream TTL in milliseconds if `proxy.ttl` it set to `'upstream'` and the upstream response included a valid
                 'Cache-Control' header with 'max-age'.

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -61,7 +61,7 @@ exports.handler = function (route, options) {
                 options.headers['x-forwarded-proto'] = (options.headers['x-forwarded-proto'] ? options.headers['x-forwarded-proto'] + ',' : '') + settings.protocol;
             }
 
-            if (settings.postResponse) {
+            if (settings.preResponse || settings.postResponse) {
                 delete options.headers['accept-encoding'];
             }
 
@@ -75,8 +75,8 @@ exports.handler = function (route, options) {
             Nipple.request(request.method, uri, options, function (err, res) {
 
                 if (err) {
-                    if (settings.postResponse) {
-                        return settings.postResponse.call(bind, request, reply, err, settings);
+                    if (settings.preResponse) {
+                        return settings.preResponse.call(bind, err, res, request, reply, settings, ttl);
                     }
                     return reply(err);
                 }
@@ -90,6 +90,10 @@ exports.handler = function (route, options) {
                             ttl = cacheControl['max-age'] * 1000;
                         }
                     }
+                }
+
+                if (settings.preResponse) {
+                    return settings.preResponse.call(bind, undefined, res, request, reply, settings, ttl);
                 }
 
                 if (settings.postResponse) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -204,6 +204,7 @@ internals.routeConfigSchema = {
                 redirects: Joi.number().min(0).integer().allow(false),
                 timeout: Joi.number().integer(),
                 mapUri: Joi.func().without('host', 'port', 'protocol', 'uri'),
+                preResponse: Joi.func(),
                 postResponse: Joi.func(),
                 ttl: Joi.string().valid('upstream').allow(null)
             }),


### PR DESCRIPTION
I added this to provide the ability to add route-specific failure handlers, rather than catching them in the onPreResponse event and having to dig through the path to figure out what the original request even was. 

This should make it a lot simpler to respond appropriately if an upstream server is down in a caching proxy (as in, respond with a cached copy rather than letting the error through to the client)
