### PR TITLE
throw when attaching route handlers without a connection

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -403,6 +403,7 @@ internals.Plugin.prototype.route = function (options) {
 
     Hoek.assert(arguments.length === 1, 'Method requires a single object argument or a single array of objects');
     Hoek.assert(typeof options === 'object', 'Invalid route options');
+    Hoek.assert(this.connections.length > 0, 'Cannot create route without connection.');
 
     this._apply(Connection.prototype._route, [options, this.realm]);
 };

--- a/test/route.js
+++ b/test/route.js
@@ -32,13 +32,23 @@ describe('Route', function () {
         done();
     });
 
+    it('throws an error when a route is made without a connection', function (done) {
+
+        expect(function () {
+
+            var server = new Hapi.Server();
+            server.route({ method: 'GET', path: '/dork', handler: function () { } });
+        }).to.throw('Cannot create route without connection.');
+        done();
+    });
+
     it('throws an error when a route is missing a method', function (done) {
 
         expect(function () {
 
             var server = new Hapi.Server();
             server.connection();
-            server.route({ path: '/test', handler: function () { } });
+            server.route({ path: '/', handler: function () { } });
         }).to.throw(/method is required/);
         done();
     });


### PR DESCRIPTION
this shouldn't be possible, and is very confusing for someone new to hapi.