### PR TITLE
Add xss protection to validation response

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -67,7 +67,7 @@ internals.input = function (source, request, next) {
         error.output.payload.validation = { source: source, keys: [] };
         if (err.details) {
             for (var i = 0, il = err.details.length; i < il; ++i) {
-                error.output.payload.validation.keys.push(err.details[i].path);
+                error.output.payload.validation.keys.push(Hoek.escapeHtml(err.details[i].path));
             }
         }
 

--- a/test/security.js
+++ b/test/security.js
@@ -220,6 +220,7 @@ describe('security', function () {
         function (res) {
 
             expect(res.result.message).to.not.contain('<script>');
+            expect(JSON.stringify(res.result.validation)).to.not.contain('<script>');
             done();
         });
     });
@@ -247,6 +248,7 @@ describe('security', function () {
         function (res) {
 
             expect(res.result.message).to.not.contain('<script>');
+            expect(JSON.stringify(res.result.validation)).to.not.contain('<script>');
             done();
         });
     });
@@ -272,6 +274,7 @@ describe('security', function () {
         function (res) {
 
             expect(res.result.message).to.not.contain('<script>');
+            expect(JSON.stringify(res.result.validation)).to.not.contain('<script>');
             done();
         });
     });


### PR DESCRIPTION
Validation field should also be escaped.
```json
{"statusCode":400,"error":"Bad Request","message":"&lt;script&gt;&lt;&#x2f;script&gt; is not allowed","validation":{"source":"query","keys":["<script></script>"]}}
```