### PR TITLE
Fix for hapijs/discuss#395.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -152,7 +152,12 @@ internals.Connection.prototype._init = function () {
             });
         };
 
-        this.listener.on('connection', this._onConnection);
+        if (this.settings.tls) {
+            this.listener.on('secureConnection', this._onConnection);
+        }
+        else {
+            this.listener.on('connection', this._onConnection);
+        }
     });
 };
 
@@ -216,7 +221,12 @@ internals.Connection.prototype._stop = function (options, callback) {
 
     this.listener.close(() => {
 
-        this.listener.removeListener('connection', this._onConnection);
+        if (this.settings.tls) {
+            this.listener.removeListener('secureConnection', this._onConnection);
+        }
+        else {
+            this.listener.removeListener('connection', this._onConnection);
+        }
         clearTimeout(timeoutId);
 
         this._init();

--- a/test/connection.js
+++ b/test/connection.js
@@ -19,6 +19,7 @@ const Lab = require('lab');
 const Vision = require('vision');
 const Wreck = require('wreck');
 const Stream = require('stream');
+const TLS = require('tls');
 
 
 // Declare internals
@@ -614,9 +615,11 @@ describe('Connection', () => {
                 socket1.on('error', () => { });
                 socket2.on('error', () => { });
 
-                socket1.connect(server.info.port, '127.0.0.1', () => {
+                socket1.connect(server.info.port, '127.0.0.1');
+                TLS.connect({ socket: socket1, rejectUnauthorized: false }, () => {
 
-                    socket2.connect(server.info.port, '127.0.0.1', () => {
+                    socket2.connect(server.info.port, '127.0.0.1');
+                    TLS.connect({ socket: socket2, rejectUnauthorized: false }, () => {
 
                         server.listener.getConnections((err, count1) => {
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -895,6 +895,45 @@ describe('Connection', () => {
             });
         });
 
+        it('does not close longpoll HTTPS requests before response (if within timeout)', (done) => {
+
+            const tlsOptions = {
+                key: '-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0UqyXDCqWDKpoNQQK/fdr0OkG4gW6DUafxdufH9GmkX/zoKz\ng/SFLrPipzSGINKWtyMvo7mPjXqqVgE10LDI3VFV8IR6fnART+AF8CW5HMBPGt/s\nfQW4W4puvBHkBxWSW1EvbecgNEIS9hTGvHXkFzm4xJ2e9DHp2xoVAjREC73B7JbF\nhc5ZGGchKw+CFmAiNysU0DmBgQcac0eg2pWoT+YGmTeQj6sRXO67n2xy/hA1DuN6\nA4WBK3wM3O4BnTG0dNbWUEbe7yAbV5gEyq57GhJIeYxRvveVDaX90LoAqM4cUH06\n6rciON0UbDHV2LP/JaH5jzBjUyCnKLLo5snlbwIDAQABAoIBAQDJm7YC3pJJUcxb\nc8x8PlHbUkJUjxzZ5MW4Zb71yLkfRYzsxrTcyQA+g+QzA4KtPY8XrZpnkgm51M8e\n+B16AcIMiBxMC6HgCF503i16LyyJiKrrDYfGy2rTK6AOJQHO3TXWJ3eT3BAGpxuS\n12K2Cq6EvQLCy79iJm7Ks+5G6EggMZPfCVdEhffRm2Epl4T7LpIAqWiUDcDfS05n\nNNfAGxxvALPn+D+kzcSF6hpmCVrFVTf9ouhvnr+0DpIIVPwSK/REAF3Ux5SQvFuL\njPmh3bGwfRtcC5d21QNrHdoBVSN2UBLmbHUpBUcOBI8FyivAWJhRfKnhTvXMFG8L\nwaXB51IZAoGBAP/E3uz6zCyN7l2j09wmbyNOi1AKvr1WSmuBJveITouwblnRSdvc\nsYm4YYE0Vb94AG4n7JIfZLKtTN0xvnCo8tYjrdwMJyGfEfMGCQQ9MpOBXAkVVZvP\ne2k4zHNNsfvSc38UNSt7K0HkVuH5BkRBQeskcsyMeu0qK4wQwdtiCoBDAoGBANF7\nFMppYxSW4ir7Jvkh0P8bP/Z7AtaSmkX7iMmUYT+gMFB5EKqFTQjNQgSJxS/uHVDE\nSC5co8WGHnRk7YH2Pp+Ty1fHfXNWyoOOzNEWvg6CFeMHW2o+/qZd4Z5Fep6qCLaa\nFvzWWC2S5YslEaaP8DQ74aAX4o+/TECrxi0z2lllAoGAdRB6qCSyRsI/k4Rkd6Lv\nw00z3lLMsoRIU6QtXaZ5rN335Awyrfr5F3vYxPZbOOOH7uM/GDJeOJmxUJxv+cia\nPQDflpPJZU4VPRJKFjKcb38JzO6C3Gm+po5kpXGuQQA19LgfDeO2DNaiHZOJFrx3\nm1R3Zr/1k491lwokcHETNVkCgYBPLjrZl6Q/8BhlLrG4kbOx+dbfj/euq5NsyHsX\n1uI7bo1Una5TBjfsD8nYdUr3pwWltcui2pl83Ak+7bdo3G8nWnIOJ/WfVzsNJzj7\n/6CvUzR6sBk5u739nJbfgFutBZBtlSkDQPHrqA7j3Ysibl3ZIJlULjMRKrnj6Ans\npCDwkQKBgQCM7gu3p7veYwCZaxqDMz5/GGFUB1My7sK0hcT7/oH61yw3O8pOekee\nuctI1R3NOudn1cs5TAy/aypgLDYTUGQTiBRILeMiZnOrvQQB9cEf7TFgDoRNCcDs\nV/ZWiegVB/WY7H0BkCekuq5bHwjgtJTpvHGqQ9YD7RhE8RSYOhdQ/Q==\n-----END RSA PRIVATE KEY-----\n',
+                cert: '-----BEGIN CERTIFICATE-----\nMIIDBjCCAe4CCQDvLNml6smHlTANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJV\nUzETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0\ncyBQdHkgTHRkMB4XDTE0MDEyNTIxMjIxOFoXDTE1MDEyNTIxMjIxOFowRTELMAkG\nA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0\nIFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nANFKslwwqlgyqaDUECv33a9DpBuIFug1Gn8Xbnx/RppF/86Cs4P0hS6z4qc0hiDS\nlrcjL6O5j416qlYBNdCwyN1RVfCEen5wEU/gBfAluRzATxrf7H0FuFuKbrwR5AcV\nkltRL23nIDRCEvYUxrx15Bc5uMSdnvQx6dsaFQI0RAu9weyWxYXOWRhnISsPghZg\nIjcrFNA5gYEHGnNHoNqVqE/mBpk3kI+rEVzuu59scv4QNQ7jegOFgSt8DNzuAZ0x\ntHTW1lBG3u8gG1eYBMquexoSSHmMUb73lQ2l/dC6AKjOHFB9Ouq3IjjdFGwx1diz\n/yWh+Y8wY1Mgpyiy6ObJ5W8CAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAoSc6Skb4\ng1e0ZqPKXBV2qbx7hlqIyYpubCl1rDiEdVzqYYZEwmst36fJRRrVaFuAM/1DYAmT\nWMhU+yTfA+vCS4tql9b9zUhPw/IDHpBDWyR01spoZFBF/hE1MGNpCSXXsAbmCiVf\naxrIgR2DNketbDxkQx671KwF1+1JOMo9ffXp+OhuRo5NaGIxhTsZ+f/MA4y084Aj\nDI39av50sTRTWWShlN+J7PtdQVA5SZD97oYbeUeL7gI18kAJww9eUdmT0nEjcwKs\nxsQT1fyKbo7AlZBY4KSlUMuGnn0VnAsB9b+LxtXlDfnjyM8bVQx1uAfRo0DO8p/5\n3J5DTjAU55deBQ==\n-----END CERTIFICATE-----\n'
+            };
+
+            const handler = (request, reply) => {
+
+                server.stop({ timeout: 200 }, (err) => {
+
+                    expect(err).to.not.exist();
+                    done();
+                });
+
+                setTimeout(() => {
+
+                    return reply('ok');
+                }, 150);
+            };
+
+            const server = new Hapi.Server();
+            server.connection({ tls: tlsOptions });
+            server.route({ method: 'GET', path: '/', handler });
+            server.start((err) => {
+
+                expect(err).to.not.exist();
+
+                const agent = new Https.Agent({ keepAlive: true, maxSockets: 1, rejectUnauthorized: false });
+
+                Wreck.get('https://localhost:' + server.info.port + '/', { agent }, (err, res, body) => {
+
+                    expect(err).to.not.exist();
+                    expect(res.headers.connection).to.equal('close');
+                    expect(body.toString()).to.equal('ok');
+                });
+            });
+        });
+
         it('removes connection event listeners after it stops', (done) => {
 
             const server = new Hapi.Server();


### PR DESCRIPTION
This is a possible fix for https://github.com/hapijs/discuss/issues/395, where longpoll HTTPS requests were getting cancelled *before* the timeout value passed to `server.stop()`.

**Fair warning**: I'm not very familiar with Hapi internals nor low-level Node HTTP & socket handling, so I don't have any idea if this fix is appropriate. Any and all suggestions—or a complete rewrite!—more than welcome! My real goal is simply to get this particular issue fixed in whatever manner is fastest. :-D 

# Issue Description

## Expected behavior

`server.stop({timeout}, callback)` should wait for the provided timeout before forcibly closing any pending requests.

## Observed behavior

For HTTPS requests **only**, `server.stop` **immediately** forcibly closes pending requests, without waiting for either a response to the request or for the timeout.

## Analysis

It looks like [`connection.js`](https://github.com/hapijs/hapi/blob/master/lib/connection.js#L231) looks for the `_isHapiProcessing` flag. However, in an HTTPS connection, that flag is `undefined`.

I **think** what is happening is that the `_dispatch` function sets the flag on a `TLSSocket` instance. But, by the time we are handling the stop in the `_stop` function, we no longer have access to the TLSSocket, but rather have just a `Socket`.

(As far as I can tell, a TLSSocket is created from a Socket originally? as some sort of wrapper?)

It appears that we can set the flag on the socket by using the `_parent` property of a TLSsocket. It's private and undocumented, so I hope there is a better way to do this, but that's all I could find.