### PR TITLE
Add validation check for stripUnknown route response option

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -129,7 +129,8 @@ internals.routeBase = Joi.object({
         modify: Joi.boolean(),
         options: Joi.object()
     })
-        .without('modify', 'sample'),
+        .without('modify', 'sample')
+        .assert('options.stripUnknown', Joi.ref('modify'), 'meet requirement of having peer modify set to true'),
     security: Joi.object({
         hsts: [
             Joi.object({

--- a/test/validation.js
+++ b/test/validation.js
@@ -1610,7 +1610,7 @@ describe('validation', () => {
                 }
             });
         }).to.throw(/"options.stripUnknown" failed to meet requirement of having peer modify set to true/);
-        
+
         done();
     });
 });

--- a/test/validation.js
+++ b/test/validation.js
@@ -1585,6 +1585,34 @@ describe('validation', () => {
             done();
         });
     });
+
+    it('throws on options.stripUnknown without modify', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+
+        expect(() => {
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: function (request, reply) {
+
+                    return reply('ok');
+                },
+                config: {
+                    response: {
+                        schema: Joi.string(),
+                        options: {
+                            stripUnknown: true
+                        }
+                    }
+                }
+            });
+        }).to.throw(/"options.stripUnknown" failed to meet requirement of having peer modify set to true/);
+        
+        done();
+    });
 });
 
 


### PR DESCRIPTION
This might save someone some time debugging in the future. Currently we can add:
````javascript
server.route({
    method: 'GET',
    path: '/',
    handler: function (request, reply) {

        return reply('ok');
    },
    config: {
        response: {
            schema: Joi.string(),
            options: {
                stripUnknown: true
            }
        }
    }
});
````
Which actually wouldn't strip any unknown keys without the `modify` key set true. With this PR if we add a route with response option `stripUnknown` set true without `modify` set to true, it will throw a validation error.