### PR TITLE
Detects and rejects malformed response headers

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -116,6 +116,22 @@ internals.Response.prototype._header = function (key, value, options) {
     options.separator = options.separator || ',';
     options.override = options.override !== false;
 
+    if ([].concat(value).some(function (val) {
+
+        if (!val) {
+            return false;
+        }
+        var headerBytes = typeof val === 'string' ? new Buffer(val) : val;
+        for (var i = 0; i < headerBytes.length; i++) {
+            if ((headerBytes[i] & 0x7f) !== headerBytes[i]) {
+
+                return true;
+            }
+        }
+    })) {
+        throw Boom.badImplementation('Header values must be ascii text');
+    }
+
     if ((!options.append && options.override) ||
         !this.headers[key]) {
 

--- a/test/response.js
+++ b/test/response.js
@@ -95,6 +95,30 @@ describe('Response', function () {
                 done();
             });
         });
+
+        it('throws error on non-ascii value', function (done) {
+
+            var thrown = false;
+
+            var handler = function (request, reply) {
+
+                try {
+                    return reply('ok').header('set-cookie', decodeURIComponent('%E0%B4%8Aset-cookie:%20foo=bar'));
+                } catch (e) {
+                    expect(e.message).to.equal('Header values must be ascii text');
+                    thrown = true;
+                }
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: 'GET', path: '/', handler: handler });
+            server.inject('/', function (res) {
+
+                expect(thrown).to.equal(true);
+                done();
+            });
+        });
     });
 
     describe('created()', function () {


### PR DESCRIPTION
This works around a byte truncation flaw in node core versions > 0.10
where the high bit is stripped from headers leading to a possible header
injection.