### PR TITLE
Backport 6c5ab9f and 23760c7. Do not duplicate vary header.

### DIFF
--- a/API.md
+++ b/API.md
@@ -2884,6 +2884,9 @@ The response object provides the following methods:
           `','`.
         - `override` - if `false`, the header value is not set if an existing value present.
           Defaults to `true`.
+        - `duplicate` - if `false`, the header value is not modified if the provided value is
+          already included. Does not apply when `append` is `false` or if the `name` is
+          `'set-cookie'`. Defaults to `true`.
 - `location(uri)` - sets the HTTP 'Location' header where:
     - `uri` - an absolute or relative URI used as the 'Location' header value.
 - `redirect(uri)` - sets an HTTP redirection response (302) and decorates the response with

--- a/lib/response.js
+++ b/lib/response.js
@@ -112,21 +112,32 @@ internals.Response.prototype.header = function (key, value, options) {
 internals.Response.prototype._header = function (key, value, options) {
 
     options = options || {};
-    options.append = options.append || false;
-    options.separator = options.separator || ',';
-    options.override = options.override !== false;
+    var append = options.append || false;
+    var separator = options.separator || ',';
+    var override = options.override !== false;
+    var duplicate = options.duplicate !== false;
 
-    if ((!options.append && options.override) ||
+    if ((!append && override) ||
         !this.headers[key]) {
 
         this.headers[key] = value;
     }
-    else if (options.override) {
+    else if (override) {
         if (key === 'set-cookie') {
             this.headers[key] = [].concat(this.headers[key], value);
         }
         else {
-            this.headers[key] = this.headers[key] + options.separator + value;
+            var existing = this.headers[key];
+            if (!duplicate) {
+                var values = existing.split(separator);
+                for (var i = 0, il = values.length; i < il; ++i) {
+                    if (values[i] === value) {
+                        return this;
+                    }
+                }
+            }
+
+            this.headers[key] = existing + separator + value;
         }
     }
 
@@ -143,7 +154,7 @@ internals.Response.prototype.vary = function (value) {
         this.headers.vary = value;
     }
     else if (this.headers.vary !== '*') {
-        this._header('vary', value, { append: true });
+        this._header('vary', value, { append: true, duplicate: false });
     }
 
     return this;

--- a/test/response.js
+++ b/test/response.js
@@ -286,6 +286,26 @@ describe('Response', function () {
                 done();
             });
         });
+
+        it('sets Vary header with multiple similar and identical values', function (done) {
+
+            var handler = function (request, reply) {
+
+                return reply('ok').vary('x').vary('xyz').vary('xy').vary('x');
+            };
+
+            var server = new Hapi.Server();
+            server.connection();
+            server.route({ method: 'GET', path: '/', handler: handler });
+
+            server.inject('/', function (res) {
+
+                expect(res.result).to.equal('ok');
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers.vary).to.equal('x,xyz,xy');
+                done();
+            });
+        });
     });
 
     describe('etag()', function () {

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -1774,6 +1774,45 @@ describe('transmission', function () {
             });
         });
 
+        it('does not set accept-encoding multiple times', function (done) {
+
+            var headersHandler = function (request, reply) {
+
+                reply({ status: 'success' })
+                    .vary('X-Custom3');
+            };
+
+            var upstream = new Hapi.Server();
+            upstream.connection();
+            upstream.route({ method: 'GET', path: '/headers', handler: headersHandler });
+            upstream.start(function () {
+
+                var proxyHandler = function (request, reply) {
+
+                    var options = {};
+                    options.headers = Hoek.clone(request.headers);
+                    delete options.headers.host;
+
+                    Wreck.request(request.method, 'http://localhost:' + upstream.info.port + '/headers', options, function (err, res) {
+
+                        reply(res).code(res.statusCode);
+                    });
+                };
+
+                var server = new Hapi.Server();
+                server.connection();
+                server.route({ method: 'GET', path: '/headers', handler: proxyHandler });
+
+                server.inject({ url: '/headers', headers: { 'accept-encoding': 'gzip' } }, function (res) {
+
+                    expect(res.statusCode).to.equal(200);
+                    expect(res.headers.vary).to.equal('X-Custom3,accept-encoding');
+
+                    upstream.stop(done);
+                });
+            });
+        });
+
         describe('response range', function () {
 
             var fileStreamHandler = function (request, reply) {


### PR DESCRIPTION
This PR is to support hapijs/h2o2#17

There seems to be problems with Inert on my LTS copy. So if the tests fail with `Object [object Object] has no method 'attempt'` it's not this PR that's adding it.

```
Object [object Object] has no method 'attempt'

      at exports.handler (/Users/ldespla/github/hapi/node_modules/inert/lib/file.js:33:24)
      at Object.exports.configure (/Users/ldespla/github/hapi/lib/handler.js:124:89)
      at new module.exports.internals.Route (/Users/ldespla/github/hapi/lib/route.js:232:108)
      at internals.Connection._addRoute (/Users/ldespla/github/hapi/lib/connection.js:359:93)
      at internals.Connection._route (/Users/ldespla/github/hapi/lib/connection.js:351:94)
      at internals.Plugin._apply (/Users/ldespla/github/hapi/lib/plugin.js:497:86)
      at internals.Plugin.route (/Users/ldespla/github/hapi/lib/plugin.js:470:82)
      at /Users/ldespla/github/hapi/test/transmit.js:2719:20
      at Object._onImmediate (/Users/ldespla/github/hapi/node_modules/lab/lib/runner.js:455:17)
      at processImmediate [as _immediateCallback] (timers.js:363:15)
```