### PR TITLE
Fix non-spec compliant Last-Modified header in response

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -74,7 +74,7 @@ internals.Response.prototype._prepare = function (request, callback) {
 
         self.bytes(stat.size);
         self.type(Mime.path(path).type || 'application/octet-stream');
-        self._header('last-modified', stat.mtime.toString());
+        self._header('last-modified', stat.mtime.toUTCString());
 
         if (request.server._etags) {
 

--- a/test/response.js
+++ b/test/response.js
@@ -1692,7 +1692,7 @@ describe('Response', function () {
             server.inject('/file', function (res1) {
 
                 var last = new Date(Date.parse(res1.headers['last-modified']) + 1000);
-                server.inject({ url: '/file', headers: { 'if-modified-since': last.toString() } }, function (res2) {
+                server.inject({ url: '/file', headers: { 'if-modified-since': last.toUTCString() } }, function (res2) {
 
                     expect(res2.statusCode).to.equal(304);
                     expect(res2.headers).to.not.have.property('content-length');
@@ -1761,6 +1761,19 @@ describe('Response', function () {
                         done();
                     });
                 });
+            });
+        });
+
+        it('returns valid http date responses in last-modified header', function (done) {
+
+            var server = new Hapi.Server();
+            server.route({ method: 'GET', path: '/file', handler: { file: __dirname + '/../package.json' } });
+
+            server.inject('/file', function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['last-modified']).to.equal(Fs.statSync(__dirname + '/../package.json').mtime.toUTCString());
+                done();
             });
         });
 


### PR DESCRIPTION
I found that the date in the `Last-Modified` header of `.file()` responses are invalid according to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29 & http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1.

This patch should fix this issue, generating valid dates, along with an extra test in case of future regressions.
