### PR TITLE
Documentation typo fix. Closes #2601.

### DIFF
--- a/API.md
+++ b/API.md
@@ -874,7 +874,7 @@ exports.register = function (server, options, next) {
 register.attributes = {
     name: 'test',
     version: '1.0.0',
-    dependency: 'yar'
+    dependencies: 'yar'
 };
 ```
 


### PR DESCRIPTION
Addresses typo regarding plugin dependencies. Closes #2601. 