### PR TITLE
Invoke reply with promise returned from handler.

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -93,7 +93,11 @@ internals.handler = function (request, callback) {
 
     // Execute handler
 
-    request.route.settings.handler.call(bind, request, reply);
+    const promise = request.route.settings.handler.call(bind, request, reply);
+
+    if (typeof promise === 'object' && typeof promise.then === 'function') {
+        reply(promise);
+    }
 };
 
 

--- a/test/handler.js
+++ b/test/handler.js
@@ -130,6 +130,27 @@ describe('handler', () => {
                 done();
             });
         });
+
+        it('calls reply with returned promise', (done) => {
+
+            const response = {};
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            const handler = function (request, reply) {
+
+                return Promise.resolve(response);
+            };
+
+            server.route({ method: 'GET', path: '/', handler });
+
+            server.inject('/', (res) => {
+
+                expect(res.result).to.equal(response);
+                done();
+            });
+        });
     });
 
     describe('register()', () => {


### PR DESCRIPTION
This allows a promise to be returned from a handler which will then
automatically be used to invoke `reply`. This way the server responds as
soon as the promise resolves or rejects.

This cleans up the code in handlers that uses promises significantly.

Simple example:

```
function handle (request, reply) {

    const promise = Promise.resolve(request.params.id);

    reply(promise);
};
```

Becomes:

```
function handle (request, reply) {

    return Promise.resolve(request.params.id);
};
```
