### PR TITLE
closes #2480: Ability to pass options to qs for payload parsing

### DIFF
--- a/API.md
+++ b/API.md
@@ -2716,12 +2716,14 @@ Each request object includes the following properties:
   definition.
 - `url` - the parsed request URI.
 
-#### `request.setUrl(url)`
+#### `request.setUrl(url, [stripTrailingSlash], [qsParserOptions])`
 
 _Available only in `'onRequest'` extension methods._
 
 Changes the request URI before the router begins processing the request where:
  - `url` - the new request path value.
+ - `stripTrailingSlash` - if truthy, strip the trailing slash from the path.
+ - `qsParserOptions` - an object of options to pass to [Qs.parse()](https://www.npmjs.com/package/qs#parsing-objects), which parses the URL's query string, if present.
 
 ```js
 var Hapi = require('hapi');

--- a/lib/request.js
+++ b/lib/request.js
@@ -168,10 +168,10 @@ exports = module.exports = internals.Request = function (connection, req, res, o
 Hoek.inherits(internals.Request, Events.EventEmitter);
 
 
-internals.Request.prototype._setUrl = function (url, stripTrailingSlash) {
+internals.Request.prototype._setUrl = function (url, stripTrailingSlash, qsParserOptions) {
 
     this.url = Url.parse(url, false);
-    this.url.query = Qs.parse(this.url.query);          // Override parsed value
+    this.url.query = Qs.parse(this.url.query, qsParserOptions);     // Override parsed value
     this.query = this.url.query;
     this.path = this.url.pathname || '';                // pathname excludes query
 

--- a/test/request.js
+++ b/test/request.js
@@ -744,6 +744,31 @@ describe('Request', function () {
                 done();
             });
         });
+
+        it('accepts querystring parser options', function (done) {
+
+            var url = 'http://localhost/page?a=1&b=1&c=1&d=1&e=1&f=1&g=1&h=1&i=1&j=1&k=1&l=1&m=1&n=1&o=1&p=1&q=1&r=1&s=1&t=1&u=1&v=1&w=1&x=1&y=1&z=1';
+            var qsParserOptions = {
+                parameterLimit: 26
+            };
+            var server = new Hapi.Server();
+            server.connection();
+            server.ext('onRequest', function (request, reply) {
+
+                request.setUrl(url, null, qsParserOptions);
+                return reply(request.query);
+            });
+
+            server.inject('/', function (res) {
+
+                expect(res.result).to.deep.equal({
+                    a: '1', b: '1', c: '1', d: '1', e: '1', f: '1', g: '1', h: '1', i: '1',
+                    j: '1', k: '1', l: '1', m: '1', n: '1', o: '1', p: '1', q: '1', r: '1',
+                    s: '1', t: '1', u: '1', v: '1', w: '1', x: '1', y: '1', z: '1'
+                });
+                done();
+            });
+        });
     });
 
     describe('log()', { parallel: false }, function () {


### PR DESCRIPTION
- added optional `qsParserOptions` parameter to `Request.setUrl()`
- added test illustrating use case prompting #2480
- updated `API.md` to reflect new parameter; added info about `stripTrailingSlash` as well