### PR TITLE
Include an option to parse payload before authenticate handler is triggered

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -283,13 +283,19 @@ internals.Route.prototype.rebuild = function (event) {
         cycle.push(this._extensions.onPreAuth);
     }
 
+    if (this.method !== 'get' && this.settings.auth && this.settings.auth.parsePayloadBeforeAuth) {
+        cycle.push(internals.payload);
+    }
+
     const authenticate = (this.settings.auth !== false);                          // Anything other than 'false' can still require authentication
     if (authenticate) {
         cycle.push(Auth.authenticate);
     }
 
     if (this.method !== 'get') {
-        cycle.push(internals.payload);
+        if (!this.settings.auth || !this.settings.auth.parsePayloadBeforeAuth){
+            cycle.push(internals.payload);
+        }
 
         if (authenticate) {
             cycle.push(Auth.payload);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -47,7 +47,8 @@ internals.auth = Joi.alternatives([
         payload: [
             Joi.string().valid('required', 'optional'),
             Joi.boolean()
-        ]
+        ],
+        parsePayloadBeforeAuth :Joi.boolean()
     })
         .without('strategy', 'strategies')
         .without('access', ['scope', 'entity'])


### PR DESCRIPTION
This will allow us to have `request.payload` inside the `authenticate` handler when we set the following config

```
{ 
  config : { 
    auth : { 
      strategy : 'foo',
      parsePayloadBeforeAuth : true 
    } 
  } 
}

```