### PR TITLE
expose filename and headers for streams in a multipart form

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -509,7 +509,7 @@ The following options are available when adding a route:
               multipart) based on the 'Content-Type' header. If `parse` is false, the raw `Buffer` is returned. This is the default value
               except when a proxy handler is used.
             - `stream` - the incoming payload is made available via a `Stream.Readable` interface. If the payload is 'multipart/form-data' and
-              `parse` is `true`, fields values are presented as text while files are provided as streams.
+              `parse` is `true`, fields values are presented as text while files are provided as streams. File streams from a 'multipart/form-data' upload will also have a property `.hapi` containing `filename` and `headers` properties.
             - `file` - the incoming payload in written to temporary file in the directory specified by the server's `payload.uploads` settings.
               If the payload is 'multipart/form-data' and `parse` is `true`, fields values are presented as text while files are saved.
         - `parse` - can be `true`, `false`, or `gunzip`; determines if the incoming payload is processed or presented raw. `true` and `gunzip` includes gunzipping when the appropriate 'Content-Encoding' is specified on the received request. If parsing is enabled and the 'Content-Type' is known (for the whole payload as well as parts), the payload

--- a/lib/payload.js
+++ b/lib/payload.js
@@ -363,7 +363,14 @@ internals.multipart = function (request, source, next) {
                 // err handled by form.once('error')
 
                 if (options.output === 'stream') {                                      // Output: 'stream'
-                    return set(part.name, Nipple.toReadableStream(payload));
+                    var item = Nipple.toReadableStream(payload);
+
+                    item.hapi = {
+                        filename: part.filename,
+                        headers: part.headers
+                    };
+
+                    return set(part.name, item);
                 }
 
                 var contentType = (part.headers && part.headers['content-type']) || '';

--- a/test/payload.js
+++ b/test/payload.js
@@ -1115,6 +1115,10 @@ describe('Payload', function () {
 
             var handler = function (request, reply) {
 
+                expect(request.payload.files[0].hapi).to.deep.equal({ filename: 'file1.txt', headers: { 'content-disposition': 'form-data; name="files"; filename="file1.txt"', 'content-type': 'text/plain'} });
+                expect(request.payload.files[1].hapi).to.deep.equal({ filename: 'file2.txt', headers: { 'content-disposition': 'form-data; name="files"; filename="file2.txt"', 'content-type': 'text/plain'} });
+                expect(request.payload.files[2].hapi).to.deep.equal({ filename: 'file3.txt', headers: { 'content-disposition': 'form-data; name="files"; filename="file3.txt"', 'content-type': 'text/plain'} });
+
                 Nipple.read(request.payload.files[1], function (err, payload2) {
 
                     Nipple.read(request.payload.files[0], function (err, payload1) {
@@ -1211,6 +1215,13 @@ describe('Payload', function () {
             var fileHandler = function (request) {
 
                 expect(request.headers['content-type']).to.contain('multipart/form-data');
+                expect(request.payload['my_file'].hapi).to.deep.equal({
+                    filename: 'image.jpg',
+                    headers: {
+                        'content-disposition': 'form-data; name="my_file"; filename="image.jpg"',
+                        'content-type': 'image/jpeg'
+                    }
+                });
 
                 Nipple.read(request.payload['my_file'], function (err, buffer) {
 


### PR DESCRIPTION
This provides some knowledge about the streams in a multipart form to the user.
