### PR TITLE
Fix empty content-length handling for gzip and 204 responses

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -129,7 +129,7 @@ internals.Response.prototype._header = function (key, value, options) {
             for (var b = 0, bl = buffer.length; b < bl; ++b) {
                 Hoek.assert((buffer[b] & 0x7f) === buffer[b], 'Header value cannot contain or convert into non-ascii characters:', key);
             }
-        };
+        }
     }
 
     if ((!append && override) ||

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -180,11 +180,11 @@ internals.transmit = function (response, callback) {
 
     var request = response.request;
     var source = response._payload;
-    var length = response.headers['content-length'] ? parseInt(response.headers['content-length'], 10) : 0;      // In case value is a string
+    var length = parseInt(response.headers['content-length'], 10);      // In case value is a string
 
     // Empty response
 
-    if (!length &&
+    if (length === 0 &&
         response.statusCode === 200 &&
         request.route.settings.response.emptyStatusCode === 204) {
 
@@ -202,7 +202,7 @@ internals.transmit = function (response, callback) {
 
     if (request.method === 'get' &&
         response.statusCode === 200 &&
-        length &&
+        length > 0 &&
         !encoding) {
 
         if (request.headers.range) {
@@ -243,7 +243,7 @@ internals.transmit = function (response, callback) {
     }
 
     if (encoding &&
-        length &&
+        length !== 0 &&
         response._isPayloadSupported()) {
 
         delete response.headers['content-length'];


### PR DESCRIPTION
The transmit logic incorrectly considers missing `content-length` headers as having a payload length of `0`, while it usually signals that chunked transfer encoding should be used (with any actual length).

This patch fixes this by always parsing the header value, and testing using integer comparisons instead of the current truthiness tests.

I have added 2 new tests to verify the chunked response behavior. I also fixed an existing compression test, which was actually not working as intended due to not signalling a compressible mime type.