### PR TITLE
change deprecated os.tmpDir call to os.tmpdir

### DIFF
--- a/API.md
+++ b/API.md
@@ -2551,7 +2551,7 @@ following options:
     - `timeout` - payload reception timeout in milliseconds. Sets the maximum time allowed for the
       client to transmit the request payload (body) before giving up and responding with a Request
       Timeout (408) error response. Set to `false` to disable. Defaults to `10000` (10 seconds).
-    - `uploads` - the directory used for writing file uploads. Defaults to `os.tmpDir()`.
+    - `uploads` - the directory used for writing file uploads. Defaults to `os.tmpdir()`.
     - `failAction` - determines how to handle payload parsing errors. Allowed values are:
         - `'error'` - return a Bad Request (400) error response. This is the default value.
         - `'log'` - report the error but continue processing the request.

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -51,7 +51,7 @@ exports.connection = {
             output: 'data',
             parse: true,
             timeout: 10 * 1000,                     // Determines how long to wait for receiving client payload. Defaults to 10 seconds
-            uploads: Os.tmpDir(),
+            uploads: Os.tmpdir(),
             defaultContentType: 'application/json',
             compression: {}
         },


### PR DESCRIPTION
os.tmpdir was deprecated in Node 7.0.0. See https://nodejs.org/api/os.html#os_os_tmpdir and https://github.com/nodejs/node/pull/6739

fixes #3369 