### PR TITLE
Handle date response in server.inject

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -278,6 +278,10 @@ internals.Connection.prototype.inject = function (options, callback) {
             res.result = res.payload;
         }
 
+        if (res.result && res.result.error === undefined) {
+            res.result = JSON.parse(JSON.stringify(res.result));
+        }
+
         return callback(res);
     });
 };


### PR DESCRIPTION
If we have date response, for example:

```js
server.route([{
  method: 'GET',
  path: '/api/test',
  handler: function(request, reply) {
    reply({
      datetime: new Date('2015-06-25T00:00:00.000Z')
    });
  }
}]);
```

and we test this route with `server.inject`:

```js
server.inject({
  method: 'GET',
  url: '/api/test'
}, function(response) {
  response.result.should.eql({
    datetime: '2015-06-25T00:00:00.000Z'
  });
});
```

This test will fail, because the real result is a js date value instead of a ISO string value. But actually, in browser, we will get the ISO string value. So I try to fix this problem with `JSON.parse` and `JSON.stringify`. When I run the test, I found the failed tests `383`, `390`, `481` is passed...