### PR TITLE
log function should only emit once if _server object

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -462,10 +462,11 @@ internals.Pack.prototype.log = function (tags, data, timestamp, _server) {
 
     var tagsMap = Hoek.mapToObject(event.tags);
 
-    this._events.emit('log', event, tagsMap);
-
     if (_server) {
         _server.emit('log', event, tagsMap);
+    }
+    else {
+        this._events.emit('log', event, tagsMap);
     }
 
     if (this._settings.debug &&


### PR DESCRIPTION
The good plugin seemed to be throwing 2 log entries when I tried to migrate the tests to hapi 6.0 when using server.log with packs.  This may potentially fix that issue.  Please let me know if instead the issue is with how pack is being used instead, and I should indeed expect 2 emits and handle that appropriately.
