### PR TITLE
Pass through cookie options when calling reply.unstate()

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -115,9 +115,9 @@ internals.state = function (name, value, options) {
 };
 
 
-internals.unstate = function (name) {
+internals.unstate = function (name, options) {
 
-    this.request._clearState(name);
+    this.request._clearState(name, options);
 };
 
 

--- a/test/response.js
+++ b/test/response.js
@@ -57,7 +57,7 @@ describe('Response', () => {
         const postHandler = function (request, reply) {
 
             reply.state('test', '123');
-            reply.unstate('empty');
+            reply.unstate('empty', { path: '/path' });
             return reply.continue();
         };
 
@@ -70,7 +70,7 @@ describe('Response', () => {
             expect(res.result).to.equal('text');
             expect(res.headers['cache-control']).to.equal('max-age=1, must-revalidate, private');
             expect(res.headers['content-type']).to.equal('text/plain; something=something, charset=ISO-8859-1');
-            expect(res.headers['set-cookie']).to.deep.equal(['abc=123', 'sid=YWJjZGVmZzEyMzQ1Ng==', 'other=something; Secure', 'x=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT', 'test=123', 'empty=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT', 'always=present']);
+            expect(res.headers['set-cookie']).to.deep.equal(['abc=123', 'sid=YWJjZGVmZzEyMzQ1Ng==', 'other=something; Secure', 'x=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT', 'test=123', 'empty=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/path', 'always=present']);
             expect(res.headers.vary).to.equal('x-control');
             expect(res.headers.combo).to.equal('o-k');
             done();


### PR DESCRIPTION
Hi, 

When calling reply().unstate(name, options) the options are sent in the 'set-cookie' response header. 

However when calling reply.unstate(name, options) - the options are not sent, therefore it is not possible to remove a cookie that has been set on a particular 'Path'.