### PR TITLE
Question: Don't add must-revalidate cache-control value.

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -425,7 +425,7 @@ internals.cache = function (response) {
 
         var ttl = (response.settings.ttl !== null ? response.settings.ttl : request._route._cache.ttl());
         var privacy = (request.auth.isAuthenticated || response.headers['set-cookie'] ? 'private' : request.route.settings.cache.privacy || 'default');
-        response._header('cache-control', 'max-age=' + Math.floor(ttl / 1000) + ', must-revalidate' + (privacy !== 'default' ? ', ' + privacy : ''));
+        response._header('cache-control', 'max-age=' + Math.floor(ttl / 1000) + (privacy !== 'default' ? ', ' + privacy : ''));
     }
     else {
         response._header('cache-control', 'no-cache');


### PR DESCRIPTION
This may be more of a question than a solution.  

Chrome audit reports any response with `Cache-Control: must-revalidate` as an error that the resource is "explicitly non-cacheable."  

Chrome audit seems to contradict [the RFC](https://tools.ietf.org/html/rfc7234#section-5.2.2.1) here, but perhaps `must-revalidate` is problematic in practice, even if it shouldn't be problematic in theory.

Removing `must-revalidate` fixes the Chrome audit results for me.  Could it be removed, or perhaps be optional?  Is Chrome audit reporting a false error?