### PR TITLE
update changelog for v6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+
+## [**6.0.0**](https://github.com/spumko/hapi/issues?milestone=102&state=closed)
+- [**#1708**](https://github.com/spumko/hapi/issues/1708) Hapi 6.0 no longer invalidates auth strategy on registration of route
+- [**#1703**](https://github.com/spumko/hapi/issues/1703) Catbox 3.0 and drop internal require support
+- [**#1700**](https://github.com/spumko/hapi/issues/1700) Change the order of actions when starting a pack
+- [**#1668**](https://github.com/spumko/hapi/issues/1668) Delete &#39;Accept-Encoding&#39; header on proxy requests
+- [**#1696**](https://github.com/spumko/hapi/issues/1696) Non-Error auth err responses are ignored in try mode
+- [**#1695**](https://github.com/spumko/hapi/issues/1695) Preserve auth error on try
+- [**#1691**](https://github.com/spumko/hapi/issues/1691) V6.0
+- [**#1693**](https://github.com/spumko/hapi/issues/1693) Enhance setting authentication defaults
+- [**#1692**](https://github.com/spumko/hapi/issues/1692) Allow testing a request against any configured authentication strategy
+- [**#1688**](https://github.com/spumko/hapi/issues/1688) Bring back reply.redirect()
+- [**#1687**](https://github.com/spumko/hapi/issues/1687) Don&#39;t log auth non-error responses with &#39;error&#39; tag
+- [**#1679**](https://github.com/spumko/hapi/issues/1679) Allow cookie-specific settings for failAction, strictHeader, and clearInvalid
+- [**#1678**](https://github.com/spumko/hapi/issues/1678) Expose the location header logic
+- [**#1677**](https://github.com/spumko/hapi/issues/1677) Enhance manifest format to support registration options (select, prefix, vhost)
+- [**#1674**](https://github.com/spumko/hapi/issues/1674) Make plugin register() and dependency() selectable
+- [**#1675**](https://github.com/spumko/hapi/issues/1675) Remove pack.list
+- [**#1673**](https://github.com/spumko/hapi/issues/1673) Make plugin.events selectable
+- [**#1663**](https://github.com/spumko/hapi/issues/1663) Allow register to pre-select servers
+- [**#1662**](https://github.com/spumko/hapi/issues/1662) Config clones bind, app, and plugins
+- [**#1661**](https://github.com/spumko/hapi/issues/1661) View manager clones engines including modules
+- [**#1658**](https://github.com/spumko/hapi/issues/1658) Set route path prefix when loading plugin
+- [**#1659**](https://github.com/spumko/hapi/issues/1659) plugin.view() modifies options&#39; basePath
+- [**#1656**](https://github.com/spumko/hapi/issues/1656) Remove pack.require() and plugin.require()
+- [**#1655**](https://github.com/spumko/hapi/issues/1655) Remove support for string view engine config
+- [**#1653**](https://github.com/spumko/hapi/issues/1653) Move Composer into Pack.compose()
+- [**#1652**](https://github.com/spumko/hapi/issues/1652) Remove composer support for multiple packs
+- [**#981**](https://github.com/spumko/hapi/issues/981) Scope plugin routes to a virtual host
+
 ## [**5.1.0**](https://github.com/spumko/hapi/issues?milestone=101&state=closed)
 - [**#1579**](https://github.com/spumko/hapi/issues/1579) Add option to remove trailing slashes to router
 - [**#1574**](https://github.com/spumko/hapi/issues/1574) Document the best way to implement a 404 from the directory handler when using path callback
@@ -7,8 +37,8 @@
 - [**#1581**](https://github.com/spumko/hapi/issues/1581) Authentication throws are treated as valid reply()
 
 ## [**5.0.0**](https://github.com/spumko/hapi/issues?milestone=100&state=closed)
-- [**#1643**](https://github.com/spumko/hapi/issues/1643) Expose cross inputs as validation context
 - [**#1644**](https://github.com/spumko/hapi/issues/1644) request.params contains empty strings for missing optional params
+- [**#1643**](https://github.com/spumko/hapi/issues/1643) Expose cross inputs as validation context
 - [**#1642**](https://github.com/spumko/hapi/issues/1642) Cjihrig header validation
 - [**#1641**](https://github.com/spumko/hapi/issues/1641) Upgrade to joi 4.x
 - [**#1622**](https://github.com/spumko/hapi/issues/1622) Extend Hapi cli to enable loading a module before loading hapi
@@ -43,13 +73,13 @@
 - [**#1566**](https://github.com/spumko/hapi/issues/1566) Precompile joi validation
 
 ## [**4.0.0**](https://github.com/spumko/hapi/issues?milestone=91&state=closed)
-- [**#1560**](https://github.com/spumko/hapi/issues/1560) 4.0.0
 - [**#1548**](https://github.com/spumko/hapi/issues/1548) wip: fix windows bugs
+- [**#1560**](https://github.com/spumko/hapi/issues/1560) 4.0.0
 - [**#1559**](https://github.com/spumko/hapi/issues/1559) joi 3.0
 - [**#1558**](https://github.com/spumko/hapi/issues/1558) Change Hapi.utils.version() to Hapi.version and remove Hoek alias
 - [**#1547**](https://github.com/spumko/hapi/issues/1547) Make certain that path is relative before joining it to relativeTo
-- [**#1524**](https://github.com/spumko/hapi/issues/1524) Coverage after lab partial condition result coverage
 - [**#1554**](https://github.com/spumko/hapi/issues/1554) coverage, closes #1524
+- [**#1524**](https://github.com/spumko/hapi/issues/1524) Coverage after lab partial condition result coverage
 - [**#1521**](https://github.com/spumko/hapi/issues/1521) Allow plugins to register handler types
 - [**#1551**](https://github.com/spumko/hapi/issues/1551) add an insecureAgent when maxSockets is set, closes #1512
 
@@ -82,8 +112,8 @@
 - [**#1466**](https://github.com/spumko/hapi/issues/1466) Drop support for server helpers
 - [**#1458**](https://github.com/spumko/hapi/issues/1458) Removed Http(s) globalAgent settings
 - [**#1485**](https://github.com/spumko/hapi/issues/1485) Bring coverage back to 100% after lab fix
-- [**#1475**](https://github.com/spumko/hapi/issues/1475) Include PATCH method in options/cors/methods default
 - [**#1476**](https://github.com/spumko/hapi/issues/1476) add PATCH to default cors methods, closes #1475
+- [**#1475**](https://github.com/spumko/hapi/issues/1475) Include PATCH method in options/cors/methods default
 - [**#1478**](https://github.com/spumko/hapi/issues/1478) Use joi 2.8 alternatives()
 - [**#1465**](https://github.com/spumko/hapi/issues/1465) Migrate to catbox 2.0
 - [**#1473**](https://github.com/spumko/hapi/issues/1473) Drop dtrace support
@@ -93,12 +123,12 @@
 - [**#1451**](https://github.com/spumko/hapi/issues/1451) Objects created in plugin.dependency or plugin.after are monitored by the wrong domain
 - [**#1452**](https://github.com/spumko/hapi/issues/1452) Perhaps include `request.pre` in handler view context 
 - [**#1453**](https://github.com/spumko/hapi/issues/1453) Include prerequisites in default view context. #1452
-- [**#1447**](https://github.com/spumko/hapi/issues/1447) Allow prerequisites string notation to use method name without ()
 - [**#1445**](https://github.com/spumko/hapi/issues/1445) Server method bind option
-- [**#1446**](https://github.com/spumko/hapi/issues/1446) Document server method callback &#39;isUncacheable&#39; argument
 - [**#1450**](https://github.com/spumko/hapi/issues/1450) Enable handlers to use the prerequisite method string notation
 - [**#1449**](https://github.com/spumko/hapi/issues/1449) Allow server methods names to include &#39;.&#39; (nested)
 - [**#1448**](https://github.com/spumko/hapi/issues/1448) Prerequisite string notation parsing errors
+- [**#1447**](https://github.com/spumko/hapi/issues/1447) Allow prerequisites string notation to use method name without ()
+- [**#1446**](https://github.com/spumko/hapi/issues/1446) Document server method callback &#39;isUncacheable&#39; argument
 - [**#1442**](https://github.com/spumko/hapi/issues/1442) Response 304
 
 ## [**2.5.0**](https://github.com/spumko/hapi/issues?milestone=84&state=closed)
@@ -110,8 +140,8 @@
 
 ## [**2.4.0**](https://github.com/spumko/hapi/issues?milestone=83&state=closed)
 - [**#1430**](https://github.com/spumko/hapi/issues/1430) Server fails to parse &quot;&quot; cookie value
-- [**#1424**](https://github.com/spumko/hapi/issues/1424) Searching actual working SSE example (#1008 does not work for me)
 - [**#1428**](https://github.com/spumko/hapi/issues/1428) request.getLog() includes same event multiple times when using multiple tags
+- [**#1424**](https://github.com/spumko/hapi/issues/1424) Searching actual working SSE example (#1008 does not work for me)
 - [**#1425**](https://github.com/spumko/hapi/issues/1425) return a reference to the server when adding via pack.server
 - [**#1419**](https://github.com/spumko/hapi/issues/1419) Send newline \n after all responses
 
@@ -119,23 +149,23 @@
 - [**#1320**](https://github.com/spumko/hapi/issues/1320) Add support for asynchronous view rendering
 
 ## [**2.2.0**](https://github.com/spumko/hapi/issues?milestone=81&state=closed)
-- [**#1404**](https://github.com/spumko/hapi/issues/1404) Protect JSON.stringify from throwing.
-- [**#1387**](https://github.com/spumko/hapi/issues/1387) EMFILE error when hapi serves static files over period of time in hapi 2.1.2
-- [**#1378**](https://github.com/spumko/hapi/issues/1378) add failureResponse option to proxy handler
 - [**#1372**](https://github.com/spumko/hapi/issues/1372) test that handler isn&#39;t called when a request is interrupted
-- [**#1382**](https://github.com/spumko/hapi/issues/1382) Make joi optional for route validation
 - [**#1362**](https://github.com/spumko/hapi/issues/1362) (cookies) TypeError: Cannot call method &#39;match&#39; of undefined
+- [**#1378**](https://github.com/spumko/hapi/issues/1378) add failureResponse option to proxy handler
 - [**#1354**](https://github.com/spumko/hapi/issues/1354) Use configuration objects to register helpers
 - [**#1380**](https://github.com/spumko/hapi/issues/1380) Allow bind context for view handler
+- [**#1382**](https://github.com/spumko/hapi/issues/1382) Make joi optional for route validation
+- [**#1404**](https://github.com/spumko/hapi/issues/1404) Protect JSON.stringify from throwing.
 - [**#1395**](https://github.com/spumko/hapi/issues/1395) JSON circular structure error in authentication error logging
 - [**#1405**](https://github.com/spumko/hapi/issues/1405) Call parseInt() for Joi-validated integers
-- [**#1409**](https://github.com/spumko/hapi/issues/1409) Status code set from upstream without passThrough flag
-- [**#1408**](https://github.com/spumko/hapi/issues/1408) precompressed file handle not closed when using head or 304
-- [**#1410**](https://github.com/spumko/hapi/issues/1410) passThrough statusCode overrides manual code value
-- [**#1411**](https://github.com/spumko/hapi/issues/1411) Wasteful encoder prep when response is 304 or head
+- [**#1414**](https://github.com/spumko/hapi/issues/1414) Sending incorrect status code (200) when file fails to open before transmit
 - [**#1413**](https://github.com/spumko/hapi/issues/1413) File stream is opened before necessary (e.g. if replaced by another response in ext)
 - [**#1412**](https://github.com/spumko/hapi/issues/1412) Missing file (404) not captured by onPreResponse
-- [**#1414**](https://github.com/spumko/hapi/issues/1414) Sending incorrect status code (200) when file fails to open before transmit
+- [**#1411**](https://github.com/spumko/hapi/issues/1411) Wasteful encoder prep when response is 304 or head
+- [**#1410**](https://github.com/spumko/hapi/issues/1410) passThrough statusCode overrides manual code value
+- [**#1409**](https://github.com/spumko/hapi/issues/1409) Status code set from upstream without passThrough flag
+- [**#1408**](https://github.com/spumko/hapi/issues/1408) precompressed file handle not closed when using head or 304
+- [**#1387**](https://github.com/spumko/hapi/issues/1387) EMFILE error when hapi serves static files over period of time in hapi 2.1.2
 - [**#1391**](https://github.com/spumko/hapi/issues/1391) Disable autoparsing without losing gzip
 - [**#1393**](https://github.com/spumko/hapi/issues/1393) add `gunzip` as third option to `parse`; resolves #1391
 - [**#1400**](https://github.com/spumko/hapi/issues/1400) Question: Can you get a log of requests that don&#39;t pass validation?
@@ -180,14 +210,13 @@
 - [**#1148**](https://github.com/spumko/hapi/issues/1148) Return 401 when allowEmptyUsername is false and username missing
 
 ## [**2.0.0**](https://github.com/spumko/hapi/issues?milestone=69&state=closed)
-- [**#1194**](https://github.com/spumko/hapi/issues/1194) Remove support for decorating request with reply()
 - [**#1322**](https://github.com/spumko/hapi/issues/1322) Does Hapi support multiple view templates?
 - [**#1317**](https://github.com/spumko/hapi/issues/1317) Cannot Parse form-encoded arrays
 - [**#1331**](https://github.com/spumko/hapi/issues/1331) Fix query(string) regression
 - [**#1332**](https://github.com/spumko/hapi/issues/1332) Payload always logging an error regardless of error state
-- [**#1301**](https://github.com/spumko/hapi/issues/1301) `querystring` =&gt; `qs`, adds support for nested objects
 - [**#1327**](https://github.com/spumko/hapi/issues/1327) Better debug support for object data
 - [**#1324**](https://github.com/spumko/hapi/issues/1324) When no query params are sent, request.params is null instead of {}.
+- [**#1301**](https://github.com/spumko/hapi/issues/1301) `querystring` =&gt; `qs`, adds support for nested objects
 - [**#1314**](https://github.com/spumko/hapi/issues/1314) Replace old payload try mode with failAction
 - [**#1313**](https://github.com/spumko/hapi/issues/1313) Change redirectToSlash default value to true
 - [**#1312**](https://github.com/spumko/hapi/issues/1312) Remove special values for server config &#39;files.relativeTo&#39;
@@ -198,11 +227,11 @@
 - [**#1295**](https://github.com/spumko/hapi/issues/1295) Replace route payload.mode with payload.output and payload.parse
 - [**#1292**](https://github.com/spumko/hapi/issues/1292) Skip loading entire multipart to memory and stream directly to multiparty
 - [**#1168**](https://github.com/spumko/hapi/issues/1168) Save stream to file like {mode: &#39;file&#39; ...}
-- [**#1264**](https://github.com/spumko/hapi/issues/1264) requesting url that is not encoded correctly should return 400, not 404
 - [**#1236**](https://github.com/spumko/hapi/issues/1236) Review lru-cache settings
 - [**#1239**](https://github.com/spumko/hapi/issues/1239) Disable cache when Authorization header is included
 - [**#1241**](https://github.com/spumko/hapi/issues/1241) Add user/private flag to state variable
 - [**#1282**](https://github.com/spumko/hapi/issues/1282) Security tests using reply().setState() which throws
+- [**#1264**](https://github.com/spumko/hapi/issues/1264) requesting url that is not encoded correctly should return 400, not 404
 - [**#1291**](https://github.com/spumko/hapi/issues/1291) Remove server config normalizeRequestPath and default to true
 - [**#1290**](https://github.com/spumko/hapi/issues/1290) Partial path param match /a{b}c does not apply isCaseSensitive
 - [**#1288**](https://github.com/spumko/hapi/issues/1288) Move auth schemes to plugins
@@ -216,8 +245,8 @@
 - [**#1279**](https://github.com/spumko/hapi/issues/1279) Convert ext method signature to handler
 - [**#1270**](https://github.com/spumko/hapi/issues/1270) Apply encoding to Response.Payload operations consistently
 - [**#1272**](https://github.com/spumko/hapi/issues/1272) Redo reply.close()
-- [**#1276**](https://github.com/spumko/hapi/issues/1276) Retain headers in 304 response
 - [**#1277**](https://github.com/spumko/hapi/issues/1277) Emit &#39;internalError&#39; for every 500, not just the one sent back
+- [**#1276**](https://github.com/spumko/hapi/issues/1276) Retain headers in 304 response
 - [**#1275**](https://github.com/spumko/hapi/issues/1275) Boom 2.0
 - [**#1274**](https://github.com/spumko/hapi/issues/1274) Fixed code example in README to comply with 2.0.x
 - [**#1238**](https://github.com/spumko/hapi/issues/1238) Special handling for &#39;*&#39; Vary response header
@@ -236,8 +265,8 @@
 - [**#1246**](https://github.com/spumko/hapi/issues/1246) Allow zero key helpers with cache
 - [**#1249**](https://github.com/spumko/hapi/issues/1249) Cleanup use of request._route.cache and request.route.cache
 - [**#1248**](https://github.com/spumko/hapi/issues/1248) Review proxy upstream ttl passing
-- [**#1251**](https://github.com/spumko/hapi/issues/1251) Replace File from response type to reply.file() helper
 - [**#1254**](https://github.com/spumko/hapi/issues/1254) File response leaks fd if gzipped stream used instead and the other way.
+- [**#1251**](https://github.com/spumko/hapi/issues/1251) Replace File from response type to reply.file() helper
 - [**#1252**](https://github.com/spumko/hapi/issues/1252) Protect response payload stream wrapper from multiple replays
 - [**#1242**](https://github.com/spumko/hapi/issues/1242) Remove server-side route caching
 - [**#1231**](https://github.com/spumko/hapi/issues/1231) request.log() no longer adds &#39;error&#39; tag if data is Error
@@ -247,8 +276,8 @@
 - [**#1230**](https://github.com/spumko/hapi/issues/1230) Remove plugin permissions
 - [**#1219**](https://github.com/spumko/hapi/issues/1219) `pack.require` doc is somewhat incorrect
 - [**#1223**](https://github.com/spumko/hapi/issues/1223) views.helpersPath requires .js files
-- [**#1183**](https://github.com/spumko/hapi/issues/1183) Remove use of removeAllListeners()
 - [**#1228**](https://github.com/spumko/hapi/issues/1228) Client request timeout and downstream listener not set when payload is a stream
+- [**#1183**](https://github.com/spumko/hapi/issues/1183) Remove use of removeAllListeners()
 - [**#1207**](https://github.com/spumko/hapi/issues/1207) Accessing the response stream.
 - [**#1216**](https://github.com/spumko/hapi/issues/1216) Remove support for `notFound` handler string
 - [**#1215**](https://github.com/spumko/hapi/issues/1215) Content-type charset attribute not added to streams
@@ -260,11 +289,12 @@
 - [**#1204**](https://github.com/spumko/hapi/issues/1204) Rename handler/ext context to bind
 - [**#1202**](https://github.com/spumko/hapi/issues/1202) Move handler and ext context to use this
 - [**#1200**](https://github.com/spumko/hapi/issues/1200) Removing confidence, alce from composer and CLI
+- [**#1194**](https://github.com/spumko/hapi/issues/1194) Remove support for decorating request with reply()
 - [**#1191**](https://github.com/spumko/hapi/issues/1191) Cannot use multiple parallel pre methods in handler mode
-- [**#1192**](https://github.com/spumko/hapi/issues/1192) Change pre type to always use handler mode
 - [**#1195**](https://github.com/spumko/hapi/issues/1195) Move request.context to request.reply.context
-- [**#1187**](https://github.com/spumko/hapi/issues/1187) Change pre to use nested arrays instead of mode (serial, parallel)
+- [**#1192**](https://github.com/spumko/hapi/issues/1192) Change pre type to always use handler mode
 - [**#1190**](https://github.com/spumko/hapi/issues/1190) Move Obj stringify step to _prepare
+- [**#1187**](https://github.com/spumko/hapi/issues/1187) Change pre to use nested arrays instead of mode (serial, parallel)
 - [**#1049**](https://github.com/spumko/hapi/issues/1049) Validate pre config schema
 - [**#1155**](https://github.com/spumko/hapi/issues/1155) 404 not being caught by onPreResponse function
 - [**#1182**](https://github.com/spumko/hapi/issues/1182) Error transformation does not work when serving static files
@@ -272,40 +302,40 @@
 - [**#1176**](https://github.com/spumko/hapi/issues/1176) Unify stream and buffer responses
 
 ## [**1.17.0**](https://github.com/spumko/hapi/issues?milestone=68&state=closed)
-- [**#1140**](https://github.com/spumko/hapi/issues/1140) Not able to login after attempting without user name
 - [**#1147**](https://github.com/spumko/hapi/issues/1147) Add request.reply.proxy()
 - [**#1146**](https://github.com/spumko/hapi/issues/1146) Expose proxy functionality as a utility
 - [**#1070**](https://github.com/spumko/hapi/issues/1070) TypeError when validate.* is set to false
 - [**#1102**](https://github.com/spumko/hapi/issues/1102) How to exclude views from layout
+- [**#1140**](https://github.com/spumko/hapi/issues/1140) Not able to login after attempting without user name
 - [**#1144**](https://github.com/spumko/hapi/issues/1144) Support pre-compressed files
 - [**#1142**](https://github.com/spumko/hapi/issues/1142) Fix ext function plugin env binding
 - [**#1137**](https://github.com/spumko/hapi/issues/1137) generateView at &#39;onRequest&#39; extension point
 
 ## [**1.16.1**](https://github.com/spumko/hapi/issues?milestone=67&state=closed)
-- [**#1136**](https://github.com/spumko/hapi/issues/1136) Handlebars 1.1.x uses prototype for registerPartials which breaks its use in Hapi
 - [**#1135**](https://github.com/spumko/hapi/issues/1135) Formatting problem in Reference.md
+- [**#1136**](https://github.com/spumko/hapi/issues/1136) Handlebars 1.1.x uses prototype for registerPartials which breaks its use in Hapi
 
 ## [**1.16.0**](https://github.com/spumko/hapi/issues?milestone=66&state=closed)
-- [**#1123**](https://github.com/spumko/hapi/issues/1123) add ability to listen on unix domain socket
 - [**#1129**](https://github.com/spumko/hapi/issues/1129) support for iisnode and windows named pipes
+- [**#1123**](https://github.com/spumko/hapi/issues/1123) add ability to listen on unix domain socket
 - [**#1133**](https://github.com/spumko/hapi/issues/1133) Joi 2.0
 - [**#1124**](https://github.com/spumko/hapi/issues/1124) Use ALCE for manifest loading.
 
 ## [**1.15.0**](https://github.com/spumko/hapi/issues?milestone=65&state=closed)
-- [**#1112**](https://github.com/spumko/hapi/issues/1112) Too strict cookie parsing?
-- [**#1094**](https://github.com/spumko/hapi/issues/1094) 404 not being caught by onPreResponse function
-- [**#1114**](https://github.com/spumko/hapi/issues/1114) What is the best way to access request headers?
 - [**#1103**](https://github.com/spumko/hapi/issues/1103) allow arrays of scopes on routes
 - [**#1116**](https://github.com/spumko/hapi/issues/1116) CORS origin bug fixes and enhancements
 - [**#1091**](https://github.com/spumko/hapi/issues/1091) Only set access-control-allow-origin if the origin header value matches (or &#39;*&#39; is allowed)
 - [**#1113**](https://github.com/spumko/hapi/issues/1113) updates plugin.views Reference.md entry to a clear and working example
+- [**#1094**](https://github.com/spumko/hapi/issues/1094) 404 not being caught by onPreResponse function
+- [**#1112**](https://github.com/spumko/hapi/issues/1112) Too strict cookie parsing?
+- [**#1114**](https://github.com/spumko/hapi/issues/1114) What is the best way to access request headers?
 
 ## [**1.14.0**](https://github.com/spumko/hapi/issues?milestone=64&state=closed)
 - [**#1098**](https://github.com/spumko/hapi/issues/1098) Add criteria support to CLI
 - [**#1092**](https://github.com/spumko/hapi/issues/1092) Empty path parameter should have empty string value, not undefined
 - [**#1028**](https://github.com/spumko/hapi/issues/1028) Expose requests content-type/mime &amp; accept
-- [**#995**](https://github.com/spumko/hapi/issues/995) Block response.created() from methods other than POST and PUT
 - [**#1024**](https://github.com/spumko/hapi/issues/1024) Hapi.Composer.compose() requires &quot;plugins&quot; but won&#39;t warn if it&#39;s not there
+- [**#995**](https://github.com/spumko/hapi/issues/995) Block response.created() from methods other than POST and PUT
 
 ## [**1.13.0**](https://github.com/spumko/hapi/issues?milestone=63&state=closed)
 - [**#1090**](https://github.com/spumko/hapi/issues/1090) Support partial path segment parameter
@@ -315,8 +345,8 @@
 - [**#1004**](https://github.com/spumko/hapi/issues/1004) validation fails when using Hapi.types.Object() at the root
 - [**#1088**](https://github.com/spumko/hapi/issues/1088) Plugin dependencies
 - [**#1085**](https://github.com/spumko/hapi/issues/1085) Validation options
-- [**#1076**](https://github.com/spumko/hapi/issues/1076) Test for both formats of Content-Encoding header
 - [**#1083**](https://github.com/spumko/hapi/issues/1083) Normalize response headers to lowercase field name
+- [**#1076**](https://github.com/spumko/hapi/issues/1076) Test for both formats of Content-Encoding header
 - [**#1081**](https://github.com/spumko/hapi/issues/1081) Migrate to Iron 1.0
 - [**#1074**](https://github.com/spumko/hapi/issues/1074) Route-specific validation error handler
 - [**#1077**](https://github.com/spumko/hapi/issues/1077) Add compileMode to schema.js
@@ -328,9 +358,9 @@
 - [**#1064**](https://github.com/spumko/hapi/issues/1064) Helper cache drop interface
 
 ## [**1.10.0**](https://github.com/spumko/hapi/issues?milestone=59&state=closed)
-- [**#1058**](https://github.com/spumko/hapi/issues/1058) Closes #1056 and #1057
 - [**#1057**](https://github.com/spumko/hapi/issues/1057) &#39;/{p*}&#39; is sorted ahead of &#39;/{a}/b/{p*}&#39;
 - [**#1056**](https://github.com/spumko/hapi/issues/1056) Allow directory paths to include multiple params and use last for resource selection
+- [**#1058**](https://github.com/spumko/hapi/issues/1058) Closes #1056 and #1057
 - [**#1054**](https://github.com/spumko/hapi/issues/1054) Enhance prerequisites configuration options
 - [**#1030**](https://github.com/spumko/hapi/issues/1030) Problems with routes
 
@@ -341,10 +371,10 @@
 - [**#1037**](https://github.com/spumko/hapi/issues/1037) Stream responses emit response event
 
 ## [**1.9.5**](https://github.com/spumko/hapi/issues?milestone=56&state=closed)
-- [**#1034**](https://github.com/spumko/hapi/issues/1034) Upping shot dep version
 - [**#1033**](https://github.com/spumko/hapi/issues/1033) Node 0.11 bug fixes
-- [**#1019**](https://github.com/spumko/hapi/issues/1019) Depend on Joi v1.1.x
+- [**#1034**](https://github.com/spumko/hapi/issues/1034) Upping shot dep version
 - [**#1032**](https://github.com/spumko/hapi/issues/1032) Updating boom version to 1.0.0
+- [**#1019**](https://github.com/spumko/hapi/issues/1019) Depend on Joi v1.1.x
 
 ## [**1.9.4**](https://github.com/spumko/hapi/issues?milestone=55&state=closed)
 - [**#1029**](https://github.com/spumko/hapi/issues/1029) Using latest hoek and moved to AUTHORS file
@@ -357,15 +387,15 @@
 - [**#1015**](https://github.com/spumko/hapi/issues/1015) Undo #1014
 
 ## [**1.9.1**](https://github.com/spumko/hapi/issues?milestone=52&state=closed)
-- [**#1001**](https://github.com/spumko/hapi/issues/1001) Pack event handlers now support correct args
 - [**#1014**](https://github.com/spumko/hapi/issues/1014) plugin.helper should be selectable
 - [**#1005**](https://github.com/spumko/hapi/issues/1005) Improve server constructor argument validation error reporting
+- [**#1001**](https://github.com/spumko/hapi/issues/1001) Pack event handlers now support correct args
 
 ## [**1.9.0**](https://github.com/spumko/hapi/issues?milestone=51&state=closed)
 - [**#998**](https://github.com/spumko/hapi/issues/998) Adding dtrace probes
 - [**#993**](https://github.com/spumko/hapi/issues/993) Plugin context
-- [**#994**](https://github.com/spumko/hapi/issues/994) Server level cache
 - [**#996**](https://github.com/spumko/hapi/issues/996) Remove Directory and View from cacheable responses
+- [**#994**](https://github.com/spumko/hapi/issues/994) Server level cache
 - [**#959**](https://github.com/spumko/hapi/issues/959) Adding foundation for dtrace probe support
 - [**#980**](https://github.com/spumko/hapi/issues/980) Add interface to register local `require` function with plugin api
 - [**#979**](https://github.com/spumko/hapi/issues/979) Confusing error message when configuring auth using default strategy when none configured
@@ -375,33 +405,33 @@
 
 ## [**1.8.3**](https://github.com/spumko/hapi/issues?milestone=50&state=closed)
 - [**#971**](https://github.com/spumko/hapi/issues/971) Use instanceof Error + isBoom to replace instanceof Boom
-- [**#951**](https://github.com/spumko/hapi/issues/951) use .isBoom instead of instanceof Boom
-- [**#958**](https://github.com/spumko/hapi/issues/958) Path params are no longer lowercased in router
-- [**#946**](https://github.com/spumko/hapi/issues/946) Updating example to be clearer
-- [**#970**](https://github.com/spumko/hapi/issues/970) Removing complexity-report
-- [**#960**](https://github.com/spumko/hapi/issues/960) Updates to case sensitive routing
 - [**#968**](https://github.com/spumko/hapi/issues/968) Changes to `plugin.hapi` and the `cookie` scheme
+- [**#970**](https://github.com/spumko/hapi/issues/970) Removing complexity-report
 - [**#967**](https://github.com/spumko/hapi/issues/967) Authentication defaultMode allowed invalid values
-- [**#963**](https://github.com/spumko/hapi/issues/963) Question: should pack.register&#39;s register pack parameter should be renamed to plugin?
 - [**#966**](https://github.com/spumko/hapi/issues/966) Expose the hapi module on the request object
+- [**#963**](https://github.com/spumko/hapi/issues/963) Question: should pack.register&#39;s register pack parameter should be renamed to plugin?
 - [**#965**](https://github.com/spumko/hapi/issues/965) Change parameter name pack to plugin to resolve #963
 - [**#962**](https://github.com/spumko/hapi/issues/962) Server config schema does not allow single string labels
-- [**#944**](https://github.com/spumko/hapi/issues/944) Found some small typos/formatting issues in Reference.md
+- [**#960**](https://github.com/spumko/hapi/issues/960) Updates to case sensitive routing
+- [**#958**](https://github.com/spumko/hapi/issues/958) Path params are no longer lowercased in router
 - [**#955**](https://github.com/spumko/hapi/issues/955) Update Reference.md plugin.lenght to plugin.length
-- [**#948**](https://github.com/spumko/hapi/issues/948) reference multiparty instead of formidable
+- [**#951**](https://github.com/spumko/hapi/issues/951) use .isBoom instead of instanceof Boom
 - [**#949**](https://github.com/spumko/hapi/issues/949) Error when hawk payload validation is required but the request contains no hash
+- [**#948**](https://github.com/spumko/hapi/issues/948) reference multiparty instead of formidable
+- [**#946**](https://github.com/spumko/hapi/issues/946) Updating example to be clearer
+- [**#944**](https://github.com/spumko/hapi/issues/944) Found some small typos/formatting issues in Reference.md
 
 ## [**1.8.2**](https://github.com/spumko/hapi/issues?milestone=49&state=closed)
+- [**#943**](https://github.com/spumko/hapi/issues/943) Updating version
 - [**#942**](https://github.com/spumko/hapi/issues/942) Layouts work correctly in jade
 - [**#941**](https://github.com/spumko/hapi/issues/941) No longer destroying request socket
-- [**#943**](https://github.com/spumko/hapi/issues/943) Updating version
 - [**#938**](https://github.com/spumko/hapi/issues/938) Fixed the code example to get Hapi&#39;s version
 - [**#936**](https://github.com/spumko/hapi/issues/936) Allow omitting trailing slash when last segment is an optional parameter
 
 ## [**1.8.1**](https://github.com/spumko/hapi/issues?milestone=48&state=closed)
+- [**#933**](https://github.com/spumko/hapi/issues/933) Updating version to 1.8.1
 - [**#928**](https://github.com/spumko/hapi/issues/928) Removing listeners on domain when exiting
 - [**#927**](https://github.com/spumko/hapi/issues/927) Removing global variable
-- [**#933**](https://github.com/spumko/hapi/issues/933) Updating version to 1.8.1
 
 ## [**1.8.0**](https://github.com/spumko/hapi/issues?milestone=47&state=closed)
 - [**#925**](https://github.com/spumko/hapi/issues/925) Fixing edge case where bad path can cause issues with url.parse
@@ -418,18 +448,18 @@
 
 ## [**1.7.0**](https://github.com/spumko/hapi/issues?milestone=43&state=closed)
 - [**#912**](https://github.com/spumko/hapi/issues/912) Fixing aborted causing duplicate res.ends issue with incoming request
-- [**#907**](https://github.com/spumko/hapi/issues/907) Adding test
 - [**#911**](https://github.com/spumko/hapi/issues/911) Allow client.request calls without a callback (ignoring response)
 - [**#910**](https://github.com/spumko/hapi/issues/910) Client does not destroy request on redirection error
+- [**#907**](https://github.com/spumko/hapi/issues/907) Adding test
 
 ## [**1.6.2**](https://github.com/spumko/hapi/issues?milestone=42&state=closed)
 - [**#906**](https://github.com/spumko/hapi/issues/906) Proxy requests are closed when server response already sent
 
 ## [**1.6.1**](https://github.com/spumko/hapi/issues?milestone=41&state=closed)
-- [**#901**](https://github.com/spumko/hapi/issues/901) Performance tweaks
-- [**#903**](https://github.com/spumko/hapi/issues/903) Fixing issue where timeout occurs after socket close in client
-- [**#897**](https://github.com/spumko/hapi/issues/897) Hapi node_modules_path now supports symlinks
 - [**#904**](https://github.com/spumko/hapi/issues/904) Issue/902
+- [**#903**](https://github.com/spumko/hapi/issues/903) Fixing issue where timeout occurs after socket close in client
+- [**#901**](https://github.com/spumko/hapi/issues/901) Performance tweaks
+- [**#897**](https://github.com/spumko/hapi/issues/897) Hapi node_modules_path now supports symlinks
 
 ## [**1.6.0**](https://github.com/spumko/hapi/issues?milestone=40&state=closed)
 - [**#891**](https://github.com/spumko/hapi/issues/891) Exposing rejectUnauthorized property on proxy
@@ -439,39 +469,39 @@
 - [**#887**](https://github.com/spumko/hapi/issues/887) Default auth scheme only works when scheme is added with &#39;default&#39; name
 
 ## [**1.4.0**](https://github.com/spumko/hapi/issues?milestone=38&state=closed)
-- [**#883**](https://github.com/spumko/hapi/issues/883) Cleanup pack requirePath
+- [**#868**](https://github.com/spumko/hapi/issues/868) Potential leak when aborting reading a payload if max size reached
 - [**#872**](https://github.com/spumko/hapi/issues/872) Test for invalid incoming path without leading &#39;/&#39;
 - [**#869**](https://github.com/spumko/hapi/issues/869) Request._replyInterface called twice but does not share wasProcessed state
-- [**#868**](https://github.com/spumko/hapi/issues/868) Potential leak when aborting reading a payload if max size reached
 - [**#870**](https://github.com/spumko/hapi/issues/870) Response treats objects as errors based on too trivial keys
 - [**#885**](https://github.com/spumko/hapi/issues/885) Fix plugin.path
+- [**#883**](https://github.com/spumko/hapi/issues/883) Cleanup pack requirePath
 
 ## [**1.3.0**](https://github.com/spumko/hapi/issues?milestone=37&state=closed)
+- [**#871**](https://github.com/spumko/hapi/issues/871) * allowed in path but used as special character in route fingerprint
 - [**#880**](https://github.com/spumko/hapi/issues/880) Performance and hawk options
-- [**#862**](https://github.com/spumko/hapi/issues/862) Minor performance tweaks
+- [**#879**](https://github.com/spumko/hapi/issues/879) Support all Hawk and Bewit options
+- [**#878**](https://github.com/spumko/hapi/issues/878) Adding Client request socket timeout
 - [**#863**](https://github.com/spumko/hapi/issues/863) Absolute paths now work correctly with hapi command
 - [**#860**](https://github.com/spumko/hapi/issues/860) Adding hapi bin test and fixing issue with no plugins
-- [**#878**](https://github.com/spumko/hapi/issues/878) Adding Client request socket timeout
+- [**#862**](https://github.com/spumko/hapi/issues/862) Minor performance tweaks
 - [**#859**](https://github.com/spumko/hapi/issues/859) Fixing test
 - [**#858**](https://github.com/spumko/hapi/issues/858) Added missing done() call in test
-- [**#871**](https://github.com/spumko/hapi/issues/871) * allowed in path but used as special character in route fingerprint
-- [**#879**](https://github.com/spumko/hapi/issues/879) Support all Hawk and Bewit options
 - [**#856**](https://github.com/spumko/hapi/issues/856) Remove _log() wrapper
 
 ## [**1.2.0**](https://github.com/spumko/hapi/issues?milestone=36&state=closed)
-- [**#848**](https://github.com/spumko/hapi/issues/848) Template settings override fix
-- [**#850**](https://github.com/spumko/hapi/issues/850) Increasing allowed sockets to 10 for client
-- [**#853**](https://github.com/spumko/hapi/issues/853) New internal proxy handler
-- [**#854**](https://github.com/spumko/hapi/issues/854) Move to use multiparty
 - [**#846**](https://github.com/spumko/hapi/issues/846) Request: View configuration to autoload helepers
+- [**#854**](https://github.com/spumko/hapi/issues/854) Move to use multiparty
+- [**#853**](https://github.com/spumko/hapi/issues/853) New internal proxy handler
+- [**#850**](https://github.com/spumko/hapi/issues/850) Increasing allowed sockets to 10 for client
+- [**#848**](https://github.com/spumko/hapi/issues/848) Template settings override fix
 - [**#845**](https://github.com/spumko/hapi/issues/845) Generic response fails to account for all possible res events
 - [**#844**](https://github.com/spumko/hapi/issues/844) Proxy to outside site fails due to request&#39;s old stream api and node 0.10 wrap()
 - [**#843**](https://github.com/spumko/hapi/issues/843) Allow setting custom headers via proxy mapUri
 
 ## [**1.0.3**](https://github.com/spumko/hapi/issues?milestone=35&state=closed)
-- [**#817**](https://github.com/spumko/hapi/issues/817) Payload bugfix for PATCH method
-- [**#822**](https://github.com/spumko/hapi/issues/822) JSONP doesn&#39;t seem to be working
 - [**#823**](https://github.com/spumko/hapi/issues/823) Issue/822
+- [**#822**](https://github.com/spumko/hapi/issues/822) JSONP doesn&#39;t seem to be working
+- [**#817**](https://github.com/spumko/hapi/issues/817) Payload bugfix for PATCH method
 - [**#818**](https://github.com/spumko/hapi/issues/818) Tiny composer documentation fix
 - [**#814**](https://github.com/spumko/hapi/issues/814) Fixed jade compile issues and updated tests to verify fix.
 - [**#804**](https://github.com/spumko/hapi/issues/804) Remove restriction on params in path for static file handler
@@ -480,18 +510,18 @@
 - [**#813**](https://github.com/spumko/hapi/issues/813) text/* content-type always echo back the received content
 
 ## [**1.1.0**](https://github.com/spumko/hapi/issues?milestone=32&state=closed)
-- [**#820**](https://github.com/spumko/hapi/issues/820) Clarified the format of payload in server.inject in the Reference doc
-- [**#837**](https://github.com/spumko/hapi/issues/837) Issue/812
-- [**#838**](https://github.com/spumko/hapi/issues/838) Issue/808
 - [**#839**](https://github.com/spumko/hapi/issues/839) Cleanup listeners
-- [**#835**](https://github.com/spumko/hapi/issues/835) `Pack`: Automatically resolve the `requirePath` if provided
+- [**#838**](https://github.com/spumko/hapi/issues/838) Issue/808
+- [**#837**](https://github.com/spumko/hapi/issues/837) Issue/812
 - [**#834**](https://github.com/spumko/hapi/issues/834) `Pack` throws an `AssertionError` if the `requirePath` is not absolute
+- [**#835**](https://github.com/spumko/hapi/issues/835) `Pack`: Automatically resolve the `requirePath` if provided
 - [**#832**](https://github.com/spumko/hapi/issues/832) Allow route.payload config to be an object with `mode`
 - [**#833**](https://github.com/spumko/hapi/issues/833) closes #832
 - [**#830**](https://github.com/spumko/hapi/issues/830) Add payload &#39;try&#39; parsing mode
 - [**#831**](https://github.com/spumko/hapi/issues/831) Closes #830
 - [**#828**](https://github.com/spumko/hapi/issues/828) Add HttpOnly support to cookie auth
 - [**#827**](https://github.com/spumko/hapi/issues/827) request debug printout format and condition
+- [**#820**](https://github.com/spumko/hapi/issues/820) Clarified the format of payload in server.inject in the Reference doc
 - [**#824**](https://github.com/spumko/hapi/issues/824) Issue/821
 
 ## [**0.15.8**](https://github.com/spumko/hapi/issues?milestone=31&state=closed)
@@ -502,40 +532,40 @@
 - [**#717**](https://github.com/spumko/hapi/issues/717) Auto cookie value
 
 ## [**0.15.4**](https://github.com/spumko/hapi/issues?milestone=28&state=closed)
-- [**#674**](https://github.com/spumko/hapi/issues/674) Adding missing branch tests
 - [**#682**](https://github.com/spumko/hapi/issues/682) Bypass node http bug in writeHead
 - [**#678**](https://github.com/spumko/hapi/issues/678) Updating tutorials and adding a plugins list doc
+- [**#674**](https://github.com/spumko/hapi/issues/674) Adding missing branch tests
 
 ## [**0.15.3**](https://github.com/spumko/hapi/issues?milestone=27&state=closed)
 - [**#677**](https://github.com/spumko/hapi/issues/677) Fix ext() with function array bug
 
 ## [**1.0.0**](https://github.com/spumko/hapi/issues?milestone=26&state=closed)
-- [**#789**](https://github.com/spumko/hapi/issues/789) Streams not properly being closed for static files when browser gets cache hit
-- [**#738**](https://github.com/spumko/hapi/issues/738) Support for Access-Control-Expose-Headers in the CORS options
-- [**#739**](https://github.com/spumko/hapi/issues/739) Adding server.stop support for destroying connections after a timeout
-- [**#755**](https://github.com/spumko/hapi/issues/755) Views now render without child path
 - [**#796**](https://github.com/spumko/hapi/issues/796) Allow unencoded double quote and backslash in the cookie value
 - [**#793**](https://github.com/spumko/hapi/issues/793) Use new assert with passed parameters instead of concat string
-- [**#768**](https://github.com/spumko/hapi/issues/768) Directory handler example
-- [**#767**](https://github.com/spumko/hapi/issues/767) Verify every example works with 1.0
-- [**#745**](https://github.com/spumko/hapi/issues/745) Basic Authentication callback with no username/password returns 500
-- [**#771**](https://github.com/spumko/hapi/issues/771) Multipart upload issue
-- [**#788**](https://github.com/spumko/hapi/issues/788) Need more detailed documentation for &quot;next&quot; callback for event handlers
-- [**#780**](https://github.com/spumko/hapi/issues/780) Relative path redirection should have vhost support
 - [**#791**](https://github.com/spumko/hapi/issues/791) Test fails: Auth Hawk includes authorization header in response when the response is a stream
+- [**#789**](https://github.com/spumko/hapi/issues/789) Streams not properly being closed for static files when browser gets cache hit
+- [**#788**](https://github.com/spumko/hapi/issues/788) Need more detailed documentation for &quot;next&quot; callback for event handlers
 - [**#787**](https://github.com/spumko/hapi/issues/787) Expose Plugin File Path
+- [**#767**](https://github.com/spumko/hapi/issues/767) Verify every example works with 1.0
+- [**#780**](https://github.com/spumko/hapi/issues/780) Relative path redirection should have vhost support
+- [**#768**](https://github.com/spumko/hapi/issues/768) Directory handler example
 - [**#784**](https://github.com/spumko/hapi/issues/784) Change server helper options.generateKey to receive the same arguments as the helper method
 - [**#782**](https://github.com/spumko/hapi/issues/782) Payload parsing should be based on request method, not path method
 - [**#781**](https://github.com/spumko/hapi/issues/781) Do not set request.state[name] when value is invalid regardless of failAction
 - [**#779**](https://github.com/spumko/hapi/issues/779) Add server config `location` for Location header prefix
 - [**#776**](https://github.com/spumko/hapi/issues/776) Streamline request.reply()
+- [**#771**](https://github.com/spumko/hapi/issues/771) Multipart upload issue
 - [**#765**](https://github.com/spumko/hapi/issues/765) Refactor views manager configuration
-- [**#751**](https://github.com/spumko/hapi/issues/751) Cleanup Unmonitored error
 - [**#752**](https://github.com/spumko/hapi/issues/752) Shared config for plugins
+- [**#751**](https://github.com/spumko/hapi/issues/751) Cleanup Unmonitored error
 - [**#759**](https://github.com/spumko/hapi/issues/759) Feature/misc
 - [**#758**](https://github.com/spumko/hapi/issues/758) cookie authentication example fails with 1.0.0
+- [**#755**](https://github.com/spumko/hapi/issues/755) Views now render without child path
+- [**#745**](https://github.com/spumko/hapi/issues/745) Basic Authentication callback with no username/password returns 500
 - [**#742**](https://github.com/spumko/hapi/issues/742) Remove built-in Oz support
 - [**#741**](https://github.com/spumko/hapi/issues/741) Remove Raw response type
+- [**#739**](https://github.com/spumko/hapi/issues/739) Adding server.stop support for destroying connections after a timeout
+- [**#738**](https://github.com/spumko/hapi/issues/738) Support for Access-Control-Expose-Headers in the CORS options
 - [**#736**](https://github.com/spumko/hapi/issues/736) Node v0.10
 
 ## [**0.15.2**](https://github.com/spumko/hapi/issues?milestone=25&state=closed)
@@ -543,52 +573,52 @@
 - [**#669**](https://github.com/spumko/hapi/issues/669) Optimize prerequisites and protect
 
 ## [**0.16.0**](https://github.com/spumko/hapi/issues?milestone=24&state=closed)
-- [**#724**](https://github.com/spumko/hapi/issues/724) Route validation is now using payload instead of schema
-- [**#700**](https://github.com/spumko/hapi/issues/700) Adding security tests and fixing security bugs
 - [**#656**](https://github.com/spumko/hapi/issues/656) Support for virtual hosts
 - [**#727**](https://github.com/spumko/hapi/issues/727) Fix hawk response header edge cases
 - [**#726**](https://github.com/spumko/hapi/issues/726) Misc features
 - [**#725**](https://github.com/spumko/hapi/issues/725) Debug enhancements
 - [**#714**](https://github.com/spumko/hapi/issues/714) Adding remote address and referrer information to request.info
+- [**#724**](https://github.com/spumko/hapi/issues/724) Route validation is now using payload instead of schema
 - [**#716**](https://github.com/spumko/hapi/issues/716) Errors when preparing a response now emit internalError correctly
 - [**#715**](https://github.com/spumko/hapi/issues/715) Auth api refactor
+- [**#700**](https://github.com/spumko/hapi/issues/700) Adding security tests and fixing security bugs
 - [**#686**](https://github.com/spumko/hapi/issues/686) Pack auth api
 - [**#683**](https://github.com/spumko/hapi/issues/683) Pack and cache API refactor
 
 ## [**0.15.1**](https://github.com/spumko/hapi/issues?milestone=23&state=closed)
-- [**#642**](https://github.com/spumko/hapi/issues/642) Adding hawk response auth header
 - [**#663**](https://github.com/spumko/hapi/issues/663) Full plugin deps
 - [**#662**](https://github.com/spumko/hapi/issues/662) Plugin deps
 - [**#659**](https://github.com/spumko/hapi/issues/659) handler interface api styles
 - [**#653**](https://github.com/spumko/hapi/issues/653) Add request defensive protection
+- [**#642**](https://github.com/spumko/hapi/issues/642) Adding hawk response auth header
 - [**#649**](https://github.com/spumko/hapi/issues/649) Migrate to lab (from mocha)
 
 ## [**0.15.0**](https://github.com/spumko/hapi/issues?milestone=22&state=closed)
-- [**#591**](https://github.com/spumko/hapi/issues/591) Fixing test to be isolated
-- [**#589**](https://github.com/spumko/hapi/issues/589) Sending a gzipped proxy response now works correctly
-- [**#615**](https://github.com/spumko/hapi/issues/615) Using path.join where possible
-- [**#593**](https://github.com/spumko/hapi/issues/593) Adding graceful shutdown from QUIT signal event
-- [**#595**](https://github.com/spumko/hapi/issues/595) Fixing gzip stream test to use simple stream
-- [**#610**](https://github.com/spumko/hapi/issues/610) Cleaning up test and stream response
-- [**#585**](https://github.com/spumko/hapi/issues/585) Server.stop now stops gracefully
-- [**#611**](https://github.com/spumko/hapi/issues/611) Adding vhost tests
-- [**#594**](https://github.com/spumko/hapi/issues/594) Adding deflate support to stream response
 - [**#638**](https://github.com/spumko/hapi/issues/638) Event tags
 - [**#632**](https://github.com/spumko/hapi/issues/632) Adding example of cookie failAction
 - [**#635**](https://github.com/spumko/hapi/issues/635) Cleanup
 - [**#634**](https://github.com/spumko/hapi/issues/634) Domains
 - [**#633**](https://github.com/spumko/hapi/issues/633) pack interface cleanup
-- [**#612**](https://github.com/spumko/hapi/issues/612) Remove monitor
 - [**#630**](https://github.com/spumko/hapi/issues/630) shot 0.1.0, Buffer response type, encoding
 - [**#619**](https://github.com/spumko/hapi/issues/619) hawk 0.10, payload cleanup, text/* parse support
 - [**#617**](https://github.com/spumko/hapi/issues/617) Upgrade to Hawk 0.9.0
+- [**#615**](https://github.com/spumko/hapi/issues/615) Using path.join where possible
 - [**#616**](https://github.com/spumko/hapi/issues/616) Cookie Max-Age is in seconds, not msec
 - [**#613**](https://github.com/spumko/hapi/issues/613) Fix proxy mapUri query bug, allow pack.api to specify key
+- [**#612**](https://github.com/spumko/hapi/issues/612) Remove monitor
+- [**#611**](https://github.com/spumko/hapi/issues/611) Adding vhost tests
 - [**#609**](https://github.com/spumko/hapi/issues/609) Virtual hosts support
+- [**#610**](https://github.com/spumko/hapi/issues/610) Cleaning up test and stream response
 - [**#607**](https://github.com/spumko/hapi/issues/607) Adding basic crumb CSRF information to reference guide 
 - [**#602**](https://github.com/spumko/hapi/issues/602) Relative paths
+- [**#595**](https://github.com/spumko/hapi/issues/595) Fixing gzip stream test to use simple stream
 - [**#596**](https://github.com/spumko/hapi/issues/596) Adding request payload section
+- [**#594**](https://github.com/spumko/hapi/issues/594) Adding deflate support to stream response
+- [**#593**](https://github.com/spumko/hapi/issues/593) Adding graceful shutdown from QUIT signal event
 - [**#592**](https://github.com/spumko/hapi/issues/592) refactor router
+- [**#591**](https://github.com/spumko/hapi/issues/591) Fixing test to be isolated
+- [**#589**](https://github.com/spumko/hapi/issues/589) Sending a gzipped proxy response now works correctly
+- [**#585**](https://github.com/spumko/hapi/issues/585) Server.stop now stops gracefully
 
 ## [**0.14.2**](https://github.com/spumko/hapi/issues?milestone=21&state=closed)
 - [**#587**](https://github.com/spumko/hapi/issues/587) Composer config options
@@ -602,12 +632,12 @@
 
 ## [**0.14.0**](https://github.com/spumko/hapi/issues?milestone=18&state=closed)
 - [**#563**](https://github.com/spumko/hapi/issues/563) Using memory instead of redis for test
-- [**#531**](https://github.com/spumko/hapi/issues/531) JSONP
 - [**#561**](https://github.com/spumko/hapi/issues/561) Composer
 - [**#553**](https://github.com/spumko/hapi/issues/553) Pack server event and socket timeout override
 - [**#543**](https://github.com/spumko/hapi/issues/543) Fix scoping bug when using multiple helper prerequisites
 - [**#438**](https://github.com/spumko/hapi/issues/438) Adding support for payload authentication validation
 - [**#537**](https://github.com/spumko/hapi/issues/537) Update docs/Reference.md
+- [**#531**](https://github.com/spumko/hapi/issues/531) JSONP
 - [**#523**](https://github.com/spumko/hapi/issues/523) Set CORS origin header to incoming request origin if allowed
 - [**#522**](https://github.com/spumko/hapi/issues/522) rename helmet to tv
 - [**#512**](https://github.com/spumko/hapi/issues/512) Direct use of Boom (0.3.0)
@@ -617,10 +647,10 @@
 - [**#498**](https://github.com/spumko/hapi/issues/498) Adding code coverage support using blanket
 - [**#494**](https://github.com/spumko/hapi/issues/494) fix typo from issue/491
 - [**#493**](https://github.com/spumko/hapi/issues/493) Fixing test that would fail periodically
-- [**#478**](https://github.com/spumko/hapi/issues/478) Cleanup ext options and error handling
 - [**#482**](https://github.com/spumko/hapi/issues/482) Parse cookies before authentication
 - [**#481**](https://github.com/spumko/hapi/issues/481) Adding log tag filtering information to readme
 - [**#480**](https://github.com/spumko/hapi/issues/480) Cleaning up this. use
+- [**#478**](https://github.com/spumko/hapi/issues/478) Cleanup ext options and error handling
 - [**#475**](https://github.com/spumko/hapi/issues/475) Simplify path regex
 
 ## [**0.13.0**](https://github.com/spumko/hapi/issues?milestone=17&state=closed)
@@ -693,12 +723,13 @@
 
 ## [**0.6.0**](https://github.com/spumko/hapi/issues?milestone=1&state=closed)
 - [**#102**](https://github.com/spumko/hapi/issues/102) v0.6.0 merge
-- [**#100**](https://github.com/spumko/hapi/issues/100) New Query Validation Fns Added
 - [**#101**](https://github.com/spumko/hapi/issues/101) modified new validation fns to use Utils.assert
+- [**#100**](https://github.com/spumko/hapi/issues/100) New Query Validation Fns Added
 - [**#99**](https://github.com/spumko/hapi/issues/99) Simplified request log interface
-- [**#91**](https://github.com/spumko/hapi/issues/91) QueryValidation fixes, add default behavior for unspecified params, added small tests
-- [**#92**](https://github.com/spumko/hapi/issues/92) Fix example
-- [**#93**](https://github.com/spumko/hapi/issues/93) fix error on subsequent url accesses for queryval
-- [**#94**](https://github.com/spumko/hapi/issues/94) debug interface, log interface
-- [**#96**](https://github.com/spumko/hapi/issues/96) Small utils
 - [**#63**](https://github.com/spumko/hapi/issues/63) Added in SSL cert passphrase to https server creation from settings.
+- [**#96**](https://github.com/spumko/hapi/issues/96) Small utils
+- [**#94**](https://github.com/spumko/hapi/issues/94) debug interface, log interface
+- [**#93**](https://github.com/spumko/hapi/issues/93) fix error on subsequent url accesses for queryval
+- [**#92**](https://github.com/spumko/hapi/issues/92) Fix example
+- [**#91**](https://github.com/spumko/hapi/issues/91) QueryValidation fixes, add default behavior for unspecified params, added small tests
+


### PR DESCRIPTION
Generated with [mdchangelog@0.2.0](https://github.com/creativelive/mdchangelog) command:

```
mdchangelog --no-prologue --no-orphan-issues --overwrite --remote spumko/hapi --order closed_at
```

I added some ordering options to mdchangelog and ordered the log by "closed_at". This will be a more predictable ordering than the previous order of "updated_at" which will change whenever folks comment or reference old issues. That's why this changelog has multiple diffs to the current one.
