### PR TITLE
api docs update: linked Route Configuration object definition to server.route()

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1326,7 +1326,7 @@ server.render('hello', context, function (err, rendered, config) {
 ### `server.route(options)`
 
 Adds a connection route where:
-- `options` - a route configuration object or an array of configuration objects.
+- `options` - a [route configuration object](#route-configuration) or an array of configuration objects.
 
 ```js
 var Hapi = require('hapi');


### PR DESCRIPTION
The docs on `server.route()` do not explain how a Route Configuration object is defined. I added a link so the users can click through and read more about it.
