### PR TITLE
Remove unused postResponse function from proxy example

### DIFF
--- a/examples/proxy.js
+++ b/examples/proxy.js
@@ -1,6 +1,5 @@
 // Load modules
 
-var Nipple = require('nipple');
 var Hapi = require('../lib');
 
 
@@ -16,32 +15,6 @@ internals.main = function () {
     var mapper = function (request, callback) {
 
         callback(null, 'http://www.google.com/search?q=' + request.params.term);
-    };
-
-    var postResponse = function (request, reply, res, settings, ttl) {
-
-        if (res.statusCode !== 200) {
-            return reply(Boom.badGateway());
-        }
-
-        Nipple.read(res, function (err, payload) {
-
-            if (err) {
-                return reply(err);
-            }
-            
-            var contentType = res.headers['content-type'];
-
-            var response = reply(payload);
-            if (ttl) {
-                response.ttl(ttl);
-            }
-
-            if (contentType) {
-                response.type(contentType);
-            }
-
-        });
     };
 
     server.route({ method: '*', path: '/{p*}', handler: { proxy: { host: 'google.com', port: 80, redirects: 5 } } });


### PR DESCRIPTION
In 0d63bafe14f5bfe760bc27e457aca845bce69b0b the `postResponse` function was moved to `examples/proxy.js` but not set as the `postResponse` handler for the proxy.

An alternative to removing the function would be to actually make use of it (see 728f041c8bdf774477a59c4db2b968e1feb78e37).  Since it is listed as deprecated, I thought it would make more sense to remove it from the example.
