### PR TITLE
Update hapijs/subtext to 3.0.1 from 3.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -70,7 +70,7 @@
             "version": "3.0.0"
         },
         "subtext": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "dependencies": {
                 "content": {
                     "version": "3.0.0"


### PR DESCRIPTION
This contains a fix in subtext where timeouts weren't respected on multipart payloads, fixing https://github.com/hapijs/subtext/issues/19. 

Related: https://github.com/hapijs/hapi/issues/2825 and https://github.com/hapijs/discuss/issues/171