### PR TITLE
Correct request.path docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -2988,7 +2988,7 @@ Each request object includes the following properties:
   [Path parameters](#path-parameters).
 - `paramsArray` - an array containing all the path `params` values in the order they appeared in
   the path.
-- `path` - the request URI's path component.
+- `path` - the request URI's [pathname](https://nodejs.org/api/url.html#url_urlobject_pathname) component.
 - `payload` - the request payload based on the route `payload.output` and `payload.parse` settings.
 - `plugins` - plugin-specific state. Provides a place to store and pass request-level plugin data.
   The `plugins` is an object where each key is a plugin name and the value is the state.


### PR DESCRIPTION
The docs on the [request object](https://github.com/hapijs/hapi/blob/db98dbb2b1bf026c5e489248ec2ea758bb47a7c3/API.md#request-object) `path` property can easily be read to mean that it corresponds to `request.url.path`, but it's really `request.url.pathname`.

The term *URL path* is pretty hazy, so if you don't like this, an alternative would be:

```diff
- the request URI's path component.
+ the request URI's path (equal to `request.url.pathname`).
```

The important thing is it should clearly communicate that `request.path` corresponds to `request.url.pathname`.

I don't know how stable the fragment links in the Node docs are (just saw a broken one, I think in some hapijs project docs), but I included the current link to `pathname`.