### PR TITLE
Use svg for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For the latest updates and release information follow [@hapijs](https://twitter.
 Current version: **5.1.x** ([release notes](https://github.com/spumko/hapi/issues?labels=release+notes&page=1&state=closed))
 
 
-[![Build Status](https://secure.travis-ci.org/spumko/hapi.png)](http://travis-ci.org/spumko/hapi)
+[![Build Status](https://secure.travis-ci.org/spumko/hapi.svg)](http://travis-ci.org/spumko/hapi)
 
 [![NPM](https://nodei.co/npm/hapi.png?downloads=true&stars=true)](https://nodei.co/npm/hapi/)
 


### PR DESCRIPTION
Hello!

Just an extremely minor patch here. You see, on my phone these png build icons looks a bit... not so crisp. And seeing as travis now offers svg icons, that would look even better. So if you want, this fixes that.

Other than that, great stuff, thanks. And have a great day!
