### PR TITLE
Route-level extension management.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -347,7 +347,7 @@ internals.Connection.prototype._ext = function (event, nodes, options) {
         // Add extension to existing routes
         var routes = this._router.table();
         for (var i = 0, il = routes.length; i < il; ++i) {
-            routes[i]._extNodes(event, nodes, options);
+            routes[i]._ext(event, nodes, options);
         }
 
         // And to special routes (notFound, etc.)
@@ -356,7 +356,7 @@ internals.Connection.prototype._ext = function (event, nodes, options) {
 
             var special = this._router.specials[specialTypes[j]];
             if (special) {
-                special.route._extNodes(event, nodes, options);
+                special.route._ext(event, nodes, options);
             }
         }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -65,7 +65,10 @@ exports = module.exports = internals.Connection = function (server, options) {
     this._registrations = {};           // Tracks plugin for dependency validation
 
     this._extensions = {
-        onRequest: null,                // New request, before handing over to the router (allows changes to the request method, url, etc.)
+        onRequest: null                 // New request, before handing over to the router (allows changes to the request method, url, etc.)
+    };
+
+    this._routeExtensions = {
         onPreAuth: null,                // After cookie parse and before authentication (skipped if state error)
         onPostAuth: null,               // After authentication (and payload processing) and before validation (skipped if auth or payload error)
         onPreHandler: null,             // After validation and body parsing, before route handler (skipped if auth or validation error)
@@ -325,10 +328,39 @@ internals.Connection.prototype.match = function (method, path, host) {
 
 internals.Connection.prototype._ext = function (event, nodes, options) {
 
-    Hoek.assert(this._extensions[event] !== undefined, 'Unknown event type', event);
+    var isConnExtension = (this._extensions[event] !== undefined);
+    var isRouteExtension = (this._routeExtensions[event] !== undefined);
 
-    this._extensions[event] = this._extensions[event] || new Topo();
-    this._extensions[event].add(nodes, options);
+    Hoek.assert(isConnExtension || isRouteExtension, 'Unknown event type', event);
+
+    if (isConnExtension) {
+        this._extensions[event] = this._extensions[event] || new Topo();
+        this._extensions[event].add(nodes, options);
+    }
+
+    if (isRouteExtension) {
+    
+        // Add pending route extension
+        this._routeExtensions[event] = this._routeExtensions[event] || [];
+        this._routeExtensions[event].push({ nodes: nodes, settings: options });
+
+        // Add extension to existing routes
+        var routes = this._router.table();
+        for (var i = 0, il = routes.length; i < il; ++i) {
+            routes[i]._extNodes(event, nodes, options);
+        }
+        
+        var specials = Object.keys(this._router.specials);
+        for (var j = 0, jl = specials.length; j < jl; ++j) {
+            
+            var special = this._router.specials[specials[j]];
+            if (special) {
+                special.route._extNodes(event, nodes, options);
+            }
+        }
+        
+    }
+
 };
 
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -328,37 +328,38 @@ internals.Connection.prototype.match = function (method, path, host) {
 
 internals.Connection.prototype._ext = function (event, nodes, options) {
 
-    var isConnExtension = (this._extensions[event] !== undefined);
-    var isRouteExtension = (this._routeExtensions[event] !== undefined);
+    var isForConnection = (this._extensions[event] !== undefined);
+    var isForRoutes = (this._routeExtensions[event] !== undefined);
 
-    Hoek.assert(isConnExtension || isRouteExtension, 'Unknown event type', event);
+    Hoek.assert(isForConnection || isForRoutes, 'Unknown event type', event);
 
-    if (isConnExtension) {
+    if (isForConnection) {
         this._extensions[event] = this._extensions[event] || new Topo();
         this._extensions[event].add(nodes, options);
     }
 
-    if (isRouteExtension) {
-    
+    if (isForRoutes) {
+
         // Add pending route extension
         this._routeExtensions[event] = this._routeExtensions[event] || [];
-        this._routeExtensions[event].push({ nodes: nodes, settings: options });
+        this._routeExtensions[event].push({ nodes: nodes, options: options });
 
         // Add extension to existing routes
         var routes = this._router.table();
         for (var i = 0, il = routes.length; i < il; ++i) {
             routes[i]._extNodes(event, nodes, options);
         }
-        
-        var specials = Object.keys(this._router.specials);
-        for (var j = 0, jl = specials.length; j < jl; ++j) {
-            
-            var special = this._router.specials[specials[j]];
+
+        // And to special routes (notFound, etc.)
+        var specialTypes = Object.keys(this._router.specials);
+        for (var j = 0, jl = specialTypes.length; j < jl; ++j) {
+
+            var special = this._router.specials[specialTypes[j]];
             if (special) {
                 special.route._extNodes(event, nodes, options);
             }
         }
-        
+
     }
 
 };

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -292,7 +292,7 @@ internals.pre = function (pre) {
 
 exports.invoke = function (request, event, callback) {
 
-    var exts = request.connection._extensions[event];
+    var exts = request._route._extensions[event] || request.connection._extensions[event];
     if (!exts) {
         return Hoek.nextTick(callback)();
     }

--- a/lib/route.js
+++ b/lib/route.js
@@ -5,6 +5,7 @@ var Catbox = require('catbox');
 var Hoek = require('hoek');
 var Joi = require('joi');
 var Subtext = require('subtext');
+var Topo = require('topo');
 var Auth = require('./auth');
 var Defaults = require('./defaults');
 var Handler = require('./handler');
@@ -61,6 +62,14 @@ exports = module.exports = internals.Route = function (options, connection, real
     this.server = connection.server;
     this.path = options.path;
     this.method = method;
+
+    // Let connection dictate route-specific extension points
+    this._extensions = {};
+
+    var extensions = Object.keys(this.connection._routeExtensions);
+    for (var i = 0, il = extensions.length; i < il; ++i) {
+        this._extensions[extensions[i]] = null;
+    }
 
     this.public = {
         method: this.method,
@@ -235,6 +244,36 @@ exports = module.exports = internals.Route = function (options, connection, real
     this.settings.handler = Handler.configure(this.settings.handler, this);
     this._prerequisites = Handler.prerequisites(this.settings.pre, this.server);
 
+    // Extensions
+
+    // Add existing extensions from connection
+    var routeExtensions = this.connection._routeExtensions;
+    var events = Object.keys(routeExtensions);
+    for (var i = 0, il = events.length; i < il; ++i) {
+
+        var extensions = routeExtensions[events[i]];
+
+        if (extensions) {
+            for (var j = 0, jl = extensions.length; j < jl; ++j) {
+                this._extNodes(events[i], extensions[j].nodes, extensions[j].settings);
+            }
+        }
+    }
+
+    // Add route-specific extensions
+    /*if (this.settings.ext) {
+    
+        var ext = this.settings.ext;
+
+        var events = Object.keys(ext);
+        for (var i = 0, il = events.length; i < il; ++i) {
+        
+            var event = events[i];
+            
+            this._ext(event, ext[event]);
+        }
+    }*/
+
     // Route lifecycle
 
     this._cycle = this.lifecycle();
@@ -253,6 +292,42 @@ internals.compileRule = function (rule) {
                                                                                  : Joi.compile(rule));
 };
 
+/*internals.Route.prototype._ext = function (event, func, options, realm) {
+
+    options = options || {};
+
+    var self = this;
+
+    Hoek.assert(this._extensions[event] !== undefined, 'Unknown event type', event);
+
+    var settings = {
+        before: options.before,
+        after: options.after,
+        group: realm.plugin
+    };
+
+    var nodes = [];
+    ([].concat(func)).forEach(function (fn, i) {
+
+        var node = {
+            func: fn,               // function (request, next) { next(); }
+            realm: realm,
+            bind: options.bind
+        };
+
+        nodes.push(node);
+    });
+
+    this._extNodes(nodes, settings);
+};*/
+
+internals.Route.prototype._extNodes = function (event, nodes, settings) {
+
+    Hoek.assert(this._extensions[event] !== undefined, 'Unknown event type', event);
+
+    this._extensions[event] = this._extensions[event] || new Topo();
+    this._extensions[event].add(nodes, settings);
+};
 
 internals.Route.prototype.lifecycle = function () {
 
@@ -320,7 +395,6 @@ internals.Route.prototype.lifecycle = function () {
 
     return cycle;
 };
-
 
 internals.state = function (request, next) {
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -253,23 +253,12 @@ exports = module.exports = internals.Route = function (options, connection, real
         var exts = routeExtensions[extPoints[k]] || [];
 
         for (var l = 0, ll = exts.length; l < ll; ++l) {
-            this._extNodes(extPoints[k], exts[l].nodes, exts[l].options);
+            this._ext(extPoints[k], exts[l].nodes, exts[l].options);
         }
     }
 
     // Add route-specific extensions
-    /*if (this.settings.ext) {
-
-        var ext = this.settings.ext;
-
-        var events = Object.keys(ext);
-        for (var i = 0, il = events.length; i < il; ++i) {
-
-            var event = events[i];
-
-            this._ext(event, ext[event]);
-        }
-    }*/
+    // (this.settings.ext) { ... }
 
     // Route lifecycle
 
@@ -289,41 +278,12 @@ internals.compileRule = function (rule) {
                                                                                  : Joi.compile(rule));
 };
 
-/*internals.Route.prototype._ext = function (event, func, options, realm) {
-
-    options = options || {};
-
-    var self = this;
-
-    Hoek.assert(this._extensions[event] !== undefined, 'Unknown event type', event);
-
-    var settings = {
-        before: options.before,
-        after: options.after,
-        group: realm.plugin
-    };
-
-    var nodes = [];
-    ([].concat(func)).forEach(function (fn, i) {
-
-        var node = {
-            func: fn,               // function (request, next) { next(); }
-            realm: realm,
-            bind: options.bind
-        };
-
-        nodes.push(node);
-    });
-
-    this._extNodes(nodes, settings);
-};*/
-
-internals.Route.prototype._extNodes = function (event, nodes, settings) {
+internals.Route.prototype._ext = function (event, nodes, options) {
 
     Hoek.assert(this._extensions[event] !== undefined, 'Unknown event type', event);
 
     this._extensions[event] = this._extensions[event] || new Topo();
-    this._extensions[event].add(nodes, settings);
+    this._extensions[event].add(nodes, options);
 };
 
 internals.Route.prototype.lifecycle = function () {

--- a/lib/route.js
+++ b/lib/route.js
@@ -66,9 +66,10 @@ exports = module.exports = internals.Route = function (options, connection, real
     // Let connection dictate route-specific extension points
     this._extensions = {};
 
-    var extensions = Object.keys(this.connection._routeExtensions);
-    for (var i = 0, il = extensions.length; i < il; ++i) {
-        this._extensions[extensions[i]] = null;
+    var routeExtensions = this.connection._routeExtensions;
+    var extPoints = Object.keys(routeExtensions);
+    for (var i = 0, il = extPoints.length; i < il; ++i) {
+        this._extensions[extPoints[i]] = null;
     }
 
     this.public = {
@@ -120,8 +121,8 @@ exports = module.exports = internals.Route = function (options, connection, real
         }
         else {
             this.settings.response.schema = internals.compileRule(rule);
-            for (var i = 0, il = statuses.length; i < il; ++i) {
-                var code = statuses[i];
+            for (var j = 0, jl = statuses.length; j < jl; ++j) {
+                var code = statuses[j];
                 this.settings.response.status[code] = internals.compileRule(this.settings.response.status[code]);
             }
         }
@@ -247,29 +248,25 @@ exports = module.exports = internals.Route = function (options, connection, real
     // Extensions
 
     // Add existing extensions from connection
-    var routeExtensions = this.connection._routeExtensions;
-    var events = Object.keys(routeExtensions);
-    for (var i = 0, il = events.length; i < il; ++i) {
+    for (var k = 0, kl = extPoints.length; k < kl; ++k) {
 
-        var extensions = routeExtensions[events[i]];
+        var exts = routeExtensions[extPoints[k]] || [];
 
-        if (extensions) {
-            for (var j = 0, jl = extensions.length; j < jl; ++j) {
-                this._extNodes(events[i], extensions[j].nodes, extensions[j].settings);
-            }
+        for (var l = 0, ll = exts.length; l < ll; ++l) {
+            this._extNodes(extPoints[k], exts[l].nodes, exts[l].options);
         }
     }
 
     // Add route-specific extensions
     /*if (this.settings.ext) {
-    
+
         var ext = this.settings.ext;
 
         var events = Object.keys(ext);
         for (var i = 0, il = events.length; i < il; ++i) {
-        
+
             var event = events[i];
-            
+
             this._ext(event, ext[event]);
         }
     }*/


### PR DESCRIPTION
This is part of the work for #2566.  Wanted to get some feedback, @hueniverse, before moving forward if you'd like me to.  This is meant to be a refactor of how lifecycle hooks are managed so that routes and connections each have their own list of dependency-managed hooks.

The approach is to let each connection keep track of route-level extensions in addition to their own `onRequest` extensions.  A route will pull-in its connection's route-level extensions when it's added.  When a new extension is added to a connection, it's also added to each route's (and special route's) list of extensions.

No tests have been added yet.  The one failing test (`188) Methods allows genreateTimeout to be false`) is failing on the current build.  There should be no API changes in this PR.  If this looks good it can be used to add lifecycle hooks to route configurations.

**Edit** Looks like some PRs have been merged in time to see no failing tests.