### PR TITLE
Cleanup request objects to avoid GC stress

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -363,20 +363,8 @@ internals.Request.prototype._reply = function (exit) {
         self.tail = undefined;
 
         if (Object.keys(self._tails).length === 0) {
-            self.server.emit('tail', self);
+            self._wag();
         }
-
-        // Cleanup
-
-        self.raw.req.removeListener('close', self._onClose);
-        self.raw.req.removeListener('error', self._onError);
-        self.raw.req.removeListener('aborted', self._onAborted);
-
-        if (self.response._close) {
-            self.response._close();
-        }
-
-        self.response = self.payload = self.raw = self.domain = self._protect = undefined;
     };
 
     process();
@@ -448,7 +436,7 @@ internals.Request.prototype._addTail = function (name) {
             self._isWagging) {
 
             self.log(['hapi', 'tail', 'remove', 'last'], { name: name, id: tailId });
-            self.server.emit('tail', self);
+            self._wag();
         }
         else {
             self.log(['hapi', 'tail', 'remove'], { name: name, id: tailId });
@@ -458,6 +446,27 @@ internals.Request.prototype._addTail = function (name) {
     return drop;
 };
 
+
+internals.Request.prototype._wag = function () {
+    this.server.emit('tail', this);
+
+
+    // Cleanup
+
+    this.raw.req.removeListener('close', this._onClose);
+    this.raw.req.removeListener('error', this._onError);
+    this.raw.req.removeListener('aborted', this._onAborted);
+
+    if (this.response._close) {
+        this.response._close();
+    }
+
+    this.response = null;
+    this.payload = null;
+    this.raw = null;
+    this.domain = null;
+    this._protect = null;
+};
 
 internals.Request.prototype._setState = function (name, value, options) {          // options: see Defaults.state
 


### PR DESCRIPTION
Removes two cases for completed requests that don't necessarily cause leaks
but do add GC overhead. Additionally these links cause a great deal of noise
when examining the heapdumps for root cause leak issues.
