### PR TITLE
[doc] Server object option property mismatch/typo

### DIFF
--- a/API.md
+++ b/API.md
@@ -211,7 +211,7 @@ var Hapi = require('hapi');
 var server = new Hapi.Server({
     cache: require('catbox-redis'),
     load: {
-        sampleInterface: 1000
+        sampleInterval: 1000
     }
 });
 ```
@@ -302,7 +302,7 @@ An object containing the process load metrics (when `load.sampleInterval` is ena
 
 ```js
 var Hapi = require('hapi');
-var server = new Hapi.Server({ load: { sampleInterface: 1000 } });
+var server = new Hapi.Server({ load: { sampleInterval: 1000 } });
 
 console.log(server.load.rss);
 ```


### PR DESCRIPTION
In the current docs for `v8.0.x`, it appears that there may be a mismatch in the `Server` object property `load`.
I've simply changed `load.sampleInterface` to `load.sampleInterval`
When following documentation one will get an error similar to:

```
/Users/blakmatrix/projects/hapidays/code/node_modules/joi/lib/index.js:121
            throw new Error(message + error.annotate());
                  ^
Error: Invalid load monitoring options {
  "sampleInterval": 0,
  "sampleInterface" [1]: 1
}

[1] sampleInterface is not allowed
    at root.assert (/Users/blakmatrix/projects/hapidays/code/node_modules/joi/lib/index.js:121:19)
    at new module.exports.internals.Heavy (/Users/blakmatrix/projects/hapidays/code/node_modules/hapi/node_modules/heavy/lib/index.js:41:9)
    at new module.exports.internals.Server (/Users/blakmatrix/projects/hapidays/code/node_modules/hapi/lib/server.js:46:19)
    at Object.<anonymous> (/Users/blakmatrix/projects/hapidays/code/app.js:7:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
```

I was unable to find any usage of `load.sampleInterface` in the code, I noticed there were a lot of interface changes in `v8.0.0` so I'm thinking perhaps interface was on the brain or perhaps some functionality didn't get shipped--either way, this will prevent others from encountering this error.
