### PR TITLE
throw an appropriate error when payload validation is used with GET or HEAD routes

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -123,6 +123,7 @@ exports = module.exports = internals.Route = function (options, connection, real
         }
     }
 
+    internals.checkPayloadValidation(this);
     Hoek.assert(!this.settings.validate.payload || this.settings.payload.parse, 'Route payload must be set to \'parse\' when payload validation enabled:', options.method, options.path);
     Hoek.assert(!this.settings.jsonp || typeof this.settings.jsonp === 'string', 'Bad route JSONP parameter name:', options.path);
 
@@ -245,6 +246,8 @@ internals.compileRule = function (rule) {
 
 
 internals.Route.prototype.lifecycle = function () {
+
+    internals.checkPayloadValidation(this);
 
     var cycle = [];
 
@@ -387,4 +390,9 @@ internals.parseJSONP = function (request, next) {
     }
 
     return next();
+};
+
+// check that payload validation is not used with a GET or HEAD method
+internals.checkPayloadValidation = function (self) {
+    Hoek.assert(!self.settings.validate.payload || self.settings.payload, 'Payload validation cannot be used with \'get\' or \'head\' HTTP methods');
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -18,6 +18,9 @@ exports.query = function (request, next) {
 
 exports.payload = function (request, next) {
 
+    if (request.method === 'get' || request.method === 'head') {
+        return next(Boom.badImplementation('Payload validation cannot be used with a \'' + request.method + '\' method'));
+    }
     return internals.input('payload', request, next);
 };
 

--- a/test/route.js
+++ b/test/route.js
@@ -3,7 +3,7 @@
 var Code = require('code');
 var Hapi = require('..');
 var Lab = require('lab');
-
+var Joi = require('joi');
 
 // Declare internals
 
@@ -19,6 +19,28 @@ var expect = Code.expect;
 
 
 describe('Route', function () {
+
+    it('throws when payload validation is used with GET or HEAD methods', function (done) {
+
+        var server = new Hapi.Server({ debug: false });
+        server.connection();
+
+        var validation = {payload: {test: Joi.number()}};
+        var routeGET = { method: 'GET', path: '/', config: { validate: validation, handler: function (req, reply) { return reply('ok'); } } };
+        var routeWILDCARD = { method: '*', path: '/', config: { validate: validation, handler: function () { } } };
+        var errMsg = 'Payload validation cannot be used with \'get\' or \'head\' HTTP methods';
+
+        expect(function () {
+            server.route(routeGET);
+        }).to.throw(errMsg);
+
+        server.route(routeWILDCARD);
+        server.inject('/', function (res) {
+
+            expect(res.result.statusCode).to.equal(500);
+            done();
+        });
+    });
 
     it('throws an error when a route is missing a path', function (done) {
 


### PR DESCRIPTION
When a user mistakenly uses a payload validation on a GET or HEAD route, an appropriate error is given, instead of

```
TypeError: Cannot read property 'parse' of null
   at new module.exports.internals.Route (... node_modules/hapi/lib/route.js:126:73)
```

This might help new users that make this mistake more quickly to uncover what's going on.

Closes #2347 