### PR TITLE
Added validation for request headers.

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -52,7 +52,7 @@ exports = module.exports = internals.Route = function (options, server, env) {
     var payloadSupported = (this.method !== 'get' && this.method !== 'head');
 
     var validation = this.settings.validate;
-    ['payload', 'query', 'path'].forEach(function (type) {
+    ['payload', 'query', 'path', 'headers'].forEach(function (type) {
 
         if (validation[type] &&
             typeof validation[type] !== 'function') {
@@ -163,6 +163,10 @@ internals.Route.prototype.lifecycle = function () {
         validate('payload')) {
 
         cycle.push(Validation.payload);
+    }
+
+    if (validate('headers')) {
+        cycle.push(Validation.headers);
     }
 
     cycle.push('onPreHandler');

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -168,6 +168,7 @@ internals.routeConfig = {
         payload: Joi.alternatives(Joi.object(), Joi.func()).allow(null, false, true),
         query: Joi.alternatives(Joi.object(), Joi.func()).allow(null, false, true),
         path: Joi.alternatives(Joi.object(), Joi.func()).allow(null, false, true),
+        headers: Joi.alternatives(Joi.object(), Joi.func()).allow(null, false, true),
         failAction: [Joi.string().valid('error', 'log', 'ignore'), Joi.func()],
         errorFields: Joi.object()
     }),

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -34,6 +34,14 @@ exports.path = function (request, next) {
 };
 
 
+// Validate request headers
+
+exports.headers = function (request, next) {
+
+    return internals.input('headers', 'headers', request, next);
+};
+
+
 internals.emptyObject = Joi.object({});
 
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -593,4 +593,64 @@ describe('Validation', function () {
             done();
         });
     });
+
+    it('validates valid header', function (done) {
+
+        var server = new Hapi.Server();
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: function (request, reply) { reply('ok'); },
+            config: {
+                validate: {
+                    headers: {
+                        accept: Joi.string().valid('application/json').required(),
+                        'user-agent': Joi.string().optional()
+                    }
+                }
+            }
+        });
+
+        server.inject({
+            url: '/',
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json'
+            }
+        }, function (res) {
+
+            expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    it('rejects invalid header', function (done) {
+
+        var server = new Hapi.Server();
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: function (request, reply) { reply('ok'); },
+            config: {
+                validate: {
+                    headers: {
+                        accept: Joi.string().valid('text/html').required(),
+                        'user-agent': Joi.string().optional()
+                    }
+                }
+            }
+        });
+
+        server.inject({
+            url: '/',
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json'
+            }
+        }, function (res) {
+
+            expect(res.statusCode).to.equal(400);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
At least partially addresses #1588.

When will `object.unknown()` from joi land in hapi?  Once it does, it should be applied to header validation due to all the extraneous headers sent with most requests.  Or is there a better way to do it today?
