### PR TITLE
Allow custom encoders to validate compression options

### DIFF
--- a/API.md
+++ b/API.md
@@ -29,7 +29,7 @@
     - [`server.decorate(type, property, method, [options])`](#serverdecoratetype-property-method-options)
     - [`server.dependency(dependencies, [after])`](#serverdependencydependencies-after)
     - [`server.emit(criteria, data, [callback])`](#serveremitcriteria-data-callback)
-    - [`server.encoder(encoding, encoder)`](#serverencoderencoding-encoder)
+    - [`server.encoder(encoding, encoder, [schema])`](#serverencoderencoding-encoder-schema)
     - [`server.event(events)`](#servereventevents)
     - [`server.expose(key, value)`](#serverexposekey-value)
     - [`server.expose(obj)`](#serverexposeobj)
@@ -1071,7 +1071,7 @@ server.on('test', (update) => console.log(update));
 server.emit('test', 'hello');
 ```
 
-### `server.encoder(encoding, encoder)`
+### `server.encoder(encoding, encoder, [schema])`
 
 Registers a custom content encoding compressor to extend the built-in support for `'gzip'` and
 '`deflate`' where:
@@ -1079,6 +1079,8 @@ Registers a custom content encoding compressor to extend the built-in support fo
 - `encoder` - a function using the signature `function(options)` where `options` are the encoding specific options configured in
   the route `compression` configuration option, and the return value is an object compatible with the output of node's
   [`zlib.createGzip()`](https://nodejs.org/dist/latest-v6.x/docs/api/zlib.html#zlib_zlib_creategzip_options).
+- `schema` - an optional [Joi](http://github.com/hapijs/joi) validation object, which is applied to the encoding compression
+   settings object on the route.
 
 ```js
 const Zlib = require('zlib');

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -5,11 +5,17 @@
 const Zlib = require('zlib');
 const Accept = require('accept');
 const Hoek = require('hoek');
+const Joi = require('joi');
 
 
 // Declare internals
 
 const internals = {};
+
+
+internals.schema = Joi.object({
+    identity: Joi.object().unknown(false).optional()
+}).unknown();
 
 
 exports = module.exports = internals.Compression = function () {
@@ -25,15 +31,24 @@ exports = module.exports = internals.Compression = function () {
         gzip: (options) => Zlib.createGunzip(options),
         deflate: (options) => Zlib.createInflate(options)
     };
+
+    this._schema = internals.schema;
 };
 
 
-internals.Compression.prototype.addEncoder = function (encoding, encoder) {
+internals.Compression.prototype.addEncoder = function (encoding, encoder, schema) {
 
     Hoek.assert(this._encoders[encoding] === undefined, `Cannot override existing encoder for ${encoding}`);
     Hoek.assert(typeof encoder === 'function', `Invalid encoder function for ${encoding}`);
+    Hoek.assert(schema === undefined || typeof schema === 'object', `Invalid encoder options schema for ${encoding}`);
     this._encoders[encoding] = encoder;
     this.encodings.push(encoding);
+
+    if (schema) {
+        this._schema = this._schema.keys({
+            [encoding]: schema
+        });
+    }
 };
 
 
@@ -42,6 +57,14 @@ internals.Compression.prototype.addDecoder = function (encoding, decoder) {
     Hoek.assert(this._decoders[encoding] === undefined, `Cannot override existing decoder for ${encoding}`);
     Hoek.assert(typeof decoder === 'function', `Invalid decoder function for ${encoding}`);
     this._decoders[encoding] = decoder;
+};
+
+
+internals.Compression.prototype.validate = function (routeSettings, message) {
+
+    const result = Joi.validate(routeSettings.compression, this._schema);
+    Hoek.assert(!result.error, `Invalid compression options (${message})`, result.error && result.error.annotate());
+    routeSettings.compression = result.value;
 };
 
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -371,9 +371,9 @@ internals.Connection.prototype.decoder = function (encoding, decoder) {
 };
 
 
-internals.Connection.prototype.encoder = function (encoding, encoder) {
+internals.Connection.prototype.encoder = function (encoding, encoder, schema) {
 
-    return this._compression.addEncoder(encoding, encoder);
+    return this._compression.addEncoder(encoding, encoder, schema);
 };
 
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -412,9 +412,9 @@ internals.Plugin.prototype.emit = function (criteria, data, callback) {
 };
 
 
-internals.Plugin.prototype.encoder = function (encoding, encoder) {
+internals.Plugin.prototype.encoder = function (encoding, encoder, schema) {
 
-    this._apply('encoder', Connection.prototype.encoder, [encoding, encoder]);
+    this._apply('encoder', Connection.prototype.encoder, [encoding, encoder, schema]);
 };
 
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -63,6 +63,7 @@ exports = module.exports = internals.Route = function (route, connection, plugin
     this.settings = Hoek.applyToDefaultsWithShallow(base, config || {}, ['bind', 'validate.headers', 'validate.payload', 'validate.params', 'validate.query']);
     this.settings.handler = handler;
     this.settings = Schema.apply('routeConfig', this.settings, routeDisplay);
+    connection._compression.validate(this.settings, routeDisplay);
 
     const socketTimeout = (this.settings.timeout.socket === undefined ? 2 * 60 * 1000 : this.settings.timeout.socket);
     Hoek.assert(!this.settings.timeout.server || !socketTimeout || this.settings.timeout.server < socketTimeout, 'Server timeout must be shorter than socket timeout:', routeDisplay);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -2872,6 +2872,64 @@ describe('Plugin', () => {
                 });
             });
         });
+
+        it('validates custom schema', (done) => {
+
+            const data = '{"test":"true"}';
+
+            const server = new Hapi.Server();
+            server.connection({ routes: { compression: { test: { some: 'option' } } } });
+
+            const encoder = (options) => {
+
+                expect(options).to.equal({ some: 'option' });
+                return Zlib.createGzip();
+            };
+
+            server.encoder('test', encoder, { some: 'option', other: false });
+
+            const handler = function (request, reply) {
+
+                return reply(request.payload);
+            };
+
+            server.route({ method: 'POST', path: '/', handler });
+            server.start((err) => {
+
+                expect(err).to.not.exist();
+
+                const uri = 'http://localhost:' + server.info.port;
+
+                Zlib.gzip(new Buffer(data), (err, zipped) => {
+
+                    expect(err).to.not.exist();
+
+                    Wreck.post(uri, { headers: { 'accept-encoding': 'test' }, payload: data }, (err, res, body) => {
+
+                        expect(err).to.not.exist();
+                        expect(res.headers['content-encoding']).to.equal('test');
+                        expect(body.toString()).to.equal(zipped.toString());
+                        server.stop(done);
+                    });
+                });
+            });
+        });
+
+        it('throws error when custom schema fails validation', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection({ routes: { compression: { test: { some: 'bad' } } } });
+
+            server.encoder('test', Hoek.ignore, { some: 'option', other: false });
+
+            const fn = () => {
+
+                server.route({ method: 'POST', path: '/', handler: Hoek.ignore });
+            };
+
+            expect(fn).to.throw(/Invalid compression options/);
+            done();
+        });
     });
 
     describe('event()', () => {


### PR DESCRIPTION
While implementing support for the new route level `compression` option in a custom encoder registered using `server.encoder()`, I realized that the current implementation either requires me to validate the compression options on each request, or trust that they are correct.

Since neither option is desirable, I created this PR to extend the API with an optional `schema` to allow the validation logic to be applied only once, when the route is created.

Let me know what you think?

Note that this only validates at the route level, and not at the connection level, since the connection already exits when adding the encoder.
