### PR TITLE
Handle empty or falsy charset in response

### DIFF
--- a/lib/response/headers.js
+++ b/lib/response/headers.js
@@ -164,7 +164,7 @@ internals.security = function (response, request) {
 internals.content = function (response) {
 
     var type = response.headers['content-type'];
-    if (type &&
+    if (type && response.settings.charset &&
         type.match(/^(?:text\/)|(?:application\/(?:json)|(?:javascript))/)) {
 
         var hasParams = (type.indexOf(';') !== -1);

--- a/test/response.js
+++ b/test/response.js
@@ -789,6 +789,24 @@ describe('Response', function () {
             });
         });
 
+        it('does not modify content-type header when charset is unset', function (done) {
+
+            var handler = function (request, reply) {
+
+                reply('text').type('text/plain').charset();
+            };
+
+            var server = new Hapi.Server();
+            server.route({ method: 'GET', path: '/', handler: handler });
+
+            server.inject('/', function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['content-type']).to.equal('text/plain');
+                done();
+            });
+        });
+
         it('sets Vary header with single value', function (done) {
 
             var handler = function (request, reply) {


### PR DESCRIPTION
This way it's possible to explicitly remove the charset from the response which can be valid for some use-cases.
