### PR TITLE
Include prerequisites in default view context. #1452

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -439,6 +439,7 @@ The following options are available when adding a route:
                 - `payload` - maps to `request.payload`.
                 - `params` - maps to `request.params`.
                 - `query` - maps to `request.query`.
+                - `pre` - maps to `request.pre`.
 
 - `config` - additional route configuration (the `config` options allows splitting the route information from its implementation):
     - `handler` - an alternative location for the route handler function. Same as the `handler` option in the parent level. Can only

--- a/lib/views.js
+++ b/lib/views.js
@@ -375,7 +375,8 @@ exports.handler = function (route, options) {
             context = {
                 params: request.params,
                 payload: request.payload,
-                query: request.query
+                query: request.query,
+                pre: request.pre
             };
         }
 

--- a/test/templates/valid/handler.html
+++ b/test/templates/valid/handler.html
@@ -7,5 +7,6 @@
     {{ payload }}
     {{ querystring }}
     {{ params.param }}
+    {{ pre.p }}
 </body>
 </html>

--- a/test/views.js
+++ b/test/views.js
@@ -351,5 +351,41 @@ describe('Views', function () {
                 done();
             });
         });
+
+        it('includes prerequisites in the default view context', function (done) {
+
+            var pre = function (request, reply) {
+
+                reply('PreHello');
+            };
+
+            var options = {
+                views: {
+                    engines: { 'html': 'handlebars' },
+                    path: __dirname + '/templates'
+                }
+            };
+
+            var server = new Hapi.Server(options);
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                config: {
+                    pre: [
+                        { method: pre, assign: 'p' }
+                    ],
+                    handler: {
+                        view: 'valid/handler'
+                    }
+                }
+            });
+
+            server.inject('/', function (res) {
+
+                expect(res.result).to.contain('PreHello');
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
Makes the resulting objects from pre methods available in the default
view context. Allows you to use `request.pre` when you use the string shortcut for a view handler.
