### PR TITLE
prepend jsonp callbacks with a comment to prevent the rosetta-flash vulnerability

### DIFF
--- a/lib/response/payload.js
+++ b/lib/response/payload.js
@@ -53,7 +53,7 @@ internals.Payload.prototype.size = function () {
 internals.Payload.prototype.jsonp = function (variable) {
 
     this._sizeOffset += variable.length + 3;
-    this._prefix = variable + '(';
+    this._prefix = '/**/' + variable + '(';
     this._data = Buffer.isBuffer(this._data) ? this._data : this._data.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
     this._suffix = ');';
 };

--- a/test/response.js
+++ b/test/response.js
@@ -1011,7 +1011,7 @@ describe('Response', function () {
 
             server.inject('/?callback=me', function (res) {
 
-                expect(res.payload).to.equal('me({"some":"value"});');
+                expect(res.payload).to.equal('/**/me({"some":"value"});');
                 expect(res.headers['content-length']).to.equal(21);
                 done();
             });
@@ -1060,7 +1060,7 @@ describe('Response', function () {
                 Zlib.unzip(new Buffer(res.payload, 'binary'), function (err, result) {
 
                     expect(err).to.not.exist;
-                    expect(result.toString()).to.equal('docall({"first":"1","last":"2"});');
+                    expect(result.toString()).to.equal('/**/docall({"first":"1","last":"2"});');
                     done();
                 });
             });
@@ -1078,7 +1078,7 @@ describe('Response', function () {
 
             server.inject('/?callback=me', function (res) {
 
-                expect(res.payload).to.equal('me(value);');
+                expect(res.payload).to.equal('/**/me(value);');
                 expect(res.headers['content-length']).to.equal(10);
                 done();
             });


### PR DESCRIPTION
[background](http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/)

tl:dr - someone created a alphanum only swf converter, which means that they can in theory use it as a callback at a JSONP endpoint, and as a result, send data across domains.

Prepending callbacks with an empty inline comment breaks the flash parser, and prevents the issue. This is how google, facebook, github, et al are handeling it.

[CVE-2014-4671A](http://helpx.adobe.com/security/products/flash-player/apsb14-17.html)
