### PR TITLE
Delay continuations when promises may be involved

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -96,15 +96,15 @@ internals.Methods.prototype._add = function (name, method, options, realm) {
 
             // Promise object
 
-            const onFulfilled = (outcome) => {
+            const onFulfilled = Hoek.nextTick((outcome) => {
 
                 return methodNext(null, outcome);
-            };
+            });
 
-            const onRejected = (err) => {
+            const onRejected = Hoek.nextTick((err) => {
 
                 return methodNext(err);
-            };
+            });
 
             result.then(onFulfilled, onRejected);
         };

--- a/lib/protect.js
+++ b/lib/protect.js
@@ -61,7 +61,7 @@ internals.Protect.prototype.run = function (next, enter) {              // enter
         return finish(Boom.badImplementation('Uncaught error', err));
     };
 
-    enter(finish);
+    this.domain.bind(enter)(finish);
 };
 
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -104,8 +104,11 @@ internals.close = function (options) {
 
 internals.continue = function (data) {
 
-    this._next(null, data);
-    this._next = null;
+    Hoek.nextTick(() => {
+
+        this._next(null, data);
+        this._next = null;
+    })();
 };
 
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -396,7 +396,7 @@ internals.Response.prototype._prepare = function (data, next) {
         return this._processPrepare(data, next);
     }
 
-    const onDone = (source) => {
+    const onDone = Hoek.nextTick((source) => {
 
         if (source instanceof Error) {
             return next(Boom.wrap(source), data);
@@ -409,7 +409,7 @@ internals.Response.prototype._prepare = function (data, next) {
         this._setSource(source);
         this._passThrough();
         this._processPrepare(data, next);
-    };
+    });
 
     this.source.then(onDone, onDone);
 };

--- a/test/request.js
+++ b/test/request.js
@@ -709,6 +709,50 @@ describe('Request', () => {
             });
         });
 
+        it('emits request-error on implementation error with a promise in pre handler', (done) => {
+
+            const server = new Hapi.Server({ debug: false });
+            server.connection();
+
+            let errs = 0;
+            let req = null;
+            server.on('request-error', (request, err) => {
+
+                ++errs;
+                expect(err).to.exist();
+                expect(err.message).to.equal('Uncaught error: boom');
+                req = request;
+            });
+
+            const handler = function (request, reply) {
+
+                throw new Error('boom');
+            };
+
+            server.route({ method: 'GET', path: '/', handler: handler });
+
+            server.ext('onPreHandler', (request, reply) => {
+
+                Promise.resolve()
+                    .then(() => reply.continue())
+                    .catch(() => reply(Boom.badImplementation('oops')));
+            });
+
+            server.once('response', () => {
+
+                expect(errs).to.equal(1);
+                expect(req.getLog('error')[0].tags).to.equal(['internal', 'implementation', 'error']);
+                done();
+            });
+
+            server.inject('/', (res) => {
+
+                expect(res.statusCode).to.equal(500);
+                expect(res.result).to.exist();
+                expect(res.result.message).to.equal('An internal server error occurred');
+            });
+        });
+
         it('does not emit request-error when error is replaced with valid response', (done) => {
 
             const server = new Hapi.Server({ debug: false });


### PR DESCRIPTION
Fixes #3073.

It's important with promises that anything callback-style be called on next tick, otherwise any error will be caught into the promise. I might have missed places where it would happen, happy to complete the PR if you can think of any.