### PR TITLE
Small doc fix for cookie auth link

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1348,7 +1348,7 @@ Each request object has the following properties:
     - `credentials` - the `credential` object received during the authentication process. The presence of an object does not mean
       successful authentication.
     - `artifacts` - an artifact object received from the authentication strategy and used in authentication-related actions.
-    - `session` - an object used by the [`'cookie'` authentication scheme](#cookie-authentication).
+    - `session` - an object used by the [`'cookie'` authentication scheme](https://github.com/spumko/hapi-auth-cookie).
 - `domain` - the node domain object used to protect against exceptions thrown in extentions, handlers and prerequisites. Can be used to
   manually bind callback functions otherwise bound to other domains.
 - `headers` - the raw request headers (references `request.raw.headers`).


### PR DESCRIPTION
Linking cookie auth in doc to new cookie auth plugin github repository instead of dead link
