### PR TITLE
Fixing server.views reference in Error Response example

### DIFF
--- a/API.md
+++ b/API.md
@@ -3066,12 +3066,18 @@ a different response object.
 var Hapi = require('hapi');
 var Inert = require('inert');
 var server = new Hapi.Server();
-server.register(Inert);
+
+server.register(Inert, function(err) {
+  if(err) console.log(err);
+});
 server.connection({ port: 80 });
-server.views({
-    engines: {
-        html: require('handlebars')
-    }
+
+server.register(require('vision'), function (err) {
+  server.views({
+      engines: {
+          html: require('handlebars')
+      }
+  });
 });
 
 server.ext('onPreResponse', function (request, reply) {

--- a/API.md
+++ b/API.md
@@ -3064,12 +3064,8 @@ a different response object.
 
 ```js
 var Hapi = require('hapi');
-var Inert = require('inert');
 var server = new Hapi.Server();
 
-server.register(Inert, function(err) {
-  if(err) console.log(err);
-});
 server.connection({ port: 80 });
 
 server.register(require('vision'), function (err) {


### PR DESCRIPTION
An Error Response example showing how to render a view doesn't register vision before calling server.views. Also, inert is unused in this example, since there are no static files being returned.