### PR TITLE
Escaping asterisks in documentation

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -395,7 +395,7 @@ The following options are available when adding a route:
     - <a name="route.config.directory"></a>`directory` - generates a directory endpoint for serving static content from a directory. Routes using the
       directory handler must include a path parameter at the end of the path string (e.g. '/path/to/somewhere/{param}' where the parameter name does
       not matter). The path parameter can use any of the parameter options (e.g. '{param}' for one level files only, '{param?}' for one level files or
-      the directory root, '{param*}' for any level, or '{param*3}' for a specific level). If additional path parameters are present, they are ignored for
+      the directory root, '{param\*}' for any level, or '{param\*3}' for a specific level). If additional path parameters are present, they are ignored for
       the purpose of selecting the file system resource. The directory handler is an object with the following options:
         - `path` - (required) the directory root path (relative paths are resolved based on the server [`files`](#server.config.files) configuration).
           Value can be:


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/62923/3263662/95bed2fa-f274-11e3-94c2-a433653da83b.png)

Backslash escaping is how it's officially documented in markdown but I'm not certain how you're generating the html version of your documentation so cannot confirm this will _actually_ do the trick.
