### PR TITLE
return a reference to the server when adding via pack.server

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -82,7 +82,7 @@ internals.Pack.prototype.server = function (arg1, arg2, arg3) {
         }
     });
 
-    this._server(new Server(arg1, arg2, arg3, this));
+    return this._server(new Server(arg1, arg2, arg3, this));
 };
 
 
@@ -116,6 +116,8 @@ internals.Pack.prototype._server = function (server) {
             self.events.emit(event, request, data, tags);
         });
     });
+
+    return server;
 };
 
 

--- a/test/pack.js
+++ b/test/pack.js
@@ -709,4 +709,17 @@ describe('Pack', function () {
             server.inject({ url: '/' }, function () { });
         });
     });
+
+    it('returns a reference to the new server when adding one to the pack', function (done) {
+
+        var pack = new Hapi.Pack();
+        var server = pack.server();
+
+        expect(server).to.exist;
+        server.inject({ url: '/' }, function (res) {
+
+            expect(res.statusCode).to.equal(404);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This is to make referencing a specific server after adding it to a pack simpler (currently you'd have to iterate over and inspect pack._servers)
