### PR TITLE
set X-Content-Type-Options to nosnif for jsonp responses

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -122,6 +122,7 @@ internals.headers = function (request, next) {
         response._payload.jsonp) {
 
         response.type('text/javascript');
+        response.header('X-Content-Type-Options', 'nosniff');
         response._payload.jsonp(request.jsonp);
     }
 

--- a/test/response.js
+++ b/test/response.js
@@ -1053,6 +1053,24 @@ describe('Response', function () {
             });
         });
 
+        it('returns a X-Content-Type-Options: nosniff header on JSONP responses', function (done) {
+
+            var handler = function (request, reply) {
+
+                reply({ some: 'value' });
+            };
+
+            var server = new Hapi.Server();
+            server.route({ method: 'GET', path: '/', config: { jsonp: 'callback', handler: handler } });
+
+            server.inject('/?callback=me', function (res) {
+
+                expect(res.payload).to.equal('/**/me({"some":"value"});');
+                expect(res.headers['x-content-type-options']).to.equal('nosniff');
+                done();
+            });
+        });
+
         it('returns a normal response when JSONP enabled but not requested', function (done) {
 
             var handler = function (request, reply) {


### PR DESCRIPTION
result of the conversations from [#1766](https://github.com/spumko/hapi/pull/1766/files#r15191632)

specifically

> This would have prevented the ... vulnerability too ... and it might prevent similar attacks that bypass the /**/-based protection in the future
