### PR TITLE
Updated stripTrailingSlash documentation.

### DIFF
--- a/API.md
+++ b/API.md
@@ -153,7 +153,7 @@ Creates a new `Server` object where:
             - `isCaseSensitive` - determines whether the paths '/example' and '/EXAMPLE' are
               considered different resources. Defaults to `true`.
             - `stripTrailingSlash` - removes trailing slashes on incoming paths. Defaults to
-              `true`.
+              `false`.
 
         - `routes` - sets the default configuration for every route a
           [route public interface](#route-public-interface) object.


### PR DESCRIPTION
Default is actually `false` per [these lines](https://github.com/hapijs/hapi/blob/98acb52c6f86dc7408e2ad8ebd914b0f79737085/lib/defaults.js#L25-L27).
