### PR TITLE
No longer removing response validation from route object if sample = 0

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -105,8 +105,7 @@ exports = module.exports = internals.Route = function (options, connection, real
         this.settings.response.status = this.settings.response.status || {};
         var statuses = Object.keys(this.settings.response.status);
 
-        if ((rule === true && !statuses.length) ||
-            this.settings.response.sample === 0) {
+        if (rule === true && !statuses.length) {
 
             this.settings.response = null;
         }
@@ -311,7 +310,7 @@ internals.Route.prototype.lifecycle = function () {
     cycle.push(Handler.execute);                                     // Must not call next() with an Error
     cycle.push('onPostHandler');                                     // An error from here on will override any result set in handler()
 
-    if (this.settings.response) {
+    if (this.settings.response && this.settings.response.sample !== 0) {
         cycle.push(Validation.response);
     }
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -1213,6 +1213,36 @@ describe('validation', function () {
         });
     });
 
+    it('does not delete the response object from the route when sample is 0', function (done) {
+
+        var server = new Hapi.Server({ debug: false });
+        server.connection();
+        server.route({
+            method: 'GET',
+            path: '/',
+            config: {
+                handler: function (request, reply) {
+
+                    return reply('ok');
+                },
+                response: {
+                    sample: 0,
+                    schema: {
+                        b: Joi.string()
+                    }
+                }
+            }
+        });
+
+        server.inject('/', function (res) {
+
+            expect(res.request.route.settings.response).to.exist();
+            expect(res.request.route.settings.response.sample).to.equal(0);
+            expect(res.request.route.settings.response.schema).to.exist();
+            done();
+        });
+    });
+
     it('fails response validation with options', function (done) {
 
         var server = new Hapi.Server({ debug: false });


### PR DESCRIPTION
When using [swagger](https://github.com/glennjones/hapi-swagger) for API documentation, setting `sample = 0` in response validation causes the schema not to be displayed in the documentation page.
This is because the `route.settings.response object` is set to null if sample === 0.  

Instead of doing this, skipping the validation step if sample === 0 keeps the same performance characteristics without removing any information from the route.