### PR TITLE
Update JSON response stringify for better performance

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -497,7 +497,8 @@ internals.Response.prototype._streamify = function (source, next) {
         const replacer = options.replacer || this.request.route.settings.json.replacer;
         const suffix = options.suffix || this.request.route.settings.json.suffix || '';
         try {
-            payload = JSON.stringify(payload, replacer, space);
+            var arguments = replacer || space ? [payload, replacer, space] : [payload];
+            payload = JSON.stringify.apply(JSON, arguments);
         }
         catch (err) {
             return next(err);

--- a/lib/response.js
+++ b/lib/response.js
@@ -499,7 +499,7 @@ internals.Response.prototype._streamify = function (source, next) {
         try {
             if (replacer || space) {
                 payload = JSON.stringify(payload, replacer, space);
-            } 
+            }
             else {
                 payload = JSON.stringify(payload);
             }

--- a/lib/response.js
+++ b/lib/response.js
@@ -497,8 +497,11 @@ internals.Response.prototype._streamify = function (source, next) {
         const replacer = options.replacer || this.request.route.settings.json.replacer;
         const suffix = options.suffix || this.request.route.settings.json.suffix || '';
         try {
-            var arguments = replacer || space ? [payload, replacer, space] : [payload];
-            payload = JSON.stringify.apply(JSON, arguments);
+            if (replacer || space) {
+                payload = JSON.stringify(payload, replacer, space);
+            } else {
+                payload = JSON.stringify(payload);
+            }
         }
         catch (err) {
             return next(err);

--- a/lib/response.js
+++ b/lib/response.js
@@ -499,7 +499,8 @@ internals.Response.prototype._streamify = function (source, next) {
         try {
             if (replacer || space) {
                 payload = JSON.stringify(payload, replacer, space);
-            } else {
+            } 
+            else {
                 payload = JSON.stringify(payload);
             }
         }


### PR DESCRIPTION
Hi, I've been doing some profiling to a REST API I've been working on and noticed that, for large JSON responses, a lot of time was being spent stringifying the actual responses. After some digging, I found out that the performance of the native V8 JSON.stringify degrades very quickly when the method is called with more than 1 argument (the Javascript object to stringify itself), even if the other arguments are null or undefined.

I've done some simple but yet conclusive tests with JSON.stringify and got some results to share:

* Object to stringify: [fathers.txt](https://github.com/hapijs/hapi/files/80244/fathers.txt)
* Script used:

```javascript
// Copy pasted data into variable fathers.
var fathers = ....;

// Test 1.
var startTime = Date.now();
JSON.stringify(fathers, null, null);
console.log(Date.now() - startTime);
// Prints 215.

// Test 2.
startTime = Date.now();
JSON.stringify(fathers);
console.log(Date.now() - startTime);
// Prints 20.
```

Hapi is currently stringifying all JSON response objects calling JSON.stringify always with all the 3 arguments, even if the last 2 are null. I updated the JSON.stringify call in Hapi to use this last 2 arguments only when they have non falsy values.