### PR TITLE
Added schema validation when creating a server method using object

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -29,6 +29,7 @@ internals.Methods.prototype.add = function (name, method, options, realm) {
     var items = [].concat(name);
     for (var i = 0, il = items.length; i < il; ++i) {
         var item = items[i];
+        Schema.assert('methodObject', item);
         this._add(item.name, item.method, item.options, realm);
     }
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -275,8 +275,8 @@ internals.method = Joi.object({
 
 
 internals.methodObject = Joi.object({
-    name: Joi.string(),
-    method: Joi.func(),
+    name: Joi.string().required(),
+    method: Joi.func().required(),
     options: Joi.object()
 });
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -274,6 +274,13 @@ internals.method = Joi.object({
 });
 
 
+internals.methodObject = Joi.object({
+    name: Joi.string(),
+    method: Joi.func(),
+    options: Joi.object()
+});
+
+
 internals.register = Joi.object({
     routes: Joi.object({
         prefix: Joi.string().regex(/^\/.+/),

--- a/test/methods.js
+++ b/test/methods.js
@@ -1097,4 +1097,21 @@ describe('Methods', function () {
             done();
         });
     });
+
+    it('throws an error if unknown keys are present when making a server method using an object', function (done) {
+
+        var fn = function () { };
+        var server = new Hapi.Server();
+
+        expect(function () {
+
+            server.method({
+                name: 'fn',
+                method: fn,
+                cache: { }
+            });
+        }).to.throw();
+
+        done();
+    });
 });


### PR DESCRIPTION
This is designed to catch simple mistakes like this:

    server.method({
        name: 'myMethod',
        method: function () { ... },
        cache: {
            expiresIn: 1000
        }
    });

which should really be:

    server.method({
        name: 'myMethod',
        method: function () { ... },
        options: {
            cache: {
                expiresIn: 1000
            }
        }
    });