### PR TITLE
Fix tests that are failing with Node's v0.12 branch.

### DIFF
--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,5 +1,6 @@
 // Load modules
 
+var Net = require('net');
 var Lab = require('lab');
 var Fs = require('fs');
 var Http = require('http');
@@ -654,7 +655,13 @@ describe('Proxy', function () {
 
                     expect(res.statusCode).to.equal(200);
                     var result = JSON.parse(body);
-                    expect(result['x-forwarded-for']).to.equal('127.0.0.1');
+
+                    var expectedClientAddress = '127.0.0.1';
+                    if (Net.isIPv6(server.listener.address().address)) {
+                        expectedClientAddress = '::ffff:127.0.0.1';
+                    }
+
+                    expect(result['x-forwarded-for']).to.equal(expectedClientAddress);
                     expect(result['x-forwarded-port']).to.match(/\d+/);
                     expect(result['x-forwarded-proto']).to.equal('http');
 
@@ -697,7 +704,13 @@ describe('Proxy', function () {
 
                     expect(res.statusCode).to.equal(200);
                     var result = JSON.parse(body);
-                    expect(result['x-forwarded-for']).to.equal('testhost,127.0.0.1');
+
+                    var expectedClientAddress = '127.0.0.1';
+                    if (Net.isIPv6(server.listener.address().address)) {
+                        expectedClientAddress = '::ffff:127.0.0.1';
+                    }
+
+                    expect(result['x-forwarded-for']).to.equal('testhost,' + expectedClientAddress);
                     expect(result['x-forwarded-port']).to.match(/1337\,\d+/);
                     expect(result['x-forwarded-proto']).to.equal('https,http');
 

--- a/test/request.js
+++ b/test/request.js
@@ -341,14 +341,20 @@ describe('Request', function () {
 
     it('request has client address', function (done) {
 
+        var server = new Hapi.Server(0);
+
         var handler = function (request, reply) {
 
-            expect(request.info.remoteAddress).to.equal('127.0.0.1');
+            var expectedClientAddress = '127.0.0.1';
+            if (Net.isIPv6(server.listener.address().address)) {
+                expectedClientAddress = '::ffff:127.0.0.1';
+            }
+
+            expect(request.info.remoteAddress).to.equal(expectedClientAddress);
             expect(request.info.remoteAddress).to.equal(request.info.remoteAddress);
             reply('ok');
         };
 
-        var server = new Hapi.Server(0);
         server.route({ method: 'GET', path: '/', handler: handler });
 
         server.start(function () {

--- a/test/server.js
+++ b/test/server.js
@@ -513,12 +513,17 @@ describe('Server', function () {
         done();
     });
 
-    it('defaults to 0.0.0.0 when no host is provided', function (done) {
+    it('defaults to 0.0.0.0 or :: when no host is provided', function (done) {
 
         var server = new Hapi.Server(0);
         server.start(function () {
 
-            expect(server.info.host).to.equal('0.0.0.0');
+            var expectedBoundAddress = '0.0.0.0';
+            if (Net.isIPv6(server.listener.address().address)) {
+                expectedBoundAddress = '::';
+            }
+
+            expect(server.info.host).to.equal(expectedBoundAddress);
             done();
         });
     });
@@ -728,7 +733,12 @@ describe('Server', function () {
             var server = new Hapi.Server(0);
             server.start(function () {
 
-                expect(server.info.host).to.equal('0.0.0.0');
+                var expectedBoundAddress = '0.0.0.0';
+                if (Net.isIPv6(server.listener.address().address)) {
+                    expectedBoundAddress = '::';
+                }
+
+                expect(server.info.host).to.equal(expectedBoundAddress);
                 expect(server.info.port).to.not.equal(0);
                 server.stop();
                 done();


### PR DESCRIPTION
Node's v0.12 branch will bind server sockets to '::' by
default if IPv6 is available on the host and if no host
is provided.

Thus, some tests that check for either servers' or clients' IP
addresses and that assume IPv4 only addresses would fail.

This change is backward compatible with Node 0.10.x.
