### PR TITLE
generate changelog via mdchangelog spumko/hapi#1606

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,43 @@
-# Breaking changes #
-* [Upcoming](https://github.com/spumko/hapi/issues?labels=breaking+changes&page=1&state=open)
-* [Closed](https://github.com/spumko/hapi/issues?labels=breaking+changes&page=1&state=closed)
-* [v4.0](https://github.com/spumko/hapi/issues/1560)
-* [v3.0](https://github.com/spumko/hapi/issues/1474)
-* [v2.0](https://github.com/spumko/hapi/issues/1178)
+# 2014-04-24 [**spumko/hapi**](https://github.com/spumko/hapi)
+88 commits against 32 issues, over a month [`19a6179`](https://github.com/spumko/hapi/commit/19a6179) - [`bb9d082`](https://github.com/spumko/hapi/commit/bb9d082)
+
+## Milestones
+- [CLOSED] [**0.6.0**](https://github.com/spumko/hapi/issues?milestone=1&state=closed)
+- [CLOSED] [**3.1.0**](https://github.com/spumko/hapi/issues?milestone=90&state=closed)
+- [CLOSED] [**4.0.0**](https://github.com/spumko/hapi/issues?milestone=91&state=closed)
+- [CLOSED] [**4.0.1**](https://github.com/spumko/hapi/issues?milestone=92&state=closed)
+
+### Issues
+- [CLOSED] [**#1590**](https://github.com/spumko/hapi/issues/1590) RSS leak occurs when request does not read entire stream response <sup>[[4.0.1](https://github.com/spumko/hapi/issues?milestone=92&state=closed)]</sup>
+- [CLOSED] [**#1560**](https://github.com/spumko/hapi/issues/1560) 4.0.0 <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1569**](https://github.com/spumko/hapi/issues/1569) Move ext topo sort to its own module <sup>[[4.0.1](https://github.com/spumko/hapi/issues?milestone=92&state=closed)]</sup>
+- [CLOSED] [**#1566**](https://github.com/spumko/hapi/issues/1566) Precompile joi validation <sup>[[4.0.1](https://github.com/spumko/hapi/issues?milestone=92&state=closed)]</sup>
+- [CLOSED] [**#1548**](https://github.com/spumko/hapi/issues/1548) wip: fix windows bugs <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1559**](https://github.com/spumko/hapi/issues/1559) joi 3.0 <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1558**](https://github.com/spumko/hapi/issues/1558) Change Hapi.utils.version() to Hapi.version and remove Hoek alias <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1547**](https://github.com/spumko/hapi/issues/1547) Make certain that path is relative before joining it to relativeTo <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1524**](https://github.com/spumko/hapi/issues/1524) Coverage after lab partial condition result coverage <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1554**](https://github.com/spumko/hapi/issues/1554) coverage, closes #1524 <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1521**](https://github.com/spumko/hapi/issues/1521) Allow plugins to register handler types <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1512**](https://github.com/spumko/hapi/issues/1512) Failing: Proxy uses rejectUnauthorized to allow proxy to self signed ssl server
+- [CLOSED] [**#1551**](https://github.com/spumko/hapi/issues/1551) add an insecureAgent when maxSockets is set, closes #1512 <sup>[[4.0.0](https://github.com/spumko/hapi/issues?milestone=91&state=closed)]</sup>
+- [CLOSED] [**#1553**](https://github.com/spumko/hapi/issues/1553) Verify cache key is a string, closes #1552
+- [CLOSED] [**#1552**](https://github.com/spumko/hapi/issues/1552) Failing: Method reuses cached method value with custom key function
+- [CLOSED] [**#1527**](https://github.com/spumko/hapi/issues/1527) Change cache engine in example - redis no longer appropriate
+- [CLOSED] [**#1525**](https://github.com/spumko/hapi/issues/1525) expose filename and headers for streams in a multipart form <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1523**](https://github.com/spumko/hapi/issues/1523) Question: How to validate payload with templated response properly ? <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1541**](https://github.com/spumko/hapi/issues/1541) Clarify that statusCode key of stream response passed in response <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1540**](https://github.com/spumko/hapi/issues/1540) Pre-gzipped source stream not properly tested for being the active source <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1538**](https://github.com/spumko/hapi/issues/1538) Passing Error objects can leak message in 500 response <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1536**](https://github.com/spumko/hapi/issues/1536) maxEventLoopDelay fails to catch when load is too high to reach next sample interval <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1528**](https://github.com/spumko/hapi/issues/1528) fix asterisks being interpreted as Markdown
+- [CLOSED] [**#1535**](https://github.com/spumko/hapi/issues/1535) Cannot set maxSockets to node default <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1533**](https://github.com/spumko/hapi/issues/1533) Proxy without passThrough fails to set cache-control header <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1532**](https://github.com/spumko/hapi/issues/1532) Multipart payload to files with multiple files skips second file when large <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1531**](https://github.com/spumko/hapi/issues/1531) pack.log() doesn't retain server debug false setting <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1530**](https://github.com/spumko/hapi/issues/1530) plugin.method() should use method bind before plugin bind <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#1515**](https://github.com/spumko/hapi/issues/1515) Coverage to 100% after lab logical statement support <sup>[[3.1.0](https://github.com/spumko/hapi/issues?milestone=90&state=closed)]</sup>
+- [CLOSED] [**#63**](https://github.com/spumko/hapi/issues/63) Added in SSL cert passphrase to https server creation from settings. <sup>[[0.6.0](https://github.com/spumko/hapi/issues?milestone=1&state=closed)]</sup>
+- [CLOSED] [**#70**](https://github.com/spumko/hapi/issues/70) Monitoring CPU fix calculation
+- [CLOSED] [**#64**](https://github.com/spumko/hapi/issues/64) Merge develop fixes into master
+


### PR DESCRIPTION
As requested at https://github.com/spumko/hapi/issues/1606#issuecomment-41769063, changelog output generated from [mdchangelog](https://github.com/creativelive/mdchangelog) command:

```
mdchangelog 19a6179...beb3d50
```

If this changelog generation is suitable, it could be incorporated into a build process (for major releases). If `mdchangelog` put the last sha at the top of the file (which it doesn't currently do), maybe something like:

```
mdchangelog HEAD...`head -1 CHANGELOG.md` >> CHANGELOG.md
```
