### PR TITLE
fix server not propagating errors on prehandler(promise) + handler error (#3242)

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -54,13 +54,18 @@ internals.prerequisites = function (request, callback) {
         }, nextSet);
     };
 
+    // save a reference to the current domain, for use in the callback below
+
+    const domain = process.domain;
+
     Items.serial(request._route._prerequisites, each, (err) => {
 
         if (err) {
             return callback(err);
         }
 
-        return internals.handler(request, callback);
+        const wrapped = domain.bind(internals.handler);
+        return wrapped(request, callback);
     });
 };
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -455,17 +455,22 @@ internals.Response.prototype._prepare = function (next) {
 
     const onDone = (source) => {
 
-        if (source instanceof Error) {
-            return next(Boom.wrap(source));
-        }
+        // do not use Hoek.nextTick because it will not work as intended
 
-        if (source instanceof internals.Response) {
-            return source._processPrepare(next);
-        }
+        process.nextTick(() => {
 
-        this._setSource(source);
-        this._passThrough();
-        this._processPrepare(next);
+            if (source instanceof Error) {
+                return next(Boom.wrap(source));
+            }
+
+            if (source instanceof internals.Response) {
+                return source._processPrepare(next);
+            }
+
+            this._setSource(source);
+            this._passThrough();
+            this._processPrepare(next);
+        });
     };
 
     const onError = (source) => {

--- a/lib/response.js
+++ b/lib/response.js
@@ -453,25 +453,20 @@ internals.Response.prototype._prepare = function (next) {
         return this._processPrepare(next);
     }
 
-    const onDone = (source) => {
+    const onDone = Hoek.nextTick((source) => {
 
-        // do not use Hoek.nextTick because it will not work as intended
+        if (source instanceof Error) {
+            return next(Boom.wrap(source));
+        }
 
-        process.nextTick(() => {
+        if (source instanceof internals.Response) {
+            return source._processPrepare(next);
+        }
 
-            if (source instanceof Error) {
-                return next(Boom.wrap(source));
-            }
-
-            if (source instanceof internals.Response) {
-                return source._processPrepare(next);
-            }
-
-            this._setSource(source);
-            this._passThrough();
-            this._processPrepare(next);
-        });
-    };
+        this._setSource(source);
+        this._passThrough();
+        this._processPrepare(next);
+    });
 
     const onError = (source) => {
 


### PR DESCRIPTION
This patch proposes a fix for #3242 ; 

The fix revolves around explicit domain bindings and execution of promise handler from the event loop (using process.nextTick) so that the error is not swallowed up by the promise itself (which was basically leading to a deadlock; the promise never fully resolved, and the callback is never called )

This is technically a bugfix, and I wasn't sure if I'm supposed to increase the patch version number, so I'll leave it up to you guys.
