### PR TITLE
Use compose method instead of composer

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -2328,7 +2328,7 @@ var manifest = {
     }
 };
 
-Hapi.Pack.composer(manifest, function (err, pack) {
+Hapi.Pack.compose(manifest, function (err, pack) {
 
     pack.start();
 });


### PR DESCRIPTION
This updates the docs to use `Hapi.Pack.compose` instead of `composer`.
