### PR TITLE
Update hapijs/shot to 1.6.0 from 1.5.3

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -221,7 +221,7 @@ internals.Connection.prototype._dispatch = function (options) {
     return function (req, res) {
 
         if (!self._started &&
-            req.connection) {
+            !Shot.isInjection(req)) {
 
             return req.connection.end();
         }

--- a/lib/request.js
+++ b/lib/request.js
@@ -110,8 +110,8 @@ internals.Request = function (connection, req, res, options) {
     this.info = {
         received: now,
         responded: 0,
-        remoteAddress: req.connection ? req.connection.remoteAddress : '',
-        remotePort: req.connection ? req.connection.remotePort : '',
+        remoteAddress: req.connection.remoteAddress,
+        remotePort: req.connection.remotePort || '',
         referrer: req.headers.referrer || req.headers.referer || '',
         host: req.headers.host ? req.headers.host.replace(/\s/g, '') : '',
         acceptEncoding: Accept.encoding(this.headers['accept-encoding'], ['identity', 'gzip', 'deflate'])

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,7 +75,7 @@
             "version": "4.0.0"
         },
         "shot": {
-            "version": "1.5.3"
+            "version": "1.6.0"
         },
         "statehood": {
             "version": "2.1.1"

--- a/test/connection.js
+++ b/test/connection.js
@@ -725,6 +725,44 @@ describe('Connection', function () {
                 done();
             });
         });
+
+        it('can set a client remoteAddress', function (done) {
+
+            var handler = function (request, reply) {
+
+                return reply(request.info.remoteAddress);
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: 'GET', path: '/', config: { handler: handler } });
+
+            server.inject({ url: '/', remoteAddress: '1.2.3.4' }, function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.payload).to.equal('1.2.3.4');
+                done();
+            });
+        });
+
+        it('sets a default remoteAddress of 127.0.0.1', function (done) {
+
+            var handler = function (request, reply) {
+
+                return reply(request.info.remoteAddress);
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: 'GET', path: '/', config: { handler: handler } });
+
+            server.inject('/', function (res) {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.payload).to.equal('127.0.0.1');
+                done();
+            });
+        });
     });
 
     describe('table()', function () {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1850,7 +1850,7 @@ describe('Plugin', function () {
                 };
 
                 plugin.attributes = {
-                  name: 'deps' + num
+                    name: 'deps' + num
                 };
 
                 return plugin;


### PR DESCRIPTION
I've made an assumption here that checking if a `request` had a `connection` property was only because Shot requests don't have one. Please tell me if this is a false assumption. 