### PR TITLE
Update API.md: added a more precise description for `request.app`

### DIFF
--- a/API.md
+++ b/API.md
@@ -2134,8 +2134,8 @@ server.route({ method: 'GET', path: '/user', config: user });
 
 Each route can be customized to change the default behavior of the request lifecycle using the
 following options:
-- `app` - reserved for any sort of request-specific application state. Should not be used by 
-  [plugins](#plugins) which should use `plugins[name]` instead.
+- `app` - application-specific request state. Should not be used by [plugins](#plugins) which
+  should use `plugins[name]` instead.
 
 - <a name="route.config.auth"></a>`auth` - authentication configuration. Value can be:
     - `false` to disable authentication if a default strategy is set.

--- a/API.md
+++ b/API.md
@@ -2134,7 +2134,7 @@ server.route({ method: 'GET', path: '/user', config: user });
 
 Each route can be customized to change the default behavior of the request lifecycle using the
 following options:
-- `app` - application-specific configuration. Should not be used by [plugins](#plugins) which
+- `app` - reserved for any sort of request-specific application state. Should not be used by [plugins](#plugins) which
   should use `plugins[name]` instead.
 
 - <a name="route.config.auth"></a>`auth` - authentication configuration. Value can be:

--- a/API.md
+++ b/API.md
@@ -2134,8 +2134,8 @@ server.route({ method: 'GET', path: '/user', config: user });
 
 Each route can be customized to change the default behavior of the request lifecycle using the
 following options:
-- `app` - reserved for any sort of request-specific application state. Should not be used by [plugins](#plugins) which
-  should use `plugins[name]` instead.
+- `app` - reserved for any sort of request-specific application state. Should not be used by 
+  [plugins](#plugins) which should use `plugins[name]` instead.
 
 - <a name="route.config.auth"></a>`auth` - authentication configuration. Value can be:
     - `false` to disable authentication if a default strategy is set.


### PR DESCRIPTION
Reference: https://github.com/hapijs/discuss/issues/239

`request.app` seems to be the place for request-specific state. This is a proposal for a more precise description.