### PR TITLE
handle empty CORS expose-headers header response

### DIFF
--- a/lib/response/headers.js
+++ b/lib/response/headers.js
@@ -104,7 +104,10 @@ internals.cors = function (response, request) {
         response._header('access-control-max-age', cors.maxAge, { override: false });
         response._header('access-control-allow-methods', cors._methods, { override: false });
         response._header('access-control-allow-headers', cors._headers, { override: false });
-        response._header('access-control-expose-headers', cors._exposedHeaders, { override: false });
+
+        if (cors._exposedHeaders.length !== 0) {
+            response._header('access-control-expose-headers', cors._exposedHeaders, { override: false });
+        }
 
         if (cors.credentials) {
             response._header('access-control-allow-credentials', 'true', { override: false });

--- a/test/response.js
+++ b/test/response.js
@@ -380,6 +380,25 @@ describe('Response', function () {
             });
         });
 
+        it('does not set empty CORS expose headers', function (done) {
+
+            var handler = function (request, reply) {
+
+                reply('ok');
+            };
+
+            var server = new Hapi.Server({ cors: { exposedHeaders: [] } });
+            server.route({ method: 'GET', path: '/', handler: handler });
+
+            server.inject({ url: '/' }, function (res) {
+                expect(res.result).to.exist;
+                expect(res.result).to.equal('ok');
+                expect(res.headers['access-control-allow-methods']).to.exist;
+                expect(res.headers['access-control-expose-headers']).to.not.exist;
+                done();
+            });
+        });
+
         it('does not set security headers by default', function (done) {
 
             var handler = function (request, reply) {


### PR DESCRIPTION
The `access-control-expose-headers` should only be included in the response for non-empty lists according to http://www.w3.org/TR/cors/#resource-requests.

This patch fixes the response on servers configured with `{ cors: { exposedHeaders: [] } }`.
