### PR TITLE
proper etag formatting

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -86,7 +86,7 @@ internals.Response.prototype._prepare = function (request, callback) {
 
             var cachedEtag = request.server._etags.get(cachekey);
             if (cachedEtag) {
-                self._header('etag', cachedEtag);
+                self._header('etag', '"' + cachedEtag + '"');
             }
             else {
                 var hash = Crypto.createHash('sha1');


### PR DESCRIPTION
The Etag value should be enclosed by double quotes according to HTTP 1.1 standards
