### PR TITLE
add plugin alias and tests

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -37,6 +37,7 @@ exports = module.exports = internals.Plugin = function (server, connections, env
     this.plugins = this.root._plugins;
     this.settings = this.root._settings;
     this.version = Package.version;
+    this.alias = options.alias || null;
 
     this.realm = typeof env !== 'string' ? env : {
         modifiers: {
@@ -198,6 +199,7 @@ internals.Plugin.prototype.register = function (plugins /*, [options], callback 
         var plugins = register, items, [register, item]
     */
 
+    Hoek.assert(!Array.isArray(plugins) || !options.alias, 'Cannot specify an alias when registering multiple plugins at once');
     var registrations = [];
     plugins = [].concat(plugins);
     for (var i = 0, il = plugins.length; i < il; ++i) {
@@ -338,6 +340,9 @@ internals.Plugin.prototype.expose = function (key, value) {
 
     var plugin = this.realm.plugin;
     this.root.plugins[plugin] = this.root.plugins[plugin] || {};
+    if (this.alias) {
+        this.root.plugins[this.alias] = this.root.plugins[plugin];
+    }
     if (typeof key === 'string') {
         this.root.plugins[plugin][key] = value;
     }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -279,7 +279,8 @@ internals.register = Joi.object({
         prefix: Joi.string().regex(/^\/.+/),
         vhost: internals.vhost
     }),
-    select: Joi.array().items(Joi.string()).single()
+    select: Joi.array().items(Joi.string()).single(),
+    alias: Joi.string()
 });
 
 internals.dependencies = Joi.array().items(Joi.string()).single();


### PR DESCRIPTION
# Background

See #2666 

# Solution

Add alias to `options` object passed to `server.register`.

# Discussion

The alias is passed to the `Plugin` constructor, and assigned to `this.alias`. From there, it is referenced in `expose()`. I am open to other suggestions on how to pass the **alias** to the `expose()` method. 

This option is only valid when registering one plugin at a time. If `options.alias` is specified when registering multiple plugins at once, and error is thrown.

I am currently not verifying that the alias does not overwrite an existing plugin's namespace in `server.plugins`. Is this something that is important? Since the alias is user-specified, it seems unlikely that they would unintentionally overload another existing plugin.

*Documentation updates still to come.* I wanted to iterate on this PR before working on the documentation. 
