### PR TITLE
show route method in error message

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -31,9 +31,9 @@ exports = module.exports = internals.Route = function (options, server, env) {
 
     // Setup and validate route configuration
 
-    Hoek.assert(options.handler || (options.config && options.config.handler), 'Missing or undefined handler:', options.path);
-    Hoek.assert(!!options.handler ^ !!(options.config && options.config.handler), 'Handler must only appear once:', options.path);            // XOR
-    Hoek.assert(options.path === '/' || options.path[options.path.length - 1] !== '/' || !server.settings.router.stripTrailingSlash, 'Path cannot end with a trailing slash when server configured to strip:', options.path);
+    Hoek.assert(options.handler || (options.config && options.config.handler), 'Missing or undefined handler:', options.method, options.path);
+    Hoek.assert(!!options.handler ^ !!(options.config && options.config.handler), 'Handler must only appear once:', options.method, options.path);            // XOR
+    Hoek.assert(options.path === '/' || options.path[options.path.length - 1] !== '/' || !server.settings.router.stripTrailingSlash, 'Path cannot end with a trailing slash when server configured to strip:', options.method, options.path);
 
     Schema.assert('route', options, options.path);
 
@@ -115,7 +115,7 @@ exports = module.exports = internals.Route = function (options, server, env) {
         Hoek.assert(!this.settings.validate.payload, 'Cannot validate HEAD or GET requests:', options.path);
     }
 
-    Hoek.assert(!this.settings.validate.payload || this.settings.payload.parse, 'Route payload must be set to \'parse\' when payload validation enabled:', options.path);
+    Hoek.assert(!this.settings.validate.payload || this.settings.payload.parse, 'Route payload must be set to \'parse\' when payload validation enabled:', options.method, options.path);
     Hoek.assert(!this.settings.jsonp || typeof this.settings.jsonp === 'string', 'Bad route JSONP parameter name:', options.path);
 
     // Authentication configuration
@@ -124,7 +124,7 @@ exports = module.exports = internals.Route = function (options, server, env) {
 
     // Cache
 
-    Hoek.assert(!this.settings.cache || this.method === 'get', 'Only GET routes can use a cache:', options.path);
+    Hoek.assert(!this.settings.cache || this.method === 'get', 'Only GET routes can use a cache:', options.method, options.path);
     this._cache = this.settings.cache ? new Catbox.Policy({ expiresIn: this.settings.cache.expiresIn, expiresAt: this.settings.cache.expiresAt }) : null;
 
     // Handler

--- a/test/route.js
+++ b/test/route.js
@@ -23,9 +23,8 @@ describe('Route', function () {
 
         var server = new Hapi.Server();
         expect(function () {
-
             server.route({ method: 'GET', path: '/', config: {} });
-        }).to.throw('Missing or undefined handler: /');
+        }).to.throw('Missing or undefined handler: GET /');
         done();
     });
 
@@ -35,7 +34,7 @@ describe('Route', function () {
         expect(function () {
 
             server.route({ method: 'GET', path: '/test/', handler: function () { } });
-        }).to.throw('Path cannot end with a trailing slash when server configured to strip: /test/');
+        }).to.throw('Path cannot end with a trailing slash when server configured to strip: GET /test/');
         done();
     });
 
@@ -66,7 +65,7 @@ describe('Route', function () {
         expect(function () {
 
             server.route({ method: 'POST', path: '/', handler: function () { }, config: { validate: { payload: {} }, payload: { parse: false } } });
-        }).to.throw('Route payload must be set to \'parse\' when payload validation enabled: /');
+        }).to.throw('Route payload must be set to \'parse\' when payload validation enabled: POST /');
         done();
     });
 


### PR DESCRIPTION
Showing only path is not enough to identify the exact route configuration when there are multiple methods for the same path.
