### PR TITLE
Fixes undefined error in `plugin.dependency`

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -341,7 +341,7 @@ internals.Pack.prototype._plugin = function (plugin, registerOptions, state, cal
                 var callback = (typeof arguments[1] === 'object' ? arguments[2] : arguments[1]);
 
                 var localState = {
-                    dependecies: state.dependecies,
+                    dependencies: state.dependencies,
                     route: env.route,
                     selection: selection.index
                 };


### PR DESCRIPTION
I'm not familiar enough with the code base to figure out how to cover this typo. All current `plugin.dependency` tests pass for some reason but it didn't work in my project. This patch fixes the typo.
