### PR TITLE
Fix shrinkwrap file so the required version of subtext is loaded.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -70,7 +70,7 @@
             "version": "2.1.1"
         },
         "subtext": {
-            "version": "2.0.0",
+            "version": "2.0.2",
             "dependencies": {
                 "content": {
                     "version": "1.0.2"


### PR DESCRIPTION
This will resolve the issue related to qs@4.x.x vs qs@5.x.x in subtext.
