### PR TITLE
Add automatic reply call if handler return promise

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -91,7 +91,12 @@ internals.handler = function (request, callback) {
 
     // Execute handler
 
-    request.route.settings.handler.call(bind, request, reply);
+    var maybePromise = request.route.settings.handler.call(bind, request, reply);
+    if (maybePromise
+          && typeof maybePromise === 'object'
+          && typeof maybePromise.then === 'function') {
+        reply(maybePromise);
+    }
 };
 
 

--- a/test/handler.js
+++ b/test/handler.js
@@ -6,6 +6,7 @@ var Code = require('code');
 var Handlebars = require('handlebars');
 var Hapi = require('..');
 var Lab = require('lab');
+var Promise = require('bluebird');
 
 
 // Declare internals
@@ -112,6 +113,20 @@ describe('handler', function () {
             server.inject('/', function (res) {
 
                 expect(res.result).to.equal('ok');
+                done();
+            });
+        });
+
+        it ('handles promises as return values', function(done) {
+            var item = { x: 123 };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: 'GET', path: '/', config: { handler: function (request, reply) { return Promise.cast(this.x); }, bind: item } });
+
+            server.inject('/', function (res) {
+
+                expect(res.result).to.equal(item.x);
                 done();
             });
         });


### PR DESCRIPTION
Hi,

Thank you for adding promises support to Hapi. What about taking next step, and check return value from handler?

So instead of this:

``` js
handler: function(request, reply) {
    var promise = this.db.Comment.createAsync(request.payload)
    .then(function(comment) {
        return { comment: comment };
    });

   reply(promise);
}
```

we can write this:

``` js
handler: function(request, reply) {
    return this.db.Comment.createAsync(request.payload)
    .then(function(comment) {
        return { comment: comment };
    });
}
```

or 

``` js
handler: function(request) {
    return this.db.Comment.createAsync(request.payload)
    .then(function(comment) {
        return { comment: comment };
    });
}
```
