### PR TITLE
Adding helpful error message when pack.register is missing a callback

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -172,6 +172,8 @@ internals.Pack.prototype.register = function (plugins /*, [options], callback */
     var options = (typeof arguments[1] === 'object' ? arguments[1] : {});
     var callback = (typeof arguments[1] === 'object' ? arguments[2] : arguments[1]);
 
+    Hoek.assert(typeof callback === 'function', 'A callback function is required to register a plugin');
+
     var state = {
         dependencies: []
     };

--- a/test/pack.js
+++ b/test/pack.js
@@ -120,6 +120,27 @@ describe('Pack', function () {
         });
     });
 
+    it('throws when register is missing a callback function', function (done) {
+
+        var pack = new Hapi.Pack();
+        pack.server({ labels: ['a', 'b'] });
+
+        var plugin = {
+            name: 'test',
+            register: function (plugin, options, next) {
+
+                next();
+            },
+            options: { something: true }
+        };
+
+        expect(function () {
+            
+            pack.register(plugin);
+        }).to.throw('A callback function is required to register a plugin');
+        done();
+    });
+
     it('registers plugin via server pack interface', function (done) {
 
         var plugin = {


### PR DESCRIPTION
Closes #1751
