### PR TITLE
Bind Promise's callbacks to current domain if set.

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -107,10 +107,11 @@ internals.Methods.prototype._add = function (name, method, options, realm) {
             };
 
             // Bind Promise's callbacks to current domain if set
-            let namespace = process.domain;
+            const namespace = process.domain;
             if (namespace) {
                 result.then(namespace.bind(onFulfilled), namespace.bind(onRejected));
-            } else {
+            }
+            else {
                 result.then(onFulfilled, onRejected);
             }
 

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -106,6 +106,13 @@ internals.Methods.prototype._add = function (name, method, options, realm) {
                 return methodNext(err);
             };
 
+            // Bind Promise's callbacks to current domain if set
+            let namespace = process.domain;
+            if (namespace) {
+                onFulfilled = namespace.bind(onFulfilled);
+                onRejected = namespace.bind(onRejected);
+            }
+
             result.then(onFulfilled, onRejected);
         };
     }

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -109,11 +109,11 @@ internals.Methods.prototype._add = function (name, method, options, realm) {
             // Bind Promise's callbacks to current domain if set
             let namespace = process.domain;
             if (namespace) {
-                onFulfilled = namespace.bind(onFulfilled);
-                onRejected = namespace.bind(onRejected);
+                result.then(namespace.bind(onFulfilled), namespace.bind(onRejected));
+            } else {
+                result.then(onFulfilled, onRejected);
             }
 
-            result.then(onFulfilled, onRejected);
         };
     }
 


### PR DESCRIPTION
This prevent crashing when server method returning a Promise with callback option set to false and a route handler throw an error.

How to reproduce ?
```js
const Hapi = require('hapi');

var server = new Hapi.Server();

server.connection({
    port: 3000
});


server.method('method', () => Promise.resolve(), { callback: false })

server.route({
    method: 'GET',
    path: '/test',
    config: {
        pre: [
            { method: 'method()' },
        ]
    },
    handler: function(request, reply){
        throw new Error('Oops');
    }
});

server.start(() => {
    console.log('Server listening ...')
})
```