### PR TITLE
Override server realm with route realm inside of handler

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -89,6 +89,8 @@ internals.handler = function (request, callback) {
     var reply = request.server._replier.interface(request, request.route.realm, finalize);
     var bind = request.route.settings.bind;
 
+    request.server.realm = request.route.realm;
+
     // Execute handler
 
     request.route.settings.handler.call(bind, request, reply);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -2105,6 +2105,55 @@ describe('Plugin', function () {
                 done();
             });
         });
+
+        it('render view in plugin handler', function (done) {
+
+            var test = function (server, options, next) {
+
+                server.path(__dirname);
+
+                var views = {
+                    engines: { 'html': Handlebars },
+                    path: './templates/plugin'
+                };
+
+                server.views(views);
+                if (Object.keys(views).length !== 2) {
+                    return next(new Error('plugin.view() modified options'));
+                }
+
+                server.route([
+                    {
+                        path: '/view', method: 'GET', handler: function (request, reply) {
+
+                          request.server.render('test', { message: options.message }, function (err, rendered, config) {
+
+                              return reply(rendered);
+                          });
+                        }
+                    }
+                ]);
+
+                return next();
+            };
+
+            test.attributes = {
+                name: 'test'
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.register({ register: test, options: { message: 'viewing it' } }, function (err) {
+
+                expect(err).to.not.exist();
+                server.inject('/view', function (res) {
+
+                    expect(res.result).to.equal('<h1>viewing it</h1>');
+
+                    done();
+                });
+            });
+        });
     });
 
     describe('views()', function () {


### PR DESCRIPTION
Use the realm for the current route inside of handler so they have access to state added during the plugin registration

Fix #2278 