### PR TITLE
inert 2.1.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -33,7 +33,7 @@
       "version": "2.10.0"
     },
     "inert": {
-      "version": "2.1.0",
+      "version": "2.1.2",
       "dependencies": {
         "lru-cache": {
           "version": "2.5.0"

--- a/test/security.js
+++ b/test/security.js
@@ -117,7 +117,7 @@ describe('security', function () {
 
         server.inject('/index%00.html', function (res) {
 
-            expect(res.statusCode).to.equal(404);
+            expect(res.statusCode).to.equal(403);
             done();
         });
     });


### PR DESCRIPTION
Update inert to 2.1.2 which includes more detailed failure http response codes.

This means that eg. `EMFILE` errors are no longer reported as `404 Not Found ` but respond with an internal error. Also, `403 Forbidden` will now be returned instead of `404 Not Found` when the server is not allowed to access a file.

Closes #2373 