### PR TITLE
Follow coding conventions concerning semicolons; Don't initialize variab...

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -187,7 +187,7 @@ internals.Auth.prototype._authenticate = function (request, next) {
 
         request._protect.run(validate, function (exit) {
 
-            var savedResults = undefined;
+            var savedResults;
             var transfer = function (err) {
 
                 exit(err, strategy, savedResults);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -40,7 +40,7 @@ internals.loadExtras = function () {
 
     if (!Hoek.isAbsolutePath(extras)) {
         if (extras[0] === '.') {
-            extrasPath = Path.join(process.cwd(), extras)
+            extrasPath = Path.join(process.cwd(), extras);
         } else {
             extrasPath = Path.join(nodeModulesPath, extras);
         }
@@ -97,7 +97,7 @@ internals.loadPacks = function (manifest, callback) {
 exports.start = function () {
 
     internals.loadExtras();
-    Hapi = require('..')
+    Hapi = require('..');
     var manifest = internals.getManifest();
 
     internals.loadPacks(manifest, function (err, options) {

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -145,7 +145,7 @@ exports.replyInterface = function (request, finalize, base) {
     reply.redirect = function (location) {
 
         return internals.wrap('', request, finalize).redirect(location);
-    }
+    };
 
     return reply;
 };

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -383,7 +383,7 @@ internals.Pack.prototype._plugin = function (plugin, registerOptions, state, cal
 
         Hoek.assert(path && typeof path === 'string', 'path must be a non-empty string');
         env.path = path;
-    }
+    };
 
     root.views = function (options) {
 

--- a/test/auth.js
+++ b/test/auth.js
@@ -648,7 +648,7 @@ describe('Auth', function () {
     it('throws when strategy does not support payload authentication', function (done) {
 
         var server = new Hapi.Server();
-        var implementation = function () { return { authenticate: internals.implementation.authenticate } };
+        var implementation = function () { return { authenticate: internals.implementation.authenticate }; };
 
         server.auth.scheme('custom', implementation);
         server.auth.strategy('default', 'custom', true, {});
@@ -671,7 +671,7 @@ describe('Auth', function () {
     it('throws when no strategy supports optional payload authentication', function (done) {
 
         var server = new Hapi.Server();
-        var implementation = function () { return { authenticate: internals.implementation.authenticate } };
+        var implementation = function () { return { authenticate: internals.implementation.authenticate }; };
 
         server.auth.scheme('custom', implementation);
         server.auth.strategy('default', 'custom', true, {});
@@ -694,7 +694,7 @@ describe('Auth', function () {
     it('allows one strategy to supports optional payload authentication while another does not', function (done) {
 
         var server = new Hapi.Server();
-        var implementation = function () { return { authenticate: internals.implementation.authenticate } };
+        var implementation = function () { return { authenticate: internals.implementation.authenticate }; };
 
         server.auth.scheme('custom1', implementation);
         server.auth.scheme('custom2', internals.implementation);
@@ -862,7 +862,7 @@ describe('Auth', function () {
 
         server.route({ method: 'GET', path: '/', handler: function (request, reply) { reply('test'); } });
 
-        var result = undefined;
+        var result;
         server.on('request', function (request, event, tags) {
 
             if (tags.unauthenticated) {
@@ -1014,5 +1014,3 @@ internals.implementation = function (server, options) {
 
     return scheme;
 };
-
-

--- a/test/clientTimeout.js
+++ b/test/clientTimeout.js
@@ -166,6 +166,6 @@ describe('Client Timeout', function () {
 
                 req.end();
             }, 100);
-        })
+        });
     });
 });

--- a/test/directory.js
+++ b/test/directory.js
@@ -88,7 +88,7 @@ describe('Directory', function () {
     it('returns a file when requesting a file from multi directory function response', function (done) {
 
         var server = new Hapi.Server({ files: { relativeTo: __dirname } });
-        server.route({ method: 'GET', path: '/multiple/{path*}', handler: { directory: { path: function () { return ['./', '../'] }, listing: true } } });
+        server.route({ method: 'GET', path: '/multiple/{path*}', handler: { directory: { path: function () { return ['./', '../']; }, listing: true } } });
 
         server.inject('/multiple/package.json', function (res) {
 

--- a/test/pack.js
+++ b/test/pack.js
@@ -787,15 +787,15 @@ describe('Pack', function () {
 
                 pack._servers[0].inject('/', function (res) {
 
-                    expect(res.result).to.equal('|2|1|')
+                    expect(res.result).to.equal('|2|1|');
 
                     pack._servers[1].inject('/', function (res) {
 
-                        expect(res.result).to.equal('|3|1|')
+                        expect(res.result).to.equal('|3|1|');
 
                         pack._servers[2].inject('/', function (res) {
 
-                            expect(res.result).to.equal('|3|2|')
+                            expect(res.result).to.equal('|3|2|');
                             done();
                         });
                     });
@@ -987,7 +987,7 @@ describe('Pack', function () {
     it('adds auth strategy via plugin', function (done) {
 
         var server = new Hapi.Server();
-        server.route({ method: 'GET', path: '/', handler: function (request, reply) { reply('authenticated!') } });
+        server.route({ method: 'GET', path: '/', handler: function (request, reply) { reply('authenticated!'); } });
 
         server.pack.register(require('./pack/--auth'), function (err) {
 

--- a/test/request.js
+++ b/test/request.js
@@ -576,7 +576,7 @@ describe('Request', function () {
             });
         });
     });
-    
+
     it('does not fail on abort', function (done) {
 
         var clientRequest;
@@ -663,10 +663,10 @@ describe('Request', function () {
                 stream.close = function () {
 
                     done();
-                }
+                };
 
                 reply(stream);
-            }, 10)
+            }, 10);
         };
 
         var server = new Hapi.Server({ timeout: { server: 5 } });
@@ -689,7 +689,7 @@ describe('Request', function () {
             setTimeout(function () {
 
                 reply(new Error('after'));
-            }, 10)
+            }, 10);
         };
 
         var server = new Hapi.Server({ timeout: { server: 5 } });
@@ -830,7 +830,7 @@ describe('Request', function () {
                 expect(res.statusCode).to.equal(200);
                 done();
             });
-        })
+        });
 
         it('does not strip trailing slash on /', function (done) {
 
@@ -841,7 +841,7 @@ describe('Request', function () {
                 expect(res.statusCode).to.equal(200);
                 done();
             });
-        })
+        });
     });
 
     describe('#log', { parallel: false }, function () {

--- a/test/router.js
+++ b/test/router.js
@@ -310,7 +310,7 @@ describe('Router', function () {
             expect(res.statusCode).to.equal(404);
             done();
         });
-    })
+    });
 
     it('fails to return OPTIONS when cors disabled', function (done) {
 

--- a/test/server.js
+++ b/test/server.js
@@ -1563,7 +1563,7 @@ describe('Server', function () {
                 var server = new Hapi.Server({ timeout: { server: 50, socket: false } });
             }).to.not.throw();
             done();
-        })
+        });
     });
 
     describe('#location', function () {

--- a/test/state.js
+++ b/test/state.js
@@ -28,7 +28,7 @@ describe('State', function () {
     it('skips parsing cookies', function (done) {
 
         var server = new Hapi.Server({ state: { cookies: { parse: false } } });
-        server.route({ method: 'GET', path: '/', handler: function (request, reply) { reply(request.state) } });
+        server.route({ method: 'GET', path: '/', handler: function (request, reply) { reply(request.state); } });
         server.inject({ method: 'GET', url: '/', headers: { cookie: 'v=a' } }, function (res) {
 
             expect(res.statusCode).to.equal(200);
@@ -84,7 +84,7 @@ describe('State', function () {
 
         var present = function (request, next) {
 
-            next(null, request.params.x)
+            next(null, request.params.x);
         };
 
         var server = new Hapi.Server();
@@ -103,7 +103,7 @@ describe('State', function () {
 
         var present = function (request, next) {
 
-            next(new Error())
+            next(new Error());
         };
 
         var server = new Hapi.Server();

--- a/test/validation.js
+++ b/test/validation.js
@@ -199,7 +199,7 @@ describe('Validation', function () {
         server.inject('/10', function (res) {
 
             expect(res.statusCode).to.equal(200);
-            expect(res.result).to.equal(11)
+            expect(res.result).to.equal(11);
             done();
         });
     });
@@ -223,7 +223,7 @@ describe('Validation', function () {
         server.inject('/10', function (res) {
 
             expect(res.statusCode).to.equal(200);
-            expect(res.result).to.equal('101')
+            expect(res.result).to.equal('101');
             done();
         });
     });
@@ -489,7 +489,7 @@ describe('Validation', function () {
         server.inject({ method: 'POST', url: '/', payload: 'null', headers: { 'content-type': 'application/json' } }, function (res) {
 
             expect(res.statusCode).to.equal(400);
-            expect(res.result.validation.source).to.equal('payload')
+            expect(res.result.validation.source).to.equal('payload');
             done();
         });
     });


### PR DESCRIPTION
...les explicitly as "undefined"

This commit doesn't break anything. I added a bunch of semicolons in order to be more consistent regarding the style guide. Basically, JSHint passes now (except for one function being initialized inside a for-loop).
