### PR TITLE
Guard against exceptions in request validation

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -51,6 +51,10 @@ internals.input = function (source, request, next) {
             return next();
         }
 
+        if (err.isBoom) {
+            return next(err);
+        }
+
         // failAction: 'error', 'log', 'ignore', function (source, err, next)
 
         if (request.route.validate.failAction === 'ignore') {
@@ -108,7 +112,9 @@ internals.input = function (source, request, next) {
 
     var schema = request.route.validate[source];
     if (typeof schema === 'function') {
-        return schema(request[source], localOptions, postValidate);
+        return request._protect.run('validate:input:' + source, postValidate, function (exit) {
+            schema(request[source], localOptions, Hoek.once(exit));
+        });
     }
 
     return Joi.validate(request[source], schema, localOptions, postValidate);
@@ -140,6 +146,10 @@ exports.response = function (request, next) {
             return next();
         }
 
+        if (err.isBoom) {
+            return next(err);
+        }
+
         // failAction: 'error', 'log'
 
         if (request.route.response.failAction === 'log') {
@@ -153,7 +163,9 @@ exports.response = function (request, next) {
     var options = request.server.settings.validation || {};
     var schema = request.route.response.schema;
     if (typeof schema === 'function') {
-        return schema(request.response.source, options, postValidate);
+        return request._protect.run('validate:response', postValidate, function (exit) {
+            schema(request.response.source, options, Hoek.once(exit));
+        });
     }
 
     return Joi.validate(request.response.source, schema, options, postValidate);


### PR DESCRIPTION
**Observed in:**

hapi `6.11.1` and `7.0.0`

**Expected behavior:**

When an input or response validation plugin throws an error, it should result in a `500` error being returned.

**Observed behavior:**

Such an error now instead breaks the request life cycle, resulting in no response at all being sent and the request not being closed.

**Solution:**

Looking at how other steps in the request life cycle protects against thrown errors using `request._protect.run()` I adapted the plugin calls in the validators to utilize the same protection. That resulted in the expected behavior for me when an input or a response validator plugin threw an exception.

All tests pass with this addition, but there's some noise in the test output that comes from the logger in `Protect`. I also haven't added any new test cases that ensures that exceptions thrown in validator plugins are caught in this new way. If you think this approach looks good then I'll happily try to incorporate the changes into the test cases.
