### PR TITLE
Allow objects as valid values for route notes

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -249,7 +249,8 @@ internals.routeConfig = internals.routeBase.keys({
     description: Joi.string(),
     notes: [
         Joi.string(),
-        Joi.array().items(Joi.string())
+        Joi.array().items(Joi.string()),
+        Joi.object().pattern(/\w\d/, Joi.string())
     ],
     tags: [
         Joi.string(),


### PR DESCRIPTION
Allow objects as valid values for route notes for more complex notes. Notes can now be a string, an array of strings, or an object with string values.