### PR TITLE
Update mime-types@2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "qs": "2.x.x",
 
     "lru-cache": "2.5.x",
-    "mime-types": "1.0.x",
+    "mime-types": "2.0.x",
     "multiparty": "3.2.x",
     "negotiator": "0.4.x",
     "optimist": "0.6.x",


### PR DESCRIPTION
Nothing dramatic. Mapping has been moved to separate project [mime-db](https://github.com/jshttp/mime-db).

Closes #1890
