### PR TITLE
Fix invalid response for empty reply() (v8.x regression)

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -457,7 +457,7 @@ internals.content = function (response) {
     if (!type) {
         var charset = (response.settings.charset ? '; charset=' + response.settings.charset : '');
 
-        if (typeof response.source === 'string') {
+        if (typeof response.source === 'string' || response.source === null) {
             response.type('text/html' + charset);
         }
         else if (Buffer.isBuffer(response.source)) {

--- a/test/reply.js
+++ b/test/reply.js
@@ -101,6 +101,7 @@ describe('Reply', function () {
                 expect(res.statusCode).to.equal(200);
                 expect(res.result).to.equal(null);
                 expect(res.payload).to.equal('');
+                expect(res.headers['content-type']).to.contain('text/html');
                 done();
             });
         });


### PR DESCRIPTION
The `content-type` header for empty responses used to not be set when calling `reply(null)`, `reply('')`, etc in the route handler.

In 8.0 the header is set as `application/json`. This is a problem, as an empty string _is not_ valid JSON, causing eg. `$.ajax()` to cast a `TypeError` when in JSON mode.

This patch changes the `content-type` to plain `text/html` for empty responses, which _is_ valid. 