### PR TITLE
Update inert to 2.1.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -33,10 +33,10 @@
             "version": "2.14.0"
         },
         "inert": {
-            "version": "2.1.5",
+            "version": "2.1.6",
             "dependencies": {
                 "lru-cache": {
-                    "version": "2.6.4"
+                    "version": "2.6.5"
                 }
             }
         },


### PR DESCRIPTION
Fixes invalid ETag generation on initial 304 responses, or range requests.