### PR TITLE
Allow custom expect-100 logic

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -86,6 +86,7 @@ exports = module.exports = internals.Connection = function (server, options) {
 
     this.listener = this.settings.listener || (this.settings.tls ? Https.createServer(this.settings.tls) : Http.createServer());
     this.listener.on('request', this._dispatch());
+    this.listener.on('checkContinue', this._dispatch());
     this._init();
 
     this.listener.on('clientError', (err, socket) => {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -53,6 +53,7 @@ exports.connection = {
         },
         response: {
             emptyStatusCode: 200,                   // HTTP status code when payload is empty (200, 204)
+            autoContinue: true,                     // Reply with 100 Continue if client expects it
             options: {}                             // Joi validation options
         },
         security: false,                            // Security headers on responses: false -> null, true -> defaults, {} -> override defaults

--- a/lib/request.js
+++ b/lib/request.js
@@ -115,7 +115,8 @@ internals.Request = function (connection, req, res, options) {
         remotePort: req.connection.remotePort || '',
         referrer: req.headers.referrer || req.headers.referer || '',
         host: req.headers.host ? req.headers.host.replace(/\s/g, '') : '',
-        acceptEncoding: Accept.encoding(this.headers['accept-encoding'], ['identity', 'gzip', 'deflate'])
+        acceptEncoding: Accept.encoding(this.headers['accept-encoding'], ['identity', 'gzip', 'deflate']),
+        expectContinue: (req.headers.expect === '100-continue')
     };
 
     this.info.hostname = this.info.host.split(':')[0];
@@ -336,6 +337,14 @@ internals.Request.prototype._lifecycle = function (err) {
 
     this.params = match.params || {};
     this.paramsArray = match.paramsArray || [];
+
+    // reply 100 Continue if autoContinue is set
+    if (this.info.expectContinue &&
+      this.route.settings.response.autoContinue === true) {
+
+        this.raw.res.writeContinue();
+        this.info.expectContinue = false;
+    }
 
     // Setup timeout
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -126,6 +126,7 @@ internals.routeBase = Joi.object({
         sample: Joi.number().min(0).max(100),
         failAction: Joi.string().valid('error', 'log'),
         modify: Joi.boolean(),
+        autoContinue: Joi.boolean(),
         options: Joi.object()
     })
         .without('modify', 'sample')

--- a/test/connection.js
+++ b/test/connection.js
@@ -1743,4 +1743,63 @@ describe('Connection', () => {
             });
         });
     });
+
+    it('responds to requests which expect 100-continue by default', (done) => {
+
+        const handler = function (request, reply) {
+
+            return reply('ok');
+        };
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.route({ method: 'GET', path: '/', handler: handler });
+        server.inject({
+            method: 'HEAD', url: '/',
+            headers: {
+                expect: '100-continue'
+            }
+        }, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.request.info.expectContinue).to.equal(false);
+            expect(res.headers['content-type']).to.contain('text/html');
+            expect(res.result).to.not.exist();
+            done();
+        });
+    });
+
+    it('does\'t responds to reqs which expect 100-continue if autoContinue is false', (done) => {
+
+        const handler = function (request, reply) {
+
+            return reply('ok');
+        };
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: handler,
+            config: {
+                response: {
+                    autoContinue: false
+                }
+            }
+        });
+        server.inject({
+            method: 'HEAD', url: '/',
+            headers: {
+                expect: '100-continue'
+            }
+        }, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.request.info.expectContinue).to.equal(true);
+            expect(res.headers['content-type']).to.contain('text/html');
+            expect(res.result).to.not.exist();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Hello,

while testing upload related stuff with hapi I noticed that there currently is no option to prevent [node from sending `100-continue`](https://nodejs.org/dist/latest-v5.x/docs/api/http.html#http_event_checkcontinue) for an requests where the client expects it (`Expect: 100-continue` Header).

This PR adds the possibility to send the 100-continue when needed (for example after validation). For now this has to be done via `request.raw.req.sendContinue()`.
I thought about adding a method to `reply`, but there already is `reply.continue()` which could be easily confused.

I've also added an option (`autoContinue`) which sends `100-continue`s to requests which expect it. (This defaults to true, so hapi still behaves the same way)

This is my first PR to hapi. I'm expecting that I did everything wrong that can be done wrong ;)
I'm open for criticism and am expecting changes to this PR before the merge.
Also I'm not sure if the tests are testing enough.

hapi new year's eve! :fireworks: :tada: :heart: 

