### PR TITLE
Resolve undefined environment variables to the empty string in the cli.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -122,7 +122,7 @@ internals.parseEnv = function (manifest) {
         if (typeof value === 'string' &&
             value.indexOf('$env.') === 0) {
 
-            manifest[key] = process.env[value.slice(5)];
+            manifest[key] = process.env[value.slice(5)] || '';
         }
         else {
             internals.parseEnv(value);

--- a/test/cli.js
+++ b/test/cli.js
@@ -385,7 +385,7 @@ describe('Hapi command line', function () {
             },
             servers: [
                 {
-                    port: '$env.port',
+                    port: '$env.undefined',
                     options: {
                         labels: ['api', 'nasty', 'test']
                     }
@@ -424,6 +424,8 @@ describe('Hapi command line', function () {
         changes.push(setEnv('plugin_option', 'plugin-option'));
         changes.push(setEnv('port', 0));
         changes.push(setEnv('special_value', 'special-value'));
+        // Ensure that the 'undefined' environment variable is *not* set.
+        changes.push(setEnv('undefined'));
 
         var configPath = internals.uniqueFilename(Os.tmpDir());
         var hapiPath = Path.join(__dirname, '..', 'bin', 'hapi');

--- a/test/pack/--options/lib/index.js
+++ b/test/pack/--options/lib/index.js
@@ -7,7 +7,12 @@ var internals = {};
 
 exports.register = function (plugin, options, next) {
 
-    console.log('app.my: %s, options.key: %s', plugin.app.my, options.key);
+    // Need to wait until the server starts to make sure that the port can
+    // be bound to successfully.
+    plugin.events.on('start', function () {
+
+        console.log('app.my: %s, options.key: %s', plugin.app.my, options.key);
+    });
 
     return next();
 };


### PR DESCRIPTION
When using a manifest that references undefined environment variables for port values, the pack fails to start because `undefined` is not a valid port parameter for a `Server`. This change causes the cli to treat undefined environment variables as the empty string. In the case where a port value is parsed, this will cause the server to use an ephemeral port.
