### PR TITLE
Add next to docs example for server.after

### DIFF
--- a/API.md
+++ b/API.md
@@ -475,9 +475,11 @@ var Hapi = require('hapi');
 var server = new Hapi.Server();
 server.connection({ port: 80 });
 
-server.after(function () {
+server.after(function (server, next) {
 
     // Perform some pre-start logic
+
+    next();
 });
 
 server.start(function (err) {

--- a/API.md
+++ b/API.md
@@ -475,7 +475,7 @@ var Hapi = require('hapi');
 var server = new Hapi.Server();
 server.connection({ port: 80 });
 
-server.after(function (server, next) {
+server.after(function (srv, next) {
 
     // Perform some pre-start logic
 


### PR DESCRIPTION
Tiny update to docs to show correct usage of `next` in `server.after` callback so that correct pieces are in place for anyone copying the example.