### PR TITLE
switch single quotes for backticks to avoid unwanted italicizing

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -393,9 +393,9 @@ The following options are available when adding a route:
               serve if the request supports content encoding. Defaults to `false`.
 
     - <a name="route.config.directory"></a>`directory` - generates a directory endpoint for serving static content from a directory. Routes using the
-      directory handler must include a path parameter at the end of the path string (e.g. '/path/to/somewhere/{param}' where the parameter name does
-      not matter). The path parameter can use any of the parameter options (e.g. '{param}' for one level files only, '{param?}' for one level files or
-      the directory root, '{param*}' for any level, or '{param*3}' for a specific level). If additional path parameters are present, they are ignored for
+      directory handler must include a path parameter at the end of the path string (e.g. `/path/to/somewhere/{param}` where the parameter name does
+      not matter). The path parameter can use any of the parameter options (e.g. `{param}` for one level files only, `{param?}` for one level files or
+      the directory root, `{param*}` for any level, or `{param*3}` for a specific level). If additional path parameters are present, they are ignored for
       the purpose of selecting the file system resource. The directory handler is an object with the following options:
         - `path` - (required) the directory root path (relative paths are resolved based on the server [`files`](#server.config.files) configuration).
           Value can be:
@@ -2950,7 +2950,7 @@ installed in the path.  The following arguments are available to the **hapi** CL
 - '-p' - the path to the node_modules folder to load plugins from (optional)
 - '--require' - a module the cli will require before hapi is required (optional) ex. loading a metrics library
 
-Note that `--require` will require from node_modules, an absolute path, a relative path, or from the node_modules
+Note that `--require` will require from `node_modules`, an absolute path, a relative path, or from the `node_modules`
 set by `-p` if available.
 
 In order to help with A/B testing there is [confidence](https://github.com/spumko/confidence). Confidence is a


### PR DESCRIPTION
Does just what the title says, this is a replacement for #1713 
