### PR TITLE
Add 'close' message processor option

### DIFF
--- a/lib/response/message.js
+++ b/lib/response/message.js
@@ -40,7 +40,8 @@ exports = module.exports = internals.Message = function (source, request, option
 
     this._processors = {
         marshall: options.marshall,
-        prepare: options.prepare
+        prepare: options.prepare,
+        close: options.close
     };
 
     // Default content-type and type-specific method
@@ -409,6 +410,10 @@ internals.Message.prototype._tap = function () {
 
 
 internals.Message.prototype._close = function () {
+
+    if (this._processors.close) {
+        this._processors.close(this);
+    }
 
     var stream = this._payload || this.source;
     if (stream instanceof Stream) {

--- a/test/response.js
+++ b/test/response.js
@@ -87,6 +87,44 @@ describe('Response', function () {
         });
     });
 
+    it('calls every message processor', function (done) {
+
+        var didCall = {};
+
+        var marshall = function (response, callback) {
+
+            didCall.marshall = true;
+            callback(null, '');
+        };
+
+        var prepare = function (response, callback) {
+
+            didCall.prepare = true;
+            callback(response);
+        };
+
+        var close = function (response) {
+
+            didCall.close = true;
+        };
+
+        var handler = function (request, reply) {
+
+            reply(new Response.Message(null, request, { marshall: marshall, prepare: prepare, close: close }));
+        };
+
+        var server = new Hapi.Server({ debug: false });
+        server.route({ method: 'GET', path: '/', config: { handler: handler } });
+
+        server.inject('/', function (res) {
+
+            expect(didCall.prepare).to.exist();
+            expect(didCall.marshall).to.exist();
+            expect(didCall.close).to.exist();
+            done();
+        });
+    });
+
     describe('Text', function () {
 
         it('returns a reply', function (done) {


### PR DESCRIPTION
The close hook is needed to implement https://github.com/hapijs/inert/pull/8 without knowledge of Hapi internals.
