### PR TITLE
Fails to set a global route auth config

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -380,8 +380,8 @@ internals.Connection.prototype._addRoute = function (config, plugin) {
 
 internals.Connection.prototype._defaultRoutes = function () {
 
-    this._router.special('notFound', new Route({ method: '_special', path: '/{p*}', handler: internals.notFound }, this, this.server, { special: true }));
-    this._router.special('badRequest', new Route({ method: '_special', path: '/{p*}', handler: internals.badRequest }, this, this.server, { special: true }));
+    this._router.special('notFound', new Route({ config: { auth: false }, method: '_special', path: '/{p*}', handler: internals.notFound }, this, this.server, { special: true }));
+    this._router.special('badRequest', new Route({ config: { auth: false }, method: '_special', path: '/{p*}', handler: internals.badRequest }, this, this.server, { special: true }));
 
     if (this.settings.routes.cors) {
         Cors.handler(this);

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -77,7 +77,7 @@ exports.handler = function (connection) {
         return;
     }
 
-    const route = new Route({ method: '_special', path: '/{p*}', handler: internals.handler }, connection, connection.server, { special: true });
+    const route = new Route({ config: { auth: false }, method: '_special', path: '/{p*}', handler: internals.handler }, connection, connection.server, { special: true });
     connection._router.special('options', route);
 };
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -53,6 +53,16 @@ describe('Connection', () => {
         done();
     });
 
+    it('does not throw when given a default authentication strategy', (done) => {
+
+        expect(() => {
+
+            const server = new Hapi.Server({ connections: { routes: { auth: 'test' } } });
+            server.connection();
+        }).not.to.throw();
+        done();
+    });
+
     it('throws when disabling autoListen and providing a port', (done) => {
 
         const server = new Hapi.Server();


### PR DESCRIPTION
After the [recent special routes changes](https://github.com/hapijs/hapi/commit/98d34046392006540b64a799b6ca58150d08df2c#diff-259dec4414a400a6e895f16ff1d0ca3bR377), a server configured to use an authentication strategy by default for all routes...
```
const server = new Hapi.Server({ connections: { routes: { auth: "foo" } });
server.connection(...);
...
server.auth.strategy("foo", ..., ...);
```
... would fail to start and instead throw an error.
```
Unknown authentication strategy: foo in path: /{p*}
```
I also doubt the special routes are supposed to require authentication in the first place, as they didn't till the aforementioned commit.

This fixes it.

However, it might be better to just ignore authentication-related options for routes where `method === "_special"`, instead of passing `config: { auth: false }` every time.