### PR TITLE
Added status code and payload to response server log

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -286,7 +286,11 @@ internals.transmit = function (response, callback) {
                 request.emit('disconnect');
             }
 
-            request._log(tags, err);
+            request._log(tags, {
+                err: err,
+                data: source._data,
+                statusCode: response.statusCode
+            });
             callback();
         }
     };


### PR DESCRIPTION
This is to expose additional information via `request._log`.  This first exposes an object instead of the `err` value, and has two additional properties added to it: `statusCode` and `data`, which represents the raw payload.

In what use case is `err` getting populated?  I can't track down how and with what this value is filled.  I'm wondering if `source._data` could replace the need for `err`.

cc @hueniverse
