### PR TITLE
Fix hapijs/shot dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "kilt": "2.x.x",
     "mimos": "3.x.x",
     "peekaboo": "2.x.x",
-    "shot": "2.x.x",
+    "shot": "3.x.x",
     "statehood": "3.x.x",
     "subtext": "4.x.x",
     "topo": "2.x.x"


### PR DESCRIPTION
It conflicts with the shrink-wrapped version. npm gets confused.