### PR TITLE
Fixed an issue with mixed-case headers not being matched correctly in CORS

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -118,7 +118,15 @@ internals.handler = function (request, reply) {
     var headers = request.headers['access-control-request-headers'];
     if (headers) {
         headers = headers.split(/\s*,\s*/);
-        if (Hoek.intersect(headers, settings._headers).length !== headers.length) {
+        if (Hoek.intersect(headers.map(function (header) {
+
+            return header.toLowerCase();
+
+        }), settings._headers.map(function (header) {
+
+            return header.toLowerCase();
+
+        })).length !== headers.length) {
             return reply(Boom.notFound('Some headers are not allowed'));
         }
     }


### PR DESCRIPTION
After the CORS rework, headers seem to be matched in a case-sensitive way.
Therefore, even if a header is allowed...
```
cors: {
    additionalHeaders: [
        "X-Requested-With"
    ]
}
```
... and the browser sends it (with a different case)...
```
Access-Control-Request-Headers: x-requested-with
```
... it won't match, thus causing the CORS preflight request to fail.

This fixes it.

The horrible blank lines are there to please the linter.
Feel free to rewrite it differently.