### PR TITLE
Expose original handler options as a property of the handler function

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -121,7 +121,10 @@ exports.configure = function (handler, route) {
 
         Hoek.assert(serverHandler, 'Unknown handler:', type);
 
-        return serverHandler(route.public, handler[type]);
+        var handlerOptions = handler[type];
+        var handlerFunction = serverHandler(route.public, handlerOptions);
+        handlerFunction[type] = handlerOptions;
+        return handlerFunction;
     }
 
     if (typeof handler === 'string') {


### PR DESCRIPTION
When handler options is an Object we just turn it to a function and there's no way to access the original handler options.

We could simply add the original handler options object as a property of the handler function and this is what this PR does.

(My use case is to provide access to proxy options to my plugin which sets up mock replies using nock for local integration testing)