### PR TITLE
correct the name of the object

### DIFF
--- a/API.md
+++ b/API.md
@@ -1720,7 +1720,7 @@ The `'request'` and `'request-internal'` events include the [request object](#re
 server.on('request', function (request, event, tags) {
 
     if (tags.received) {
-        console.log('New request: ' + event.id);
+        console.log('New request: ' + request.id);
     }
 });
 ```


### PR DESCRIPTION
There is no `event.id`.