### PR TITLE
Editor support improvements for Atom, Sublime, and others:

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.js]
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[{package.json,.travis.yml,.eslintrc}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,1 @@
+{ "extends": "./node_modules/lab/lib/linters/eslint/.eslintrc" }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "accept": "1.x.x",
-    "ammo":  "1.x.x",
+    "ammo": "1.x.x",
     "boom": "^2.5.x",
     "call": "2.x.x",
     "catbox": "^4.2.x",
@@ -45,6 +45,8 @@
   "devDependencies": {
     "bluebird": "2.x.x",
     "code": "1.x.x",
+    "eslint": "0.19.x",
+    "eslint-plugin-hapi": "^1.0.0",
     "handlebars": "2.x.x",
     "lab": "5.x.x",
     "wreck": "5.x.x"


### PR DESCRIPTION
`npm test` uses `lab` to enforce the code style. We can help contributors by also having their editor flag the problems as they type. This PR adds:

* Local `eslint` so lint plugins can report on divergence from Hapi JavaScript style
* `.editorconfig` so editorconfig plugins can apply Hapi indentation and line termination

I copied the `.eslintrc` from `lab`, and adjusted the `plugins` entry to make Atom happy.

Hazard: need to track `lab` changes to ~~`.eslintrc` and~~ its `package.json` dependencies on `eslint` and `eslint-plugin-hapi`.
