### PR TITLE
Include ETag and Last-Modified in 304 response

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -95,11 +95,6 @@ internals.marshall = function (request, next) {
         response._payload = new internals.Empty();
         delete response.headers['content-length'];
 
-        if (response.statusCode === 304) {                  // Causes errors on some browsers
-            delete response.headers.etag;
-            delete response.headers['last-modified'];
-        }
-
         return internals.headers(request, next);
     }
 

--- a/lib/response/message.js
+++ b/lib/response/message.js
@@ -158,8 +158,8 @@ internals.Message.prototype.etag = function (tag, options) {
 
 internals.Message.prototype._varyEtag = function () {
 
-    if (this.settings.varyEtag &&
-        this.headers.etag &&
+    if (this.headers.etag &&
+        this.settings.varyEtag &&
         this.headers.vary) {
 
         var hash = Crypto.createHash('sha1');

--- a/test/response.js
+++ b/test/response.js
@@ -1715,8 +1715,8 @@ describe('Response', function () {
 
                         expect(res3.statusCode).to.equal(304);
                         expect(res3.headers['content-length']).to.not.exist();
-                        expect(res3.headers.etag).to.not.exist();
-                        expect(res3.headers['last-modified']).to.not.exist();
+                        expect(res3.headers.etag).to.exist();
+                        expect(res3.headers['last-modified']).to.exist();
 
                         var fd = Fs.openSync(__dirname + '/file/note.txt', 'w');
                         Fs.writeSync(fd, new Buffer('Test'), 0, 4);
@@ -1810,8 +1810,8 @@ describe('Response', function () {
 
                     expect(res2.statusCode).to.equal(304);
                     expect(res2.headers['content-length']).to.not.exist();
-                    expect(res2.headers.etag).to.not.exist();
-                    expect(res2.headers['last-modified']).to.not.exist();
+                    expect(res2.headers.etag).to.exist();
+                    expect(res2.headers['last-modified']).to.exist();
                     done();
                 });
             });
@@ -1828,8 +1828,8 @@ describe('Response', function () {
 
                     expect(res2.statusCode).to.equal(304);
                     expect(res2.headers['content-length']).to.not.exist();
-                    expect(res2.headers.etag).to.not.exist();
-                    expect(res2.headers['last-modified']).to.not.exist();
+                    expect(res2.headers.etag).to.exist();
+                    expect(res2.headers['last-modified']).to.exist();
                     done();
                 });
             });


### PR DESCRIPTION
`ETag` is mandated by https://tools.ietf.org/html/rfc7232#section-4.1:

> The server generating a 304 response MUST generate any of the
> following header fields that would have been sent in a 200 (OK)
> response to the same request: Cache-Control, Content-Location, Date,
> ETag, Expires, and Vary.

`Last-Modified` is suggested to be included as well.
