### PR TITLE
Incompatible transfer-encoding/content-encoding headers when response is compressed

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -192,6 +192,7 @@ internals.transmit = function (response, request, callback) {
                 }
 
                 response._header('content-encoding', encoding);
+                response._header('transfer-encoding', encoding);
                 response.vary('accept-encoding');
 
                 if (source._hapi &&


### PR DESCRIPTION
I ran into this issue with nginx: http://trac.nginx.org/nginx/ticket/99

When using an nginx < v1.1 as a proxy and the response `transfer-encoding` is `chunked` and `content-encoding` is not chunked nginx will not deliver the body to the client.

Example:

``` js
var Hapi = require('hapi'); // v6.0.2

// Create a server with a host and port
var server = Hapi.createServer('localhost', 8000);

// Add the route
server.route({
  method: 'GET',
  path: '/hello',
  handler: function (request, reply) {
    reply('hello world');
  }
});

// Start the server
server.start();
```

```
$ curl -v -H"accept-encoding: gzip" -H"connection: close" localhost:8000/hello
* Adding handle: conn: 0x7fac49003a00
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7fac49003a00) send_pipe: 1, recv_pipe: 0
* About to connect() to localhost port 8000 (#0)
*   Trying ::1...
*   Trying fe80::1...
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /hello HTTP/1.1
> User-Agent: curl/7.30.0
> Host: localhost:8000
> Accept: */*
> accept-encoding: gzip
> connection: close
>
< HTTP/1.1 200 OK
< content-type: text/html; charset=utf-8
< cache-control: no-cache
< content-encoding: gzip
< vary: accept-encoding
< Date: Tue, 17 Jun 2014 20:12:23 GMT
< Connection: close
< Transfer-Encoding: chunked
<
* Closing connection 0
```

Note that `Transfer-Encoding` is `chunked` while `content-encoding` is `gzip`. Technically that isn't valid (I guess), and nginx < 1.1 fails to deliver the response to the client in that case.

By explicitly setting the `transfer-encoding` header nginx proxies the response properly.
