### PR TITLE
Fixed broken windows tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2014, Walmart and other contributors.
+Copyright (c) 2011-2015, Walmart and other contributors.
 Copyright (c) 2011, Yahoo Inc.
 All rights reserved.
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -1111,9 +1111,7 @@ describe('Connection', function () {
 
                 server.inject('/', function (res) {
 
-                    var EOL = Os.EOL;
-                    var html = '<div>' + EOL + '    <h1>hola!</h1>' + EOL + '</div>' + EOL;
-                    expect(res.result).to.equal(html);
+                    expect(res.result).to.match(/(?=.*[a-zA-Z])/);
                     done();
                 });
             });

--- a/test/connection.js
+++ b/test/connection.js
@@ -1111,7 +1111,9 @@ describe('Connection', function () {
 
                 server.inject('/', function (res) {
 
-                    expect(res.result).to.equal('<div>\n    <h1>hola!</h1>\n</div>\n');
+                    var EOL = Os.EOL;
+                    var html = '<div>' + EOL + '    <h1>hola!</h1>' + EOL + '</div>' + EOL;
+                    expect(res.result).to.equal(html);
                     done();
                 });
             });

--- a/test/connection.js
+++ b/test/connection.js
@@ -1111,7 +1111,7 @@ describe('Connection', function () {
 
                 server.inject('/', function (res) {
 
-                    expect(res.result).to.match(/(?=.*[a-zA-Z])/);
+                    expect(res.result.replace(/\r/g, '')).to.equal('<div>\n    <h1>hola!</h1>\n</div>\n');
                     done();
                 });
             });


### PR DESCRIPTION
When testing hapi on windows I found 2 broken tests, this PR is to fix this one https://github.com/hapijs/hapi/blob/master/test/connection.js#L1089-L1118 whilst the I cannot fix the other test here https://github.com/hapijs/hapi/blob/master/test/connection.js#L64-L73 as this is beyond me at the moment. 

Thanks