### PR TITLE
Fix flaw in tracking of plugin registration status

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -244,7 +244,7 @@ internals.Plugin.prototype.register = function (plugins /*, [options], callback 
         registrations.push(registration);
     }
 
-    this.root._registring = true;
+    this.root._registering++;
 
     const each = (item, next) => {
 
@@ -319,7 +319,7 @@ internals.Plugin.prototype.register = function (plugins /*, [options], callback 
 
     Items.serial(registrations, each, (err) => {
 
-        this.root._registring = false;
+        this.root._registering--;
         return Hoek.nextTick(callback)(err);
     });
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -50,7 +50,7 @@ exports = module.exports = internals.Server = function (options) {
     this._decorations = {};
     this._plugins = {};                                                             // Exposed plugin properties by name
     this._app = {};
-    this._registring = false;                                                       // true while register() is waiting for plugin callbacks
+    this._registering = 0;                                                           // > 0 while register() is waiting for plugin callbacks
     this._state = 'stopped';                                                        // 'stopped', 'initializing', 'initialized', 'starting', 'started', 'stopping', 'invalid'
 
     this._extensionsSeq = 0;                                                        // Used to keep absolute order of extensions based on the order added across locations
@@ -228,7 +228,7 @@ internals.Server.prototype.initialize = function (callback) {
     Hoek.assert(typeof callback === 'function', 'Missing required start callback function');
     const nextTickCallback = Hoek.nextTick(callback);
 
-    if (this._registring) {
+    if (this._registering) {
         return nextTickCallback(new Error('Cannot start server before plugins finished registration'));
     }
 

--- a/test/server.js
+++ b/test/server.js
@@ -301,12 +301,22 @@ describe('Server', () => {
 
         it('fails to start server when registration incomplete', (done) => {
 
-            const plugin = function () { };
+            const plugin = function (server, opts, next) {
+
+                next();
+            };
             plugin.attributes = { name: 'plugin' };
+
+            const pluginAsync = function (server, opts, next) {
+
+                process.nextTick(next);
+            };
+            pluginAsync.attributes = { name: 'pluginAsync' };
 
             const server = new Hapi.Server();
             server.connection();
-            server.register(plugin, Hoek.ignore);
+            server.register(pluginAsync);
+            server.register(plugin);
             server.start((err) => {
 
                 expect(err).to.exist();
@@ -317,12 +327,22 @@ describe('Server', () => {
 
         it('fails to start server when registration incomplete (promise)', (done) => {
 
-            const plugin = function () { };
+            const plugin = function (server, opts, next) {
+
+                next();
+            };
             plugin.attributes = { name: 'plugin' };
+
+            const pluginAsync = function (server, opts, next) {
+
+                process.nextTick(next);
+            };
+            pluginAsync.attributes = { name: 'pluginAsync' };
 
             const server = new Hapi.Server();
             server.connection();
-            server.register(plugin, Hoek.ignore);
+            server.register(pluginAsync);
+            server.register(plugin);
             server.start().catch((err) => {
 
                 expect(err).to.exist();


### PR DESCRIPTION
Per #2516, `server.start()` is supposed to error when plugin registrations haven't completed. It's tracked with a boolean, which means that a later `server.register()` can clobber the value. Example:

```js
// Will work as intended:
server.register(syncPlugin);
server.register(asyncPlugin);
server.start();

// Won't:
server.register(asyncPlugin);
server.register(syncPlugin);
server.start();
```

This PR updates the relevant tests to cover that and changes the status variable to a counter to fix it.

Note that the basic relationship between `server.register()` and `server.start()` still lends itself to race conditions. It's not hard to get into a situation where things appear to be setup ok, but then sometimes some other aysnc prerequisite to calling `server.start()` will finish before plugin registration and `server.start()` will error. Example:

```js
// register some plugins

// When plugin registration wins the race, everything seems to be ok. When
// somethingAsync() does, server.start() will error.
somethingAsync()
.then(function () {
  return server.start();
});
```

You can keep track of it yourself, of course (that's what I'm doing now), but it's kind of a pain. I think it'd be nice to have something like this:

```js
// Promise that settles based on all plugin registrations that have already
// happened (maybe make additional calls to server.register throw after this):
server.ready()
.then(function () {
  return server.start();
})
```