### PR TITLE
Fix mis-documentation of various failAction options

### DIFF
--- a/API.md
+++ b/API.md
@@ -2106,13 +2106,6 @@ following options:
         - `'error'` - return a Bad Request (400) error response. This is the default value.
         - `'log'` - report the error but continue processing the request.
         - `'ignore'` - take no action and continue processing the request.
-        - a custom error handler function with the signature `function(request, reply, source, error)` where:
-            - `request` - the [request object](#request-object).
-            - `reply` - the continuation [reply interface](#reply-interface).
-            - `source` - the source of the invalid field (e.g. `'headers'`, `'params'`, `'query'`,
-              `'payload'`).
-            - `error` - the error object prepared for the client response (including the
-              validation function error under `error.data`).
     - `qs` - optional parsing options object passed to the [**qs** module](https://github.com/hapijs/qs).
     - `defaultContentType` - the default 'Content-Type' HTTP header value is not present.
       Defaults to `'application/json'`.
@@ -2146,13 +2139,6 @@ following options:
         - `error` - return an Internal Server Error (500) error response. This is the default
           value.
         - `log` - log the error but send the response.
-        - a custom error handler function with the signature `function(request, reply, source, error)` where:
-            - `request` - the [request object](#request-object).
-            - `reply` - the continuation [reply interface](#reply-interface).
-            - `source` - the source of the invalid field (e.g. `'headers'`, `'params'`, `'query'`,
-              `'payload'`).
-            - `error` - the error object prepared for the client response (including the
-              validation function error under `error.data`).
     - `modify` - if `true`, applies the validation rule changes to the response. Defaults to
       `false`.
     - `options` - options to pass to [Joi](http://github.com/hapijs/joi). Useful to set
@@ -2199,13 +2185,6 @@ following options:
         - `'error'` - return a Bad Request (400) error response. This is the default value.
         - `'log'` - report the error but continue processing the request.
         - `'ignore'` - take no action.
-        - a custom error handler function with the signature `function(request, reply, source, error)` where:
-            - `request` - the [request object](#request-object).
-            - `reply` - the continuation [reply interface](#reply-interface).
-            - `source` - the source of the invalid field (e.g. `'headers'`, `'params'`, `'query'`,
-              `'payload'`).
-            - `error` - the error object prepared for the client response (including the
-              validation function error under `error.data`).
 
 - `validate` - request input validation rules for various request components. When using a
   [Joi](http://github.com/hapijs/joi) validation object, the values of the other inputs (i.e.


### PR DESCRIPTION
As pointed out in #2746 there are various places in the docs that indicate a `failAction` callback can be provided.  Turns out that's not quite the case!  It can only be used with route validation options.  This PR removes it from cookie parsing, payload parsing, and response validation sections of the docs (#2741 fixed for route prerequisites).  Wouldn't mind if someone made double sure that these options can go, but as far as I can tell, the tests, schema, and codebase indicate that they can.