### PR TITLE
Lookup route during OPTIONS by using request.info.hostname. Closes #2930

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -98,7 +98,7 @@ internals.handler = function (request, reply) {
 
     // Lookup route
 
-    const route = request.connection.match(method, request.path, request.headers.host);
+    const route = request.connection.match(method, request.path, request.info.hostname);
     if (!route) {
         return reply(Boom.notFound());
     }

--- a/test/cors.js
+++ b/test/cors.js
@@ -664,6 +664,26 @@ describe('CORS', () => {
                 done();
             });
         });
+
+        it('correctly finds route when using vhost setting', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection({ routes: { cors: true } });
+            server.route({
+                method: 'POST',
+                vhost: 'example.com',
+                path: '/',
+                handler: function (request, reply) { }
+            });
+
+            server.inject({ method: 'OPTIONS', url: 'http://example.com:4000/', headers: { origin: 'http://localhost', 'access-control-request-method': 'POST' } }, (res) => {
+
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['access-control-allow-methods']).to.equal('POST');
+                done();
+            });
+        });
     });
 
     describe('headers()', () => {


### PR DESCRIPTION
During a normal request the route is looked up using the [value of `request.info.hostname`](https://github.com/hapijs/hapi/blob/master/lib/request.js#L331):
```javascript
const match = this.connection._router.route(this.method, this.path, this.info.hostname);
```

However during an OPTIONS request, it's currently being looked up via the [value of `request.headers.host`](https://github.com/hapijs/hapi/blob/master/lib/cors.js#L101):
```javascript
const route = request.connection.match(method, request.path, request.headers.host);
```
These values are different when not using port 80, therfore this can cause the route not to be found correctly when there's a vhost setting on a route as per https://github.com/hapijs/glue/issues/38 https://github.com/hapijs/hapi/issues/2930.