### PR TITLE
Return explicit error when trying to stream a non-Readable stream

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -447,8 +447,11 @@ internals.Response.prototype._marshal = function (next) {
 internals.Response.prototype._streamify = function (source, next) {
 
     if (source instanceof Stream) {
-        var stream = (source.socket || source);
-        if (stream._readableState.objectMode) {
+        if (typeof source._read !== 'function' || typeof source._readableState !== 'object') {
+            return next(Boom.badImplementation('Stream is not a streams2 Readable'));
+        }
+
+        if (source._readableState.objectMode) {
             return next(Boom.badImplementation('Cannot reply with stream in object mode'));
         }
 


### PR DESCRIPTION
Fix #2368 & #2301 by returning an explicit error for non`Readable` streams instead of throwing.

This also fixes buggy behavior introduced in #2302, where a `Writable` only stream can be accepted as long as it contains a `socket._readableState` object.