### PR TITLE
Don't re-initialize the server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -176,21 +176,21 @@ internals.Server.prototype.initialize = function (callback) {
         return Promises.wrap(this, this.initialize);
     }
 
-    const errorCallback = Hoek.nextTick(callback);
+    const nextTickCallback = Hoek.nextTick(callback);
     if (!this.connections.length) {
-        return errorCallback(new Error('No connections to start'));
+        return nextTickCallback(new Error('No connections to start'));
     }
 
     if (this._registring) {
-        return errorCallback(new Error('Cannot start server before plugins finished registration'));
+        return nextTickCallback(new Error('Cannot start server before plugins finished registration'));
     }
 
     if (this._state === 'initialized') {
-        return callback();
+        return nextTickCallback();
     }
 
     if (this._state !== 'stopped') {
-        return errorCallback(new Error('Cannot initialize server while it is in ' + this._state + ' state'));
+        return nextTickCallback(new Error('Cannot initialize server while it is in ' + this._state + ' state'));
     }
 
     // Assert dependencies
@@ -203,7 +203,7 @@ internals.Server.prototype.initialize = function (callback) {
                 for (let k = 0; k < dependency.deps.length; ++k) {
                     const dep = dependency.deps[k];
                     if (!connection.registrations[dep]) {
-                        return errorCallback(new Error('Plugin ' + dependency.plugin + ' missing dependency ' + dep + ' in connection: ' + connection.info.uri));
+                        return nextTickCallback(new Error('Plugin ' + dependency.plugin + ' missing dependency ' + dep + ' in connection: ' + connection.info.uri));
                     }
                 }
             }
@@ -212,7 +212,7 @@ internals.Server.prototype.initialize = function (callback) {
             for (let j = 0; j < dependency.deps.length; ++j) {
                 const dep = dependency.deps[j];
                 if (!this._registrations[dep]) {
-                    return errorCallback(new Error('Plugin ' + dependency.plugin + ' missing dependency ' + dep));
+                    return nextTickCallback(new Error('Plugin ' + dependency.plugin + ' missing dependency ' + dep));
                 }
             }
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -185,6 +185,10 @@ internals.Server.prototype.initialize = function (callback) {
         return errorCallback(new Error('Cannot start server before plugins finished registration'));
     }
 
+    if (this._state === 'initialized') {
+        return callback();
+    }
+
     if (this._state !== 'stopped') {
         return errorCallback(new Error('Cannot initialize server while it is in ' + this._state + ' state'));
     }

--- a/test/server.js
+++ b/test/server.js
@@ -192,6 +192,23 @@ describe('Server', () => {
             });
         });
 
+        it('does not re-initialize the server', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            server.initialize((err) => {
+
+                expect(err).to.not.exist();
+
+                server.initialize((err) => {
+
+                    expect(err).to.not.exist();
+                    done();
+                });
+            });
+        });
+
         it('returns connection start error', (done) => {
 
             const server = new Hapi.Server();


### PR DESCRIPTION
I often run into issues in tests when `server.initialize()` is called multiple times. At the moment an error is thrown when it happens:

> Cannot initialize server while it is in initialized state

This PR changes the behavior, when the server is in `initialized` state, it doesn't attempt to run the initialization process again, it just calls the callback. I opened this PR to receive initial feedback, happy to improve it later.