### PR TITLE
Missing tick in API docs.

### DIFF
--- a/API.md
+++ b/API.md
@@ -1077,7 +1077,7 @@ for performing injections, with some additional options and response properties:
       `artifacts` are used to bypass the default authentication strategies, and are validated
       directly as if they were received via an authentication scheme. Ignored if set without
       `credentials`. Defaults to no artifacts.
-    - `allowInternals` - allows access to routes with `config.isInternal` set to `true. Defaults to
+    - `allowInternals` - allows access to routes with `config.isInternal` set to `true`. Defaults to
       `false`.
     - `remoteAddress` - sets the remote address for the incoming connection.
     - `simulate` - an object with options used to simulate client request stream conditions for


### PR DESCRIPTION
Missing from https://github.com/hapijs/hapi/commit/69c9d737e21477c89a243802b44ac967eecbdcc#diff-88333ba11114e014e87198d04680144dR1080.