### PR TITLE
Adds clarification of upstream to client behavior in proxy passThrough

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -426,7 +426,7 @@ The following options are available when adding a route:
             - `'http'`
             - `'https'`
         - `uri` - an absolute URI used instead of the incoming host, port, protocol, path, and query. Cannot be used with `host`, `port`, `protocol`, or `mapUri`.
-        - `passThrough` - if `true`, forwards the headers sent from the client to the upstream service being proxied to. Defaults to `false`.
+        - `passThrough` - if `true`, forwards the headers sent from the client to the upstream service being proxied to, headers sent from the upstream service will also be forwarded to the client. Defaults to `false`.
         - `localStatePassThrough` - if `false`, any locally defined state is removed from incoming requests before being passed upstream. This is
           a security feature to prevent local state (e.g. authentication cookies) from leaking upstream to other servers along with the cookies intended
           for those servers. This value can be overridden on a per state basis via the [`server.state()`](#serverstatename-options) `passThrough` option.


### PR DESCRIPTION
Understanding that passThrough is needed to send upstream set headers to the client is not specifically called out, adding some more context to this option.
