### PR TITLE
Fast server shutdown

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -209,6 +209,16 @@ internals.Connection.prototype._stop = function (options, callback) {
         this._init();
         return callback();
     });
+
+    // Tell idle keep-alive connections to close
+
+    Object.keys(this._connections).forEach((key) => {
+
+        const connection = this._connections[key];
+        if (!connection._isHapiProcessing) {
+            connection.end();
+        }
+    });
 };
 
 
@@ -218,10 +228,17 @@ internals.Connection.prototype._dispatch = function (options) {
 
     return (req, res) => {
 
-        if (!this._started &&
-            !Shot.isInjection(req)) {
+        // Track socket request processing state
 
-            return req.connection.end();
+        if (req.socket) {
+            req.socket._isHapiProcessing = true;
+            res.on('finish', () => {
+
+                req.socket._isHapiProcessing = false;
+                if (!this._started) {
+                    req.socket.end();
+                }
+            });
         }
 
         // Create request

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -285,6 +285,11 @@ internals.transmit = function (response, callback) {
         }
     }
 
+    const isInjection = Shot.isInjection(request.raw.req);
+    if (!isInjection && !request.connection._started) {
+        request.raw.res.setHeader('connection', 'close');
+    }
+
     request.raw.res.writeHead(response.statusCode);
 
     // Write payload
@@ -352,7 +357,7 @@ internals.transmit = function (response, callback) {
 
     // Injection
 
-    if (Shot.isInjection(request.raw.req)) {
+    if (isInjection) {
         request.raw.res._hapi = {
             request: request
         };

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -2325,6 +2325,25 @@ describe('transmission', () => {
                 done();
             });
         });
+
+        it('does not add connection close header to normal requests', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            const handler = function (request, reply) {
+
+                return reply('ok');
+            };
+
+            server.route({ method: 'GET', path: '/', handler: handler });
+            server.inject('/', (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.headers.connection).to.not.equal('close');
+                done();
+            });
+        });
     });
 
     describe('cache()', () => {


### PR DESCRIPTION
When a server is handling persistent connections (using http keep-alive), the `timeout` option for `server.stop()` is a bit mislabeled. If just one of the persistent connections don't make any requests within the timeout duration, the server waits for the timeout even though no requests are processing. As such, it is effectively a stop delay option.

This patch tracks the request processing state of the connections, and immediately ends idle connections on `server.stop()`. Additionally, it signals that the server is closing on active requests (by adding `connection: close` to the response), and forcibly ends the connection once the response has been submitted. This means that the `timeout` option works as expected, and the server is much more likely to stop before the timeout is reached).

Note that actively closing these connections means that the closed server check on new requests from #2363, is no longer needed.

The first 3 patches adds additional tests that validate the current behavior, and the final patch actually implements the new behavior along with new and modified tests.