### PR TITLE
allow array as valid validate config on headers, params, query and payload

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -116,8 +116,8 @@ internals.routeBase = Joi.object({
         options: Joi.object(),
         ranges: Joi.boolean(),
         sample: Joi.number().min(0).max(100),
-        schema: Joi.alternatives(Joi.object(), Joi.func()).allow(true, false),
-        status: Joi.object().pattern(/\d\d\d/, Joi.alternatives(Joi.object(), Joi.func()).allow(true, false))
+        schema: Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(true, false),
+        status: Joi.object().pattern(/\d\d\d/, Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(true, false))
     })
         .without('modify', 'sample')
         .assert('options.stripUnknown', Joi.ref('modify'), 'meet requirement of having peer modify set to true'),

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -154,10 +154,10 @@ internals.routeBase = Joi.object({
         server: Joi.number().integer().positive().allow(false).required()
     }),
     validate: Joi.object({
-        headers: Joi.alternatives(Joi.object(), Joi.func()).allow(null, false, true),
-        params: Joi.alternatives(Joi.object(), Joi.func()).allow(null, false, true),
-        query: Joi.alternatives(Joi.object(), Joi.func()).allow(null, false, true),
-        payload: Joi.alternatives(Joi.object(), Joi.func()).allow(null, false, true),
+        headers: Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(null, false, true),
+        params: Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(null, false, true),
+        query: Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(null, false, true),
+        payload: Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(null, false, true),
         failAction: [
             Joi.string().valid('error', 'log', 'ignore'),
             Joi.func()


### PR DESCRIPTION
fixes #3119

was not sure where to test, just add a test with arrays under test/validation.js ?