### PR TITLE
add `gunzip` as third option to `parse`; resolves #1391

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -482,9 +482,8 @@ The following options are available when adding a route:
               `parse` is `true`, fields values are presented as text while files are provided as streams.
             - `file` - the incoming payload in written to temporary file in the directory specified by the server's `payload.uploads` settings.
               If the payload is 'multipart/form-data' and `parse` is `true`, fields values are presented as text while files are saved.
-        - `parse` - determines if the incoming payload is processed or presented raw. Processing includes applying any 'Content-Encoding'
-          received and parsing 'multipart/form-data'. If the 'Content-Type' is known (for the whole payload as well as parts), the payload
-          is converted into an object when possibler. If parsing is enabled and the format is unknown, a Bad Request (400) error response is
+        - `parse` - can be `true`, `false`, or `gunzip`; determines if the incoming payload is processed or presented raw. `true` and `gunzip` includes gunzipping when the appropriate 'Content-Encoding' is specified on the received request. If parsing is enabled and the 'Content-Type' is known (for the whole payload as well as parts), the payload
+          is converted into an object when possible. If the format is unknown, a Bad Request (400) error response is
           sent. Defaults to `true`, except when a proxy handler is used. The supported mime types are:
             - 'application/json'
             - 'application/x-www-form-urlencoded'

--- a/lib/payload.js
+++ b/lib/payload.js
@@ -70,6 +70,12 @@ exports.read = function (request, next) {
         return failActionNext(Boom.unsupportedMediaType());
     }
 
+    // Parse: gunzip
+
+    if (request.route.payload.parse === 'gunzip') {
+        return internals.gunzip(request, failActionNext);
+    }
+
     // Parse: true
 
     if (request.route.payload.parse) {
@@ -85,21 +91,10 @@ exports.read = function (request, next) {
 internals.parse = function (request, next, failActionNext) {
 
     var output = request.route.payload.output;      // Output: 'data', 'stream', 'file'
-    var source = request.raw.req;
 
-    // Content-encoding
+    // Setup source
 
-    var contentEncoding = source.headers['content-encoding'];
-    if (contentEncoding === 'gzip' || contentEncoding === 'deflate') {
-        var decoder = (contentEncoding === 'gzip' ? Zlib.createGunzip() : Zlib.createInflate());
-        next = Utils.once(next);                                                                     // Modify next() for async events
-        decoder.once('error', function (err) {
-
-            return next(Boom.badRequest('Invalid compressed payload'));
-        });
-
-        source = source.pipe(decoder);
-    }
+    var source = gunzipSource(request.raw.req, next);
 
     // Tap request
 
@@ -152,7 +147,6 @@ internals.parse = function (request, next, failActionNext) {
         }
 
         internals.object(payload, request.mime, function (err, result) {
-
             if (err) {
                 return next(err);
             }
@@ -163,6 +157,18 @@ internals.parse = function (request, next, failActionNext) {
     });
 };
 
+internals.gunzip = function (request, next, failActionNext) {
+
+    var output = request.route.payload.output;      // Output: 'data', 'stream', 'file'
+    
+    // Setup source
+
+    var source = gunzipSource(request.raw.req, next);
+    
+    // Continue raw processing
+
+    internals._raw(output, source, request, next);
+};
 
 internals.raw = function (request, next) {
 
@@ -171,6 +177,12 @@ internals.raw = function (request, next) {
     // Setup source
 
     var source = request.raw.req;
+
+    internals._raw(output, source, request, next);
+};
+
+internals._raw = function(output, source, request, next) {
+
     var tap = request._tap();
     if (tap) {
         source = source.pipe(tap);
@@ -440,3 +452,25 @@ internals.Counter.prototype._transform = function (chunk, encoding, next) {
     this.bytes += chunk.length;
     next(null, chunk);
 };
+
+
+// Helpers
+
+function gunzipSource(source, next) {
+
+    // Content-encoding
+
+    var contentEncoding = source.headers['content-encoding'];
+    if (contentEncoding === 'gzip' || contentEncoding === 'deflate') {
+        var decoder = (contentEncoding === 'gzip' ? Zlib.createGunzip() : Zlib.createInflate());
+        next = Utils.once(next);                                                                     // Modify next() for async events
+        decoder.once('error', function (err) {
+
+            return next(Boom.badRequest('Invalid compressed payload'));
+        });
+
+        source = source.pipe(decoder);
+    }
+
+    return source;
+}

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -213,7 +213,7 @@ internals.routeConfigSchema = {
     bind: Joi.object().allow(null),
     payload: Joi.object({
         output: Joi.string().valid('data', 'stream', 'file'),
-        parse: Joi.boolean(),
+        parse: Joi.any().allow([true, false, 'gunzip']),
         allow: [Joi.string(), Joi.array()],
         override: Joi.string(),
         maxBytes: Joi.number(),


### PR DESCRIPTION
enabling Hapi routes to toggle on the gunzip stream without enabling
parsing.
