### PR TITLE
Adding an optional `onError` handler to proxy configuration.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -73,6 +73,10 @@ exports.handler = function (route, options) {
             Nipple.request(request.method, uri, options, function (err, res) {
 
                 if (err) {
+                    if (settings.onError) {
+                        return settings.onError(request, reply, err, settings);
+                    }
+
                     return reply(err);
                 }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -205,6 +205,7 @@ internals.routeConfigSchema = {
                 timeout: Joi.number().integer(),
                 mapUri: Joi.func().without('host', 'port', 'protocol', 'uri'),
                 postResponse: Joi.func(),
+                onError: Joi.func(),
                 ttl: Joi.string().valid('upstream').allow(null)
             }),
             view: Joi.string()


### PR DESCRIPTION
Allow for custom processing of errors returned by the underlying `nipple.request`.
