### PR TITLE
Fix Content-Type overriding

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -73,7 +73,11 @@ internals.Response.prototype._prepare = function (request, callback) {
         }
 
         self.bytes(stat.size);
-        self.type(Mime.path(path).type || 'application/octet-stream');
+
+        if (!self.headers['content-type']) {
+            self.type(Mime.path(path).type || 'application/octet-stream');
+        }
+
         self._header('last-modified', stat.mtime.toUTCString());
 
         if (request.server._etags) {

--- a/test/response.js
+++ b/test/response.js
@@ -1584,6 +1584,23 @@ describe('Response', function () {
             });
         });
 
+        it('returns a file in the response with the correct headers using custom mime type', function (done) {
+
+            var server = new Hapi.Server({ files: { relativeTo: __dirname } });
+            var handler = function (request, reply) {
+
+                reply.file('../bin/hapi').type('application/example');
+            };
+
+            server.route({ method: 'GET', path: '/file', handler: handler });
+
+            server.inject('/file', function (res) {
+
+                expect(res.headers['content-type']).to.equal('application/example');
+                done();
+            });
+        });
+
         it('does not cache etags', function (done) {
 
             var server = new Hapi.Server({ files: { relativeTo: __dirname, etagsCacheMaxSize: 0 } });


### PR DESCRIPTION
Similarly to #1760 it's not possible to use custom `Content-Type` header for files. The following doesn't work:

```
reply.file('./example').type('application/json');
```

The returned `Content-Type` header is `application/octet-stream`. This pull request fixes the issue and returns `application/json`.
