### PR TITLE
Add preload flag to HSTS header and fix casing for includeSubDomains.

### DIFF
--- a/API.md
+++ b/API.md
@@ -2161,7 +2161,7 @@ following options:
       be set to that number. Defaults to `true`. You may also specify an object with the
       following fields:
         - `maxAge` - the max-age portion of the header, as a number. Default is `15768000`.
-        - `includeSubdomains` - a boolean specifying whether to add the `includeSubdomains`
+        - `includeSubDomains` - a boolean specifying whether to add the `includeSubDomains`
           flag to the header.
         - `preload` - a boolean specifying whether to add the 'preload' flag (used to submit
           domains inclusion in Chrome's HTTP Strict Transport Security (HSTS) preload list)

--- a/API.md
+++ b/API.md
@@ -2163,6 +2163,9 @@ following options:
         - `maxAge` - the max-age portion of the header, as a number. Default is `15768000`.
         - `includeSubdomains` - a boolean specifying whether to add the `includeSubdomains`
           flag to the header.
+        - `preload` - a boolean specifying whether to add the 'preload' flag (used to submit
+          domains inclusion in Chrome's HTTP Strict Transport Security (HSTS) preload list)
+          to the header.
     - `xframe` - controls the 'X-Frame-Options' header. When set to `true` the header will
       be set to `DENY`, you may also specify a string value of 'deny' or 'sameorigin'. To
       use the 'allow-from' rule, you must set this to an object with the following fields:

--- a/lib/route.js
+++ b/lib/route.js
@@ -204,7 +204,10 @@ exports = module.exports = internals.Route = function (options, connection, real
             else {
                 security._hsts = 'max-age=' + (security.hsts.maxAge || 15768000);
                 if (security.hsts.includeSubdomains) {
-                    security._hsts += '; includeSubdomains';
+                    security._hsts += '; includeSubDomains';
+                }
+                if (security.hsts.preload) {
+                    security._hsts += '; preload';
                 }
             }
         }

--- a/lib/route.js
+++ b/lib/route.js
@@ -203,7 +203,7 @@ exports = module.exports = internals.Route = function (options, connection, real
             }
             else {
                 security._hsts = 'max-age=' + (security.hsts.maxAge || 15768000);
-                if (security.hsts.includeSubdomains) {
+                if (security.hsts.includeSubdomains || security.hsts.includeSubDomains) {
                     security._hsts += '; includeSubDomains';
                 }
                 if (security.hsts.preload) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -113,7 +113,9 @@ internals.routeBase = Joi.object({
         hsts: [
             Joi.object({
                 maxAge: Joi.number(),
-                includeSubdomains: Joi.boolean()
+                includeSubdomains: Joi.boolean(),
+                includeSubDomains: Joi.boolean(),
+                preload: Joi.boolean()
             }),
             Joi.boolean(),
             Joi.number()

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -2843,14 +2843,14 @@ describe('transmission', function () {
             };
 
             var server = new Hapi.Server();
-            server.connection({ routes: { security: { hsts: { maxAge: 123456789, includeSubdomains: true } } } });
+            server.connection({ routes: { security: { hsts: { maxAge: 123456789, includeSubDomains: true } } } });
             server.route({ method: 'GET', path: '/', handler: handler });
 
             server.inject({ url: '/' }, function (res) {
 
                 expect(res.result).to.exist();
                 expect(res.result).to.equal('Test');
-                expect(res.headers['strict-transport-security']).to.equal('max-age=123456789; includeSubdomains');
+                expect(res.headers['strict-transport-security']).to.equal('max-age=123456789; includeSubDomains');
                 done();
             });
         });
@@ -2890,7 +2890,47 @@ describe('transmission', function () {
 
                 expect(res.result).to.exist();
                 expect(res.result).to.equal('Test');
-                expect(res.headers['strict-transport-security']).to.equal('max-age=15768000; includeSubdomains');
+                expect(res.headers['strict-transport-security']).to.equal('max-age=15768000; includeSubDomains');
+                done();
+            });
+        });
+
+        it('returns correct hsts header when security.hsts is an object only specifying includeSubDomains', function (done) {
+
+            var handler = function (request, reply) {
+
+                return reply('Test');
+            };
+
+            var server = new Hapi.Server();
+            server.connection({ routes: { security: { hsts: { includeSubDomains: true } } } });
+            server.route({ method: 'GET', path: '/', handler: handler });
+
+            server.inject({ url: '/' }, function (res) {
+
+                expect(res.result).to.exist();
+                expect(res.result).to.equal('Test');
+                expect(res.headers['strict-transport-security']).to.equal('max-age=15768000; includeSubDomains');
+                done();
+            });
+        });
+
+        it('returns correct hsts header when security.hsts is an object only specifying includeSubDomains and preload', function (done) {
+
+            var handler = function (request, reply) {
+
+                return reply('Test');
+            };
+
+            var server = new Hapi.Server();
+            server.connection({ routes: { security: { hsts: { includeSubDomains: true, preload: true } } } });
+            server.route({ method: 'GET', path: '/', handler: handler });
+
+            server.inject({ url: '/' }, function (res) {
+
+                expect(res.result).to.exist();
+                expect(res.result).to.equal('Test');
+                expect(res.headers['strict-transport-security']).to.equal('max-age=15768000; includeSubDomains; preload');
                 done();
             });
         });


### PR DESCRIPTION
See https://scotthelme.co.uk/hsts-preloading/ for more information.

Also fixes casing issue in HSTS header: includeSubDomains - http://tools.ietf.org/html/rfc6797.