### PR TITLE
Fix Hapi Issue #2501, pass on auth artifacts object in server.inject

### DIFF
--- a/API.md
+++ b/API.md
@@ -1029,6 +1029,9 @@ for performing injections, with some additional options and response properties:
     - `credentials` - an optional credentials object containing authentication information. The
       `credentials` are used to bypass the default authentication strategies, and are validated
       directly as if they were received via an authentication scheme. Defaults to no credentials.
+    - `artifacts` - an optional artifacts object containing authentication artifact information. The
+      `artifacts` are used to bypass the default authentication strategies, and are validated
+      directly as if they were received via an authentication scheme. Defaults to no artifacts.
     - `simulate` - an object with options used to simulate client request stream conditions for
       testing:
         - `error` - if `true`, emits an `'error'` event after payload transmission (if any).

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -237,12 +237,16 @@ internals.Connection.prototype._dispatch = function (options) {
 internals.Connection.prototype.inject = function (options, callback) {
 
     var settings = options;
-    if (settings.credentials) {
+    if (settings.credentials || settings.artifacts) {
         settings = Hoek.shallow(options);               // options can be reused
         delete settings.credentials;
+        delete settings.artifacts;
     }
 
-    var needle = this._dispatch({ credentials: options.credentials });
+    var needle = this._dispatch({
+        credentials: options.credentials,
+        artifacts: options.artifacts
+    });
     Shot.inject(needle, settings, function (res) {
 
         if (res.raw.res._hapi) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -89,6 +89,10 @@ exports = module.exports = internals.Request = function (connection, req, res, o
     if (options.credentials) {
         this.auth.credentials = options.credentials;
     }
+    if (options.artifacts) {
+        this.auth.artifacts = options.artifacts;
+    }
+
 
     // Assigned elsewhere:
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -635,6 +635,31 @@ describe('Connection', function () {
             });
         });
 
+        it('passes the options.artifacts object', function (done) {
+
+            var handler = function (request, reply) {
+                return reply(request.auth.artifacts);
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: 'GET', path: '/', config: { handler: handler } });
+
+            var options = {
+                url: '/',
+                credentials: { foo: 'bar' },
+                artifacts: { bar: 'baz' }
+            };
+
+            server.connections[0].inject(options, function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.result.bar).to.equal('baz');
+                expect(options.artifacts).to.exist();
+                done();
+            });
+        });
+
         it('returns the request object', function (done) {
 
             var handler = function (request, reply) {


### PR DESCRIPTION
Allow server.inject options parameter to specify a .artifacts object too, so that we can test handlers that use the authentication by-product artifacts too. This was done similarly to how the .credentials object is passed there.
A test was added to verify this behavior. API documentation updated.