### PR TITLE
`postResponse` -> `onResponse` in ttl comment

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -453,7 +453,7 @@ The following options are available when adding a route:
               - `ttl` - the upstream TTL in milliseconds if `proxy.ttl` it set to `'upstream'` and the upstream response included a valid
                 'Cache-Control' header with 'max-age'.
         - `ttl` - if set to `'upstream'`, applies the upstream response caching policy to the response using the `response.ttl()` method (or passed
-          as an argument to the `postResponse` method if provided).
+          as an argument to the `onResponse` method if provided).
 
     - <a name="route.config.view"></a>`view` - generates a template-based response. The `view` option can be set to one of:
         - a string with the template file name.


### PR DESCRIPTION
Looks like `postResponse` was updated to `onResponse`, but this occurrence was missed.

When you grep the repo for the string "postResponse", this is the only occurrence, apart from the changelog.
