### PR TITLE
Fix subtext shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -64,7 +64,7 @@
             "version": "5.0.0"
         },
         "subtext": {
-            "version": "4.2.1",
+            "version": "4.2.2",
             "dependencies": {
                 "content": {
                     "version": "3.0.2"
@@ -86,7 +86,7 @@
                     }
                 },
                 "wreck": {
-                    "version": "9.0.0"
+                    "version": "10.0.0"
                 }
             }
         },


### PR DESCRIPTION
We cannot shrinkwrap with hapi anymore because subtext 4.2.1 requires wreck@8 but this tells it to take wreck@9, updated subtext and aligned the shrinkwrap in this PR.
Depends on https://github.com/hapijs/subtext/pull/37.

Closes #3352 
Closes #3354 
Closes #3355 