### PR TITLE
Updated error when calling server.start with no callback

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -127,6 +127,8 @@ internals.Server.prototype.start = function (callback) {
 
     var self = this;
 
+    Hoek.assert(typeof callback === 'function', 'Missing required start callback function');
+
     if (this._state === 'initialized') {
         return this._start(callback);
     }

--- a/test/server.js
+++ b/test/server.js
@@ -233,6 +233,17 @@ describe('Server', function () {
             }).to.throw('Cannot start server before plugins finished registration');
             done();
         });
+
+        it('fails to start when no callback is passed', function (done) {
+
+            var server = new Hapi.Server();
+
+            expect(function () {
+
+                server.start();
+            }).to.throw('Missing required start callback function');
+            done();
+        });
     });
 
     describe('stop()', function () {


### PR DESCRIPTION
Updated the start method of server to verify that a callback was
passed. If no callback is passed, a friendly error is thrown.

    Error: A callback is required when calling server.start

This is compared to the old error which required some digging
to find the cause of the problem.

    TypeError: callback is not a function

Related to #2705