### PR TITLE
don't duplicate accept-encoding in vary header

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -143,6 +143,15 @@ internals.Response.prototype.vary = function (value) {
         this.headers.vary = value;
     }
     else if (this.headers.vary !== '*') {
+
+        var values = this.headers.vary.split(',');
+
+        for (var i = 0, il = values.length; i < il; ++i) {
+            if (values[i] === value) {
+                return this;
+            }
+        }
+
         this._header('vary', value, { append: true });
     }
 

--- a/test/response.js
+++ b/test/response.js
@@ -286,6 +286,26 @@ describe('Response', function () {
                 done();
             });
         });
+
+        it('sets Vary header with multiple similar and identical values', function (done) {
+
+            var handler = function (request, reply) {
+
+                return reply('ok').vary('x').vary('xyz').vary('xy').vary('x');
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: 'GET', path: '/', handler: handler });
+
+            server.inject('/', function (res) {
+
+                expect(res.result).to.equal('ok');
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers.vary).to.equal('x,xyz,xy');
+                done();
+            });
+        });
     });
 
     describe('etag()', function () {


### PR DESCRIPTION
This is in relation hapijs/h2o2#17 .

accept-encoding value in vary header was being duplicated. This fixes the issue and adds a test case to cover the scenario.

I could have fixed it instead in [lib/response.js](https://github.com/hapijs/hapi/blob/master/lib/response.js#L129), to not add a value if it already exists in a header but I thought that was too brittle to do there.

PS: forgot to say, I will make a lts PR if this is accepted.