### PR TITLE
Add regex to allow leading $ and _

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -35,7 +35,7 @@ internals.Methods.prototype.add = function (name, method, options, realm) {
 };
 
 
-exports.methodNameRx = /^[_$a-zA-Z]\w*(?:\.[a-zA-Z]\w*)*$/;
+exports.methodNameRx = /^[_$a-zA-Z]\w*(?:\.[_$a-zA-Z]\w*)*$/;
 
 
 internals.Methods.prototype._add = function (name, method, options, realm) {

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -35,7 +35,7 @@ internals.Methods.prototype.add = function (name, method, options, realm) {
 };
 
 
-exports.methodNameRx = /^[a-zA-Z]\w*(?:\.[a-zA-Z]\w*)*$/;
+exports.methodNameRx = /^[_$a-zA-Z]\w*(?:\.[a-zA-Z]\w*)*$/;
 
 
 internals.Methods.prototype._add = function (name, method, options, realm) {

--- a/test/methods.js
+++ b/test/methods.js
@@ -39,6 +39,40 @@ describe('Methods', function () {
         });
     });
 
+    it('registers a method with leading _', function (done) {
+
+        var _add = function (a, b, next) {
+
+            return next(null, a + b);
+        };
+
+        var server = new Hapi.Server();
+        server.method('_add', _add);
+
+        server.methods._add(1, 5, function (err, result) {
+
+            expect(result).to.equal(6);
+            done();
+        });
+    });
+
+    it('registers a method with leading $', function (done) {
+
+        var $add = function (a, b, next) {
+
+            return next(null, a + b);
+        };
+
+        var server = new Hapi.Server();
+        server.method('$add', $add);
+
+        server.methods.$add(1, 5, function (err, result) {
+
+            expect(result).to.equal(6);
+            done();
+        });
+    });
+
     it('registers a method (no callback)', function (done) {
 
         var add = function (a, b) {


### PR DESCRIPTION
Fixes #2401
added to the regex to allow leading $ and _
added two tests to validate that the leading $ _ is allowed for a method name