### PR TITLE
Some array enumeration / loops causing problems

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -138,7 +138,7 @@ internals.Ext.prototype.sort = function (event) {
         var group = afterNodes[n];
 
         for (var iI = 0, jl = groups[group].length; iI < jl; ++iI) {
-            var node = groups[group][itemIndex];
+            var node = groups[group][iI];
             graph[node] = graph[node].concat(graphAfters[group]);
         }
     }
@@ -148,7 +148,7 @@ internals.Ext.prototype.sort = function (event) {
     var ancestors = {};
     var graphNodes = Object.keys(graph);
     for (var gI = 0, jl = graphNodes.length; gI < jl; ++gI) {
-        var node = graphNodes[i];
+        var node = graphNodes[gI];
         var children = graph[node];
 
         for (var j = 0, jl = children.length; j < jl; ++j) {


### PR DESCRIPTION
These loops were getting hung on a prototype array property "stackSize." I updated to sequential for loops, and all is well.

I would _love_ to know where this "stackSize" property has been coming from. I've been encountering this issue constantly lately, and it has proved resistant to Googling.
