### PR TITLE
Improved validation of route method label

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -35,11 +35,13 @@ exports = module.exports = internals.Route = function (options, connection, real
     Hoek.assert(options.handler || (options.config && options.config.handler), 'Missing or undefined handler:', options.method, options.path);
     Hoek.assert(!!options.handler ^ !!(options.config && options.config.handler), 'Handler must only appear once:', options.method, options.path);            // XOR
     Hoek.assert(options.path === '/' || options.path[options.path.length - 1] !== '/' || !connection.settings.router.stripTrailingSlash, 'Path cannot end with a trailing slash when connection configured to strip:', options.method, options.path);
+    Hoek.assert(/^[a-zA-Z0-9!#\$%&'\*\+\-\.^_`\|~]+$/.test(options.method), 'Invalid method name:', options.method, options.path);
 
     Schema.assert('route', options, options.path);
 
     var handler = options.handler || options.config.handler;
     var method = options.method.toLowerCase();
+    Hoek.assert(method !== 'head', 'Method name not allowed:', options.method, options.path);
 
     // Apply settings in order: {connection} <- {handler} <- {realm} <- {route}
 
@@ -81,8 +83,7 @@ exports = module.exports = internals.Route = function (options, connection, real
     // Validation
 
     var validation = this.settings.validate;
-    if (this.method === 'get' ||
-        this.method === 'head') {
+    if (this.method === 'get') {
 
         // Assert on config, not on merged settings
 
@@ -123,8 +124,7 @@ exports = module.exports = internals.Route = function (options, connection, real
 
     // Payload parsing
 
-    if (this.method === 'get' ||
-        this.method === 'head') {
+    if (this.method === 'get') {
 
         this.settings.payload = null;
     }
@@ -272,8 +272,7 @@ internals.Route.prototype.lifecycle = function () {
         cycle.push(Auth.authenticate);
     }
 
-    if (this.method !== 'get' &&
-        this.method !== 'head') {
+    if (this.method !== 'get') {
 
         cycle.push(internals.payload);
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -214,7 +214,7 @@ internals.vhost = Joi.alternatives([
 
 
 internals.route = Joi.object({
-    method: Joi.alternatives(Joi.string(), Joi.array().includes(Joi.string()).min(1)).required(),
+    method: Joi.string().required(),
     path: Joi.string().required(),
     vhost: internals.vhost,
     handler: Joi.any(),                         // Validated in route.config

--- a/test/route.js
+++ b/test/route.js
@@ -53,6 +53,28 @@ describe('Route', function () {
         done();
     });
 
+    it('throws an error when a route has a malformed method name', function (done) {
+
+        expect(function () {
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: '"GET"', path: '/', handler: function () { } });
+        }).to.throw(/Invalid method name/);
+        done();
+    });
+
+    it('throws an error when a route uses the HEAD method', function (done) {
+
+        expect(function () {
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: 'HEAD', path: '/', handler: function () { } });
+        }).to.throw(/Method name not allowed/);
+        done();
+    });
+
     it('throws an error when a route is missing a handler', function (done) {
 
         expect(function () {


### PR DESCRIPTION
This patch improves route method option handling in 3 ways:

 1. It fixes a bug in the validation which allows a nested array (eg.  `['GET', ['POST']]`) but later crashes when creating the route.
 1. It enforces the non-`HEAD` method restriction from the API docs.
 1. It limits the allowed value to token characters from https://tools.ietf.org/html/rfc7230#section-3.2.6.

Finally, I have included a couple of tests for `HEAD` responses, validating the existing implementation.