### PR TITLE
Don't force header keys to lowercase

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -111,7 +111,6 @@ internals.Response.prototype.code = function (statusCode) {
 
 internals.Response.prototype.header = function (key, value, options) {
 
-    key = key.toLowerCase();
     if (key === 'vary') {
         return this.vary(value);
     }


### PR DESCRIPTION
While the RFC clearly states that header keys are to be treated as case
insensitive, forcing them lowercase can create confusion between an
API's documentation and what a developer sees when they inspect response
headers.

For the same reasons camelCase matters when it comes to readability and
consistency, it is worthwhile to preserve the case of header keys as
they are defined via response.header(key, value).

My real world use case for this is that I am getting questions on a
semi-regular basis concerning the case differences that exist between
our API docs and our API responses. I'd strongly prefer the case I use
in our documentation to be the same case our API developers see when
they inspect and debug responses.