### PR TITLE
Add 405 Support

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -30,31 +30,8 @@ exports = module.exports = internals.Router = function (server) {
                 // the wrong verb was provided and this is a 405.
                 var router = server._router;
                 var vhost = (router.vhosts && request.info.host && router.vhosts[request.info.host.split(':')[0]]);
-                var supportedMethods = function (request, table) {
-
-                    // This function returns an array containing the verbs that
-                    // match the requested route. If no verbs match, then null is returned
-                    var supported = null;
-
-                    for (var method in table) {
-                        var routes = table[method];
-
-                        for (var i = 0, il = routes.length; i < il; ++i) {
-                            var route = routes[i];
-                            var test = route.match(request);
-
-                            if (test === true) {
-                                supported = (supported || []);
-                                supported.push(method.toUpperCase());
-                                break;
-                            }
-                        }
-                    }
-
-                    return supported;
-                };
-                var supported = (vhost && supportedMethods(request, vhost)) ||
-                                supportedMethods(request, router.routes);
+                var supported = (vhost && internals.supportedMethods(request, vhost)) ||
+                                internals.supportedMethods(request, router.routes);
 
                 // If no matching verbs exist in the routing table, this is a 404
                 if (!supported) {
@@ -115,6 +92,30 @@ internals.Router.prototype.route = function (request) {
                 this.notfound;
 
     return (route instanceof Error ? this.badResource : route);
+};
+
+
+internals.supportedMethods = function (request, table) {
+
+    // This function returns an array containing the verbs that
+    // match the requested route. If no verbs match, then null is returned
+    var supported = null;
+
+    for (var method in table) {
+        var routes = table[method];
+
+        for (var i = 0, il = routes.length; i < il; ++i) {
+            var route = routes[i];
+
+            if (route.match(request) === true) {
+                supported = (supported || []);
+                supported.push(method.toUpperCase());
+                break;
+            }
+        }
+    }
+
+    return supported;
 };
 
 

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -362,7 +362,7 @@ describe('Proxy', function () {
         upstream.start(function () {
 
             var server = new Hapi.Server();
-            server.route({ method: 'POST', path: '/notfound', handler: { proxy: { host: 'localhost', port: upstream.info.port } } });
+            server.route({ method: 'GET', path: '/notfound', handler: { proxy: { host: 'localhost', port: upstream.info.port } } });
 
             server.inject('/notfound', function (res) {
 

--- a/test/router.js
+++ b/test/router.js
@@ -307,6 +307,36 @@ describe('Router', function () {
 
         server.inject({ method: 'OPTIONS', url: '/' }, function (res) {
 
+            expect(res.statusCode).to.equal(405);
+            done();
+        });
+    });
+
+    it('returns 405 when method is not supported', function (done) {
+
+        var server = new Hapi.Server();
+        var handler = function (request, reply) {
+
+            reply('ok');
+        };
+
+        server.route({ method: 'PUT', path: '/test', handler: handler });
+        server.route({ method: 'POST', path: '/test', handler: handler });
+        server.inject({ method: 'GET', url: '/test' }, function (res) {
+
+            expect(res.headers.allow).to.exist;
+            expect(res.statusCode).to.equal(405);
+            done();
+        });
+    });
+
+    it('returns 404 when route is not defined', function (done) {
+
+        var server = new Hapi.Server();
+
+        server.inject({ method: 'HEAD', url: '/test' }, function (res) {
+
+            expect(res.headers.allow).to.not.exist;
             expect(res.statusCode).to.equal(404);
             done();
         });


### PR DESCRIPTION
Add 405 support to the `notfound` route.  Closes #1534
