### PR TITLE
Remove '{}' payload from cors OPTIONS response

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -388,7 +388,7 @@ internals.Connection.prototype._defaultRoutes = function () {
                 cors: this.settings.routes.cors,
                 handler: function (request, reply) {
 
-                    return reply({});
+                    return reply();
                 }
             }
         }, this, this.server.realm));

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -1779,6 +1779,7 @@ describe('transmission', function () {
             server.inject({ method: 'options', url: '/', headers: { origin: 'http://x.example.com' } }, function (res) {
 
                 expect(res.statusCode).to.equal(200);
+                expect(res.payload.length).to.equal(0);
                 expect(res.headers['access-control-allow-origin']).to.equal('http://test.example.com http://www.example.com');
                 done();
             });


### PR DESCRIPTION
While I guess the payload is allowed, it is quite redundant and adds a  `content-type` header.