### PR TITLE
Remove assumption that all absolute paths start with '/'

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -7,6 +7,7 @@ var Async = require('async');
 var Response = require('./response');
 var File = require('./file');
 var Utils = require('./utils');
+var isAbsolute = require('absolute-path');
 
 
 // Declare internals
@@ -34,7 +35,7 @@ exports.handler = function (route, options) {
             path += '/';
         }
 
-        if (path[0] !== '/') {
+        if (!isAbsolute(path)) {
             path = Path.join(relativeTo, path);
         }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -7,6 +7,7 @@ var Mime = require('mime');
 var Boom = require('boom');
 var Utils = require('./utils');
 var Response = require('./response');
+var isAbsolute = require('absolute-path');
 
 
 // Declare internals
@@ -44,7 +45,7 @@ exports.Response = internals.Response = function (path, options, request) {
     var relativeTo = (request._route.env.path || request.server.settings.files.relativeTo);
 
     var source = {
-        path: Path.normalize(path[0] === '/' ? path : Path.join(relativeTo, path)),
+        path: Path.normalize(isAbsolute(path) ? path : Path.join(relativeTo, path)),
         settings: options,
         stat: null
     };

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -11,6 +11,7 @@ var Defaults = require('./defaults');
 var Ext = require('./ext');
 var Methods = require('./methods');
 var Protect = require('./protect');
+var isAbsolute = require('absolute-path');
 
 
 // Declare internals
@@ -491,7 +492,7 @@ internals.Pack.prototype._require = function (name, options, callback, requireFu
         if (itemName[0] === '.') {
             itemName = Path.join(callerPath, itemName);
         }
-        else if (itemName[0] !== '/' &&
+        else if (!isAbsolute(itemName[0]) &&
                  self._settings.requirePath) {
 
             itemName = Path.join(self._settings.requirePath, itemName);

--- a/lib/views.js
+++ b/lib/views.js
@@ -7,6 +7,7 @@ var Defaults = require('./defaults');
 var Schema = require('./schema');
 var Utils = require('./utils');
 var Response = require('./response');
+var isAbsolute = require('absolute-path');
 // Additional engine modules required in constructor
 
 
@@ -290,7 +291,7 @@ internals.Manager.prototype._path = function (template, settings, isLayout) {
 
     // Validate path
 
-    var isAbsolutePath = (template[0] === '/');
+    var isAbsolutePath = (isAbsolute(template));
     var isInsecurePath = template.match(/\.\.\//g);
 
     if (!settings.allowAbsolutePaths &&
@@ -314,7 +315,7 @@ internals.Manager.prototype._path = function (template, settings, isLayout) {
 internals.path = function (base, path, file) {
 
     if (path &&
-        path[0] === '/') {
+        isAbsolute(path[0])) {
 
         return Path.join(path || '', file || '');
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "optimist": "0.6.x",
     "negotiator": "0.4.x",
     "semver": "2.2.x",
-    "qs": "0.6.x"
+    "qs": "0.6.x",
+    "absolute-path": "0.0.0"
   },
   "devDependencies": {
     "lab": "1.x.x",


### PR DESCRIPTION
I was unable to serve static files using hapi on Windows. The reason for the failure is that there are a number of places in the framework where it is assumed that a static path must begin with `'/'`.

I've extracted the `Path.isAbsolute()` function from node core that is available in the `0.11.x` series as a stand-alone module. I've also extracted the tests relating to this new function in the newly created `absolute-path` module.

The code was taken from: joyent/node@90266750617adb1ce1ca4ce43fe48f9b0fa11343

The `absolute-path` module can be found at [node-absolute-path](/filearts/node-absolute-path)

Please note: As I am on Windows, I do not get meaningful results from `make test`.
