### PR TITLE
Fix inconsistent error responses when using JSONP

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -261,6 +261,10 @@ internals.Route.prototype.lifecycle = function () {
 
     // 'onRequest'
 
+    if (this.settings.jsonp) {
+        cycle.push(internals.parseJSONP);
+    }
+
     if (this.settings.state.parse) {
         cycle.push(internals.state);
     }
@@ -289,10 +293,6 @@ internals.Route.prototype.lifecycle = function () {
 
     if (this.settings.validate.params) {
         cycle.push(Validation.params);
-    }
-
-    if (this.settings.jsonp) {
-        cycle.push(internals.parseJSONP);
     }
 
     if (this.settings.validate.query) {


### PR DESCRIPTION
Greetings,

It appears that when using JSONP, only half the time will a response be wrapped and sent, depending on where the routing cycle ends during the request.

#### Inconsistent Responses

For example, if any one of these things occur during the request, the response **will not be wrapped** in JSONP:
* State fails
* Pre-auth hook points trigger a response
* Authentication failure / missing
* Post-auth hook points trigger a response
* Payload fails to parse / authenticate
* Headers validation fails
* Params validation fails

Only when these things occur, do they actually get wrapped in a JSONP response:
* Query validation fails
* Payload validation fails
* Pre-handler hook points trigger a response
* Handler responses
* Post-handler hook points trigger a response
* Response validation fails

#### Motivation

In our situation, we have created a custom authentication scheme that will check and authenticate a query, header or cookie parameter (e.g. API key) and return the credentials for the route handler. 

Since state and authentication occurs earlier in the routing cycle than JSONP does, those responses will not be wrapped up in a JSONP context, making it impossible for the client to understand what happened. Same thing goes if a route parameter was bogus. However, if they mess up a query parameter, they would actually get that error wrapped.

`GET /some/stuff?callback=test` (no key param, cookie, or Authorization header)
##### Expected
```js
/**/test({"statusCode":401,"error":"Unauthorized","message":"Missing authentication"});
```

##### Actual
```js
{
    "statusCode": 401,
    "error": "Unauthorized",
    "message": "Missing authentication"
}
```

#### TL.DR

This request moves JSONP handling to the top of the request cycle, as an attempt to make all responses consistent. Naturally, the only response that would not get wrapped is when the jsonp callback method name is invalid, then obviously it cannot be wrapped.

If the client is passing in a JSONP callback, they should expect that the response, no matter how it ends, should come back wrapped up. Error or not, here I come!


