### PR TITLE
allow origin header to be capitalized

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -156,13 +156,13 @@ exports.headers = function (response) {
 
     response.vary('origin');
 
-    if (!request.headers.origin ||
-        !internals.matchOrigin(request.headers.origin, settings)) {
+    const origin = request.headers.origin || request.headers.Origin;
 
+    if (!origin || !internals.matchOrigin(origin, settings)) {
         return;
     }
 
-    response._header('access-control-allow-origin', request.headers.origin);
+    response._header('access-control-allow-origin', origin);
 
     if (settings.credentials) {
         response._header('access-control-allow-credentials', 'true');

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -86,7 +86,7 @@ internals.handler = function (request, reply) {
 
     // Validate CORS preflight request
 
-    const origin = request.headers.origin;
+    const origin = request.headers.origin || request.headers.Origin;
     if (!origin) {
         return reply(Boom.notFound('CORS error: Missing Origin header'));
     }

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -127,7 +127,7 @@ internals.handler = function (request, reply) {
     // Reply with the route CORS headers
 
     const response = reply();
-    response._header('access-control-allow-origin', request.headers.origin);
+    response._header('access-control-allow-origin', origin);
     response._header('access-control-allow-methods', method);
     response._header('access-control-allow-headers', settings._headersString);
     response._header('access-control-max-age', settings.maxAge);

--- a/test/cors.js
+++ b/test/cors.js
@@ -59,6 +59,24 @@ describe('CORS', () => {
         });
     });
 
+    it('returns OPTIONS response if origin header is capitalized', (done) => {
+
+        const handler = function (request, reply) {
+
+            return reply(Boom.badRequest());
+        };
+
+        const server = new Hapi.Server();
+        server.connection({ routes: { cors: true } });
+        server.route({ method: 'GET', path: '/', handler: handler });
+
+        server.inject({ method: 'OPTIONS', url: '/', headers: { Origin: 'http://example.com/', 'access-control-request-method': 'GET' } }, (res) => {
+
+            expect(res.headers['access-control-allow-origin']).to.equal('http://example.com/');
+            done();
+        });
+    });
+
     it('returns OPTIONS response (server config)', (done) => {
 
         const handler = function (request, reply) {


### PR DESCRIPTION
If origin header is capitalized, hapi returns a 404 for CORS preflight (OPTIONS) request.