### PR TITLE
Create an entry at server.plugins on plugin registration

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -37,6 +37,7 @@ exports = module.exports = internals.Plugin = function (server, connections, env
     this.plugins = this.root._plugins;
     this.settings = this.root._settings;
     this.version = Package.version;
+    this.plugins[env] = {};
 
     this.realm = typeof env !== 'string' ? env : {
         modifiers: {
@@ -319,7 +320,6 @@ internals.Plugin.prototype.expose = function (key, value) {
     Hoek.assert(this.realm.plugin, 'Cannot call expose() outside of a plugin');
 
     var plugin = this.realm.plugin;
-    this.root.plugins[plugin] = this.root.plugins[plugin] || {};
     if (typeof key === 'string') {
         this.root.plugins[plugin][key] = value;
     }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -156,6 +156,31 @@ describe('Plugin', function () {
             });
         });
 
+        it('registers plugin and exposes api', function (done) {
+
+            var server = new Hapi.Server();
+            server.connection({ labels: ['a', 'b'] });
+
+            var test = {
+                register: function (server, options, next) {
+
+                    expect(options.something).to.be.true();
+                    return next();
+                }
+            };
+
+            test.register.attributes = {
+                name: 'test'
+            };
+
+            server.register({ register: test, options: { something: true } }, function (err) {
+
+                expect(err).to.not.exist();
+                expect(server.plugins.test).to.exist();
+                done();
+            });
+        });
+
         it('registers a required plugin', function (done) {
 
             var server = new Hapi.Server();


### PR DESCRIPTION
I need to check if a plugin is registered and reading the [documentation](http://hapijs.com/api#serverplugins) I was trying to do it testing the presence of `server.plugins['plugin-name']`.

Since the `server.plugins['plugin-name']` is only assigned when the expose method is called I moved that logic to the plugin construction.