### PR TITLE
Enable disabling cache-control headers

### DIFF
--- a/API.md
+++ b/API.md
@@ -2223,7 +2223,9 @@ following options:
   Ignored if the method is an arrow function.
 
 - `cache` - if the route method is 'GET', the route can be configured to include caching
-  directives in the response using the following options:
+  directives in the response.
+  The default `Cache-Control: no-cache` header can be disabled by setting `cache` to `false`.
+  Caching can be customized using an object with the following options:
     - `privacy` - determines the privacy flag included in client-side caching using the
       'Cache-Control' header. Values are:
         - `'default'` - no privacy flag. This is the default setting.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -66,7 +66,7 @@ internals.routeBase = Joi.object({
         expiresAt: Joi.string(),
         privacy: Joi.string().valid('default', 'public', 'private'),
         statuses: Joi.array().items(Joi.number().integer().min(200)).min(1)
-    }),
+    }).allow(false),
     cors: Joi.object({
         origin: Joi.array().min(1),
         maxAge: Joi.number(),

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -378,11 +378,12 @@ internals.Empty.prototype._read = function (/* size */) {
 
 internals.cache = function (response) {
 
-    if (response.headers['cache-control']) {
+    const request = response.request;
+
+    if (response.headers['cache-control'] || request.route.settings.cache === false ) {
         return;
     }
 
-    const request = response.request;
     const policy = request._route._cache && (request.route.settings.cache._statuses[response.statusCode] || (response.statusCode === 304 && request.route.settings.cache._statuses['200']));
     if (policy ||
         response.settings.ttl) {

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -566,7 +566,7 @@ describe('transmission', () => {
             });
         });
 
-        it('sets caching headers', (done) => {
+        it('sets specific caching headers', (done) => {
 
             const server = new Hapi.Server();
             server.register(Inert, Hoek.ignore);
@@ -577,6 +577,36 @@ describe('transmission', () => {
 
                 expect(res.statusCode).to.equal(200);
                 expect(res.headers['cache-control']).to.equal('max-age=86400, must-revalidate, public');
+                done();
+            });
+        });
+
+        it('sets caching headers', (done) => {
+
+            const server = new Hapi.Server();
+            server.register(Inert, Hoek.ignore);
+            server.connection();
+            server.route({ method: 'GET', path: '/public/{path*}', handler: { directory: { path: __dirname, listing: false, index: false } } });
+
+            server.inject('/public/transmit.js', (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['cache-control']).to.equal('no-cache');
+                done();
+            });
+        });
+
+        it('does not set caching headers if disabled', (done) => {
+
+            const server = new Hapi.Server();
+            server.register(Inert, Hoek.ignore);
+            server.connection();
+            server.route({ method: 'GET', path: '/public/{path*}', config: { cache: false }, handler: { directory: { path: __dirname, listing: false, index: false } } });
+
+            server.inject('/public/transmit.js', (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers['cache-control']).to.be.undefined();
                 done();
             });
         });


### PR DESCRIPTION
Sometimes you just don't want Cache-Control headers at all.

One example is old IE versions not loading fonts with a Cache-Control header.