### PR TITLE
Explicit statusCode takes precedence over emptyStatusCode

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -44,6 +44,7 @@ exports = module.exports = internals.Response = function (source, request, optio
     this._contentEncoding = null;               // Set during transmit
     this._contentType = null;                   // Used if no explicit content-type is set and type is known
     this._error = null;                         // The boom object when created from an error
+    this._statusCodeExplicit = false;           // true if statusCode set by user via response.code()
 
     this._processors = {
         marshal: options.marshal,
@@ -105,6 +106,7 @@ internals.Response.prototype.code = function (statusCode) {
     Hoek.assert(Hoek.isInteger(statusCode), 'Status code must be an integer');
 
     this.statusCode = statusCode;
+    this._statusCodeExplicit = true;
     return this;
 };
 

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -197,7 +197,7 @@ internals.transmit = function (response, callback) {
     // Empty response
 
     if (length === 0 &&
-        response.statusCode === 200 &&
+        response._statusCodeExplicit === false &&
         request.route.settings.response.emptyStatusCode === 204) {
 
         response.code(204);

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -652,6 +652,25 @@ describe('transmission', () => {
             });
         });
 
+        it('allows handler to override default emptyStatusCode with 200', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection({ routes: { response: { emptyStatusCode: 204 } } });
+
+            const handler = function (request, reply) {
+
+                return reply().code(200);
+            };
+
+            server.route({ method: 'GET', path: '/', handler: handler });
+            server.inject('/', (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.result).to.equal(null);
+                done();
+            });
+        });
+
         it('does not send 204 for chunked transfer payloads', (done) => {
 
             const server = new Hapi.Server();


### PR DESCRIPTION
Closes #3152, assuming it's agreed that it's a bug.

This approach using a `_statusCodeExplicit` flag seemed like the least drastic way to fix the issue, without reordering some steps of the response/transmit flow.