### PR TITLE
Fix inverted boolean argument documentation.

### DIFF
--- a/API.md
+++ b/API.md
@@ -3099,7 +3099,7 @@ When using the `redirect()` method, the response object provides these additiona
     - `isTemporary` - if `false`, sets status to permanent. Defaults to `true`.
 - `permanent(isPermanent)` - sets the status code to `301` or `308` (based on the `rewritable()`
   setting) where:
-    - `isPermanent` - if `true`, sets status to temporary. Defaults to `false`.
+    - `isPermanent` - if `false`, sets status to temporary. Defaults to `true`.
 - `rewritable(isRewritable)` - sets the status code to `301`/`302` for rewritable (allows changing
   the request method from 'POST' to 'GET') or `307`/`308` for non-rewritable (does not allow
   changing the request method from 'POST' to 'GET'). Exact code based on the `temporary()` or


### PR DESCRIPTION
Even with this change this is still confusing documentation / API in general (to me it'd be simpler if there were just `temporary()` or `permanent()`):

> `temporary(isTemporary)` - sets the status code to `302` or `307`
> `permanent(isPermanent)` - sets the status code to `301` or `308`

In reality either method can set the status to any of the 4 codes depending on its argument value and `rewritable()`.
