### PR TITLE
add Origin to CORS header

### DIFF
--- a/API.md
+++ b/API.md
@@ -2127,7 +2127,7 @@ following options:
       ('Access-Control-Max-Age'). The greater the value, the longer it will take before the
       browser checks for changes in policy. Defaults to `86400` (one day).
     - `headers` - a strings array of allowed headers ('Access-Control-Allow-Headers').
-      Defaults to `['Accept', 'Authorization', 'Content-Type', 'If-None-Match']`.
+      Defaults to `['Accept', 'Authorization', 'Content-Type', 'If-None-Match', 'Origin']`.
     - `additionalHeaders` - a strings array of additional headers to `headers`. Use this to
       keep the default headers in place.
     - `exposedHeaders` - a strings array of exposed headers

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -87,7 +87,8 @@ exports.cors = {
         'Accept',
         'Authorization',
         'Content-Type',
-        'If-None-Match'
+        'If-None-Match',
+        'Origin'
     ],
     additionalHeaders: [],
     exposedHeaders: [

--- a/test/cors.js
+++ b/test/cors.js
@@ -534,37 +534,11 @@ describe('CORS', () => {
             }, (res) => {
 
                 expect(res.statusCode).to.equal(200);
-                expect(res.headers['access-control-allow-headers']).to.equal('Accept,Authorization,Content-Type,If-None-Match');
+                expect(res.headers['access-control-allow-headers']).to.equal('Accept,Authorization,Content-Type,If-None-Match,Origin');
                 done();
             });
         });
 
-        it('matches allowed headers (case insensitive', (done) => {
-
-            const handler = function (request, reply) {
-
-                return reply('ok');
-            };
-
-            const server = new Hapi.Server();
-            server.connection({ routes: { cors: true } });
-            server.route({ method: 'GET', path: '/', handler: handler });
-
-            server.inject({
-                method: 'OPTIONS',
-                url: '/',
-                headers: {
-                    origin: 'http://test.example.com',
-                    'access-control-request-method': 'GET',
-                    'access-control-request-headers': 'authorization'
-                }
-            }, (res) => {
-
-                expect(res.statusCode).to.equal(200);
-                expect(res.headers['access-control-allow-headers']).to.equal('Accept,Authorization,Content-Type,If-None-Match');
-                done();
-            });
-        });
 
         it('errors on disallowed headers', (done) => {
 


### PR DESCRIPTION
solves #2894 

Add 'Origin' to CORS headers for Safari requests.
Removed duplicate test.