### PR TITLE
Don't respond to connections until listening is started

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -120,21 +120,22 @@ internals.Connection.prototype._init = function () {
             self.info.port = address.port;
             self.info.uri = (self.settings.uri || (self.info.protocol + '://' + self.info.host + ':' + self.info.port));
         }
+
+        self._onConnection = function _onConnection(connection) {
+
+            var key = connection.remoteAddress + ':' + connection.remotePort;
+            self._connections[key] = connection;
+
+            connection.once('close', function () {
+
+                delete self._connections[key];
+            });
+        };
+
+        self.listener.on('connection', self._onConnection);
     });
 
     this._connections = {};
-    this._onConnection = function (connection) {
-
-        var key = connection.remoteAddress + ':' + connection.remotePort;
-        self._connections[key] = connection;
-
-        connection.once('close', function () {
-
-            delete self._connections[key];
-        });
-    };
-
-    this.listener.on('connection', this._onConnection);
 };
 
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -511,7 +511,10 @@ describe('Connection', function () {
 
             var server = new Hapi.Server();
             server.connection();
+            var initial = server.listener.listeners('connection').length;
             server.start(function () {
+
+                expect(server.listener.listeners('connection').length).to.be.greaterThan(initial);
 
                 server.stop(function () {
 
@@ -519,7 +522,7 @@ describe('Connection', function () {
 
                         server.stop(function () {
 
-                            expect(server.listeners('connection').length).to.equal(0);
+                            expect(server.listener.listeners('connection').length).to.equal(initial);
                             done();
                         });
                     });


### PR DESCRIPTION
This also fixes the _removes connection event listeners after it stops_ test to do what it says.