### PR TITLE
Inert 2.1.3 update

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -33,7 +33,7 @@
       "version": "2.10.0"
     },
     "inert": {
-      "version": "2.1.2",
+      "version": "2.1.0",
       "dependencies": {
         "lru-cache": {
           "version": "2.5.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -33,7 +33,7 @@
       "version": "2.10.0"
     },
     "inert": {
-      "version": "2.1.0",
+      "version": "2.1.3",
       "dependencies": {
         "lru-cache": {
           "version": "2.5.0"

--- a/test/security.js
+++ b/test/security.js
@@ -117,7 +117,7 @@ describe('security', function () {
 
         server.inject('/index%00.html', function (res) {
 
-            expect(res.statusCode).to.equal(403);
+            expect(res.statusCode).to.equal(404);
             done();
         });
     });


### PR DESCRIPTION
I have reverted the 2.1.2 update which modified the null byte security test, as the new version returns a 404 again.

Closes #2398