### PR TITLE
Fix markdown link formatting typo

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -2841,6 +2841,6 @@ When installing **hapi** with the global flag the **hapi** binary script will be
 - '-c' - the path to configuration json file (required)
 - '-p' - the path to the node_modules folder to load plugins from (optional)
 
-In order to help with A/B testing there is (confidence)[https://github.com/spumko/confidence).  Confidence is a configuration document format, an API, and a foundation for A/B testing. The configuration format is designed to work with any existing JSON-based configuration, serving values based on object path ('/a/b/c' translates to a.b.c). In addition, confidence defines special $-prefixed keys used to filter values for a given criteria.
+In order to help with A/B testing there is [confidence](https://github.com/spumko/confidence).  Confidence is a configuration document format, an API, and a foundation for A/B testing. The configuration format is designed to work with any existing JSON-based configuration, serving values based on object path ('/a/b/c' translates to a.b.c). In addition, confidence defines special $-prefixed keys used to filter values for a given criteria.
 
 


### PR DESCRIPTION
Minor typo in the last paragraph
