### PR TITLE
Don't compress responses with content-length 0

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -227,7 +227,7 @@ internals.transmit = function (response, callback) {
     // Content-Encoding
 
     var compressor = null;
-    if (encoding) {
+    if (encoding && parseInt(response.headers['content-length'], 10) !== 0) {
         delete response.headers['content-length'];
         response._header('content-encoding', encoding);
         response.vary('accept-encoding');


### PR DESCRIPTION
It's seems silly to activate chunked mode & apply gzip when it can't decrease the size of the transfer.
