### PR TITLE
Clean response objects for aborted requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -122,7 +122,12 @@ exports = module.exports = internals.Request = function (server, req, res, optio
 
     this._onClose = function () {
 
+        // The user won't actually see this but we want to send something so request cleanup
+        // occurs and more importantly logging occurs.
         self.log(['hapi', 'request', 'error', 'closed']);
+        self._reply(Boom.internal('Closed'));
+
+        self._isClosed = true;
     };
 
     this.raw.req.once('close', this._onClose);
@@ -405,6 +410,14 @@ internals.Request.prototype._setResponse = function (response) {
         (response.isBoom || this.response.source !== response.source)) {
 
         this.response._close();
+    }
+
+    // If we have already been terminated then just cleanup the response so we don't leak it
+    if (this._isClosed) {
+        if (response._close) {
+            response._close();
+        }
+        return;
     }
 
     this.response = response;


### PR DESCRIPTION
Prevents leaks that can occur if a reply occurs after a request has been
closed due to abort.
