### PR TITLE
replaced hapijs.com with Make Me Hapi, punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ Launch the application (`node .`) and open 'http://localhost:8000/hello' in a br
 ## More information
 
 - For the **latest updates** follow [@hapijs](https://twitter.com/hapijs).
-- For more **information, tutorials, and references** on the currently published version, visit [**hapijs.com**](http://hapijs.com)
-- For a full application example, check out [postmile](https://github.com/hueniverse/postmile)
+- For a self-guided lesson on hapi, use [Make Me Hapi](https://github.com/spumko/makemehapi).
+- For a full application example, check out [postmile](https://github.com/hueniverse/postmile).
 - Information about the **work-in-progress** in the master branch:
     - [API reference](/docs/Reference.md)
     - [Upcoming breaking changes](https://github.com/spumko/hapi/issues?labels=breaking+changes)
-- For **discussions** join the [#hapi channel](http://webchat.freenode.net/?channels=hapi) on irc.freenode.net
+- For **discussions** join the [#hapi channel](http://webchat.freenode.net/?channels=hapi) on irc.freenode.net.
 - Any **issues or questions** (no matter how basic), open an issue.
 


### PR DESCRIPTION
hapijs.com has not been updated in months (years?) aside from bumping version to 4.0.  It has 0% redeeming value, so I replaced it with something you have that is far more informative.

If you had hapijs.com on GitHub, I'd be hapi to edit that instead.

& needed a few .
