### PR TITLE
Send correct response for HEAD requests

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -66,7 +66,7 @@ internals.marshal = function (request, next) {
 
         internals.cache(response);
 
-        if (!response._isPayloadSupported()) {
+        if (!response._isPayloadSupported() && request.method !== 'head') {
 
             // Close unused file streams
 
@@ -75,9 +75,7 @@ internals.marshal = function (request, next) {
             // Set empty stream
 
             response._payload = new internals.Empty();
-            if (request.method !== 'head') {
-                delete response.headers['content-length'];
-            }
+            delete response.headers['content-length'];
 
             return Auth.response(request, next);               // Must be last in case requires access to headers
         }
@@ -100,6 +98,17 @@ internals.marshal = function (request, next) {
                 typeof response._payload.size === 'function') {
 
                 response._header('content-length', response._payload.size(), { override: false });
+            }
+
+            if (!response._isPayloadSupported()) {
+
+                // Close unused file streams
+
+                response._close();
+
+                // Set empty stream
+
+                response._payload = new internals.Empty();
             }
 
             internals.content(response, true);


### PR DESCRIPTION
I noticed that a `HEAD` request for some of my routes did not send the `content-length` header, while a normal `GET` request would. I have updated the logic to properly set the header. This is done by not skipping the marshal step.

This also fixes specific cases where the `content-type` header could be different for `GET` and `HEAD` if it is set during or post marshaling.

FYI, the modified and new test both fail on current master as follows:
```
Failed tests:

  141) Connection route() responds to HEAD requests for a GET route:

      Expected undefined to equal specified value

      at /hapijs/hapi/test/connection.js:1690:63

  143) Connection route() returns 500 on HEAD requests for failed responses:

      actual expected

      200500

      Expected 200 to equal specified value

      at /hapijs/hapi/test/connection.js:1749:48
```