### PR TITLE
Style: callback to have explicit returns

### DIFF
--- a/docs/Style.md
+++ b/docs/Style.md
@@ -683,3 +683,4 @@
 
   - First argument must always be `err`
   - If a function takes a `callback` argument, it **must** be called on `process.nextTick()`. Otherwise, the argument name **must** be `next` to clearly declare that it may get called on same tick
+  - Callbacks should always be called with explicit `return`;


### PR DESCRIPTION
Currently the behavior with callbacks is inconsistent with explicit return for callbacks winning slightly:

```
ag next | grep -v function | grep -v return | wc # => 159
ag next | grep -v function | grep return | wc # => 191
```

Argument for explicit return on callback is that you do not want any code executed after a `callback()` which sets it apart from any other function calls. Making this explicit clarifies the flow.

This would work the same for cases with `return reply()`
