### PR TITLE
fix asterisks being interpreted as Markdown

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -693,8 +693,7 @@ server.route({
 });
 ```
 
-In addition to the optional '?' suffix, a parameter name can also specify the number of matching segments using the '*' suffix, followed by a number
-greater than 1. If the number of expected parts can be anything, then use '*' without a number (matching any number of segments can only be used in the
+In addition to the optional `?` suffix, a parameter name can also specify the number of matching segments using the `*` suffix, followed by a number greater than 1. If the number of expected parts can be anything, then use `*` without a number (matching any number of segments can only be used in the
 last path segment).
 
 ```javascript


### PR DESCRIPTION
They are supposed to be literal asterisks. Markdown was changing them into HTML `<em>` and `</em>` tags.
