### PR TITLE
server.dependency: call after with (server, options, next). Closes #2520

### DIFF
--- a/API.md
+++ b/API.md
@@ -841,8 +841,9 @@ Used within a plugin to declares a required dependency on other [plugins](#plugi
 - `after` - an optional function called after all the specified dependencies have been registered
   and before the server starts. The function is only called if the server is started. If a circular
   dependency is detected, an exception is thrown (e.g. two plugins each has an `after` function
-  to be called after the other). The function signature is `function(server, next)` where:
+  to be called after the other). The function signature is `function(server, options, next)` where:
     - `server` - the server the `dependency()` method was called on.
+    - `options` - the options object passed to the plugin during registration.
     - `next` - the callback function the method must call to return control over to the application
       and complete the registration process. The function signature is `function(err)` where:
         - `err` - internal error condition, which is returned back via the
@@ -855,7 +856,7 @@ exports.register = function (server, options, next) {
     return next();
 };
 
-var after = function (server, next) {
+var after = function (server, options, next) {
 
     // Additional plugin registration logic
     return next();

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -15,7 +15,7 @@ var Schema = require('./schema');
 var internals = {};
 
 
-exports = module.exports = internals.Plugin = function (server, connections, env, options) {            // env can be a realm or plugin name
+exports = module.exports = internals.Plugin = function (server, connections, env, options, pluginOptions) {            // env can be a realm or plugin name
 
     var self = this;
 
@@ -45,6 +45,7 @@ exports = module.exports = internals.Plugin = function (server, connections, env
                 vhost: options.routes && options.routes.vhost
             }
         },
+        pluginOptions: pluginOptions || {},
         plugin: env,
         plugins: {},
         settings: {
@@ -119,7 +120,7 @@ internals.Plugin.prototype.select = function (/* labels */) {
 };
 
 
-internals.Plugin.prototype._select = function (labels, plugin, options) {
+internals.Plugin.prototype._select = function (labels, plugin, options, pluginOptions) {
 
     var connections = this.connections;
 
@@ -145,7 +146,7 @@ internals.Plugin.prototype._select = function (labels, plugin, options) {
     }
 
     var env = (plugin !== undefined ? plugin : this.realm);                     // Allow empty string
-    return new internals.Plugin(this.root, connections, env, options);
+    return new internals.Plugin(this.root, connections, env, options, pluginOptions);
 };
 
 
@@ -235,7 +236,7 @@ internals.Plugin.prototype.register = function (plugins /*, [options], callback 
 
     Items.serial(registrations, function (item, next) {
 
-        var selection = self._select(options.select, item.name, options);
+        var selection = self._select(options.select, item.name, options, item.options);
 
         // Protect against multiple registrations
 
@@ -258,8 +259,15 @@ internals.Plugin.prototype.register = function (plugins /*, [options], callback 
 
 internals.Plugin.prototype.after = function (method, dependencies) {
 
+    Hoek.assert(typeof method === 'function', 'method must be a function');
+    this._after(method.bind(this, this), dependencies);
+};
+
+
+internals.Plugin.prototype._after = function (func, dependencies) {
+
     this.root._afters = this.root._afters || new Topo();
-    this.root._afters.add({ func: method, plugin: this }, { after: dependencies, group: this.realm.plugin });
+    this.root._afters.add({ func: func }, { after: dependencies, group: this.realm.plugin });
 };
 
 
@@ -327,7 +335,7 @@ internals.Plugin.prototype.dependency = function (dependencies, after) {
     this.root._dependencies.push({ plugin: this.realm.plugin, connections: this.connections, deps: dependencies });
 
     if (after) {
-        this.after(after, dependencies);
+        this._after(after.bind(this, this, this.realm.pluginOptions), dependencies);
     }
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -190,7 +190,7 @@ internals.Server.prototype.start = function (callback) {
 
         Items.serial(exts.nodes, function (ext, next) {
 
-            ext.func(ext.plugin, next);
+            ext.func(next);
         },
         function (err) {
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1637,6 +1637,50 @@ describe('Plugin', function () {
                 done();
             });
         });
+
+        it('passes server, options, next to after method', function (done) {
+
+            var a = {
+                register: function (server, options, next) {
+
+                    server.dependency(['b'], afterA);
+                    next();
+                },
+                options: {
+                    optionsFor: 'a'
+                }
+            };
+
+            var afterA = function (server, options, next) {
+
+                expect(next).to.be.a.function();
+                expect(options).to.equal(a.options);
+                done();
+            };
+
+            a.register.attributes = {
+                name: 'a'
+            };
+
+            var b = function (server, options, next) {
+
+                return next();
+            };
+
+            b.attributes = {
+                name: 'b'
+            };
+
+            var server = new Hapi.Server();
+            server.connection({ port: 80, host: 'localhost' });
+            server.register(a, function (err) {
+
+                server.register(b, function (err) {
+
+                    server.start();
+                });
+            });
+        });
     });
 
     describe('events', function () {
@@ -2734,7 +2778,7 @@ internals.plugins = {
     },
     deps1: function (server, options, next) {
 
-        server.dependency('deps2', function (server, next) {
+        server.dependency('deps2', function (server, options, next) {
 
             server.expose('breaking', server.plugins.deps2.breaking);
             return next();


### PR DESCRIPTION
This fixes #2520 without breaking any other tests, but I'm not entirely happy with it:

* The arguments list for the `Plugin` constructor is getting a little long
* ~~That check for `ext.arity` in `Server.start` doesn't explain itself~~
* ~~`Plugin.after` is getting too clever with its arguments~~

(Update: cleaned up a little in later commits, now squashed in.)