### PR TITLE
Fix backtick in docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -2282,7 +2282,7 @@ following options:
         - `'log'` - log the error but continue processing the request.
         - `'ignore'` - take no action.
         - a custom error handler function with the signature
-          'function(request, reply, source, error)` where:
+          `function(request, reply, source, error)` where:
             - `request` - the [request object](#request-object).
             - `reply` - the continuation [reply interface](#reply-interface).
             - `source` - the source of the invalid field (e.g. `'headers'`, `'params'`, `'query'`, `'payload'`).


### PR DESCRIPTION
A straight quote was used in place of a backtick.