### PR TITLE
Fix typo in defaults.js

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -25,7 +25,7 @@ exports.server = {
     // Router
 
     router: {
-        isCaseSensitive: true,                      // Case-seinsitive paths
+        isCaseSensitive: true,                      // Case-sensitive paths
         stripTrailingSlash: false                   // Remove trailing slash from incoming paths
     },
 


### PR DESCRIPTION
In comments on line 28 in defaults.js, sensitive was misspelled as seinsitive.
