### PR TITLE
Improve wording of auth strategy mode/default

### DIFF
--- a/API.md
+++ b/API.md
@@ -649,10 +649,10 @@ Registers an authentication strategy where:
 - `name` - the strategy name.
 - `scheme` - the scheme name (must be previously registered using
   [`server.auth.scheme()`](#serverauthschemename-scheme)).
-- `mode` - unless set to `false`, the scheme is automatically assigned as the default strategy for any route
-  without an `auth` config. Can only be assigned to a single server strategy. Value must be `true`
+- `mode` - defaults to `false`.  If set, the value must be `true`
   (which is the same as `'required'`) or a valid authentication mode (`'required'`, `'optional'`,
-  `'try'`). Defaults to `false`.
+  `'try'`).  If set to a value other than `false`, the scheme is automatically assigned as the default strategy for any route
+  without an `auth` config. Can only be assigned to a single server strategy.
 - `options` - scheme options based on the scheme requirements.
 
 ```js

--- a/API.md
+++ b/API.md
@@ -649,7 +649,7 @@ Registers an authentication strategy where:
 - `name` - the strategy name.
 - `scheme` - the scheme name (must be previously registered using
   [`server.auth.scheme()`](#serverauthschemename-scheme)).
-- `mode` - if `true`, the scheme is automatically assigned as a required strategy to any route
+- `mode` - unless set to `false`, the scheme is automatically assigned as the default strategy for any route
   without an `auth` config. Can only be assigned to a single server strategy. Value must be `true`
   (which is the same as `'required'`) or a valid authentication mode (`'required'`, `'optional'`,
   `'try'`). Defaults to `false`.


### PR DESCRIPTION
I found this wording confusing, and noticed other people have as well (e.g. https://github.com/dwyl/hapi-auth-jwt2/issues/137 ).  I think the proposed update better reflects when `server.auth.strategy` sets a default strategy for routes.