### PR TITLE
Properly terminate code block in API.md for server.initialize

### DIFF
--- a/API.md
+++ b/API.md
@@ -1052,6 +1052,7 @@ server.initialize(function (err) {
 
     Hoek.assert(!err, err);
 });
+```
 
 ### `server.inject(options, callback)`
 


### PR DESCRIPTION
This was gobbling server.inject up into a code block on the website
![screen shot 2015-08-13 at 14 18 35](https://cloud.githubusercontent.com/assets/916064/9250592/37d0c41c-41c6-11e5-947a-50bfb6e22a28.png)
