### PR TITLE
Refuse to handle incoming request after server is stopped

### DIFF
--- a/API.md
+++ b/API.md
@@ -1499,8 +1499,8 @@ server.on('request-internal', function (request, event, tags) {
 
 ### `server.stop([options], [callback])`
 
-Stops the server's connections by refusing to accept any new connections (existing connections will
-continue until closed or timeout), where:
+Stops the server's connections by refusing to accept any new connections or requests (existing
+connections will continue until closed or timeout), where:
 - `options` - optional object with:
     - `timeout` - overrides the timeout in millisecond before forcefully terminating a connection.
       Defaults to `5000` (5 seconds).

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -58,6 +58,7 @@ exports = module.exports = internals.Connection = function (server, options) {
     // Connection facilities
 
     this._started = false;
+    this._stopping = false;
     this._connections = {};
     this._onConnection = null;          // Used to remove event listener on stop
     this._registrations = {};           // Tracks plugin for dependency validation
@@ -172,6 +173,7 @@ internals.Connection.prototype._stop = function (options, callback) {
         return process.nextTick(callback);
     }
 
+    this._stopping = true;
     this._started = false;
     this.info.started = 0;
 
@@ -184,6 +186,8 @@ internals.Connection.prototype._stop = function (options, callback) {
     }, options.timeout);
 
     this.listener.close(function () {
+
+        self._stopping = false;
 
         self.listener.removeListener('connection', self._onConnection);
         clearTimeout(timeoutId);
@@ -201,6 +205,10 @@ internals.Connection.prototype._dispatch = function (options) {
     options = options || {};
 
     return function (req, res) {
+
+        if (self._stopping) {
+            return req.connection.end();
+        }
 
         // Create request
 


### PR DESCRIPTION
As described in joyent/node#9066, `node` can continue to emit `request` events on closed http servers. This patch works around this by checking if the server is stopping before responding to incoming requests.