### PR TITLE
Bumping shrinkwrapped pez minor release version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -70,7 +70,7 @@
                     "version": "3.0.2"
                 },
                 "pez": {
-                    "version": "2.1.2",
+                    "version": "2.1.3",
                     "dependencies": {
                         "b64": {
                             "version": "3.0.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hapi",
   "description": "HTTP Server framework",
   "homepage": "http://hapijs.com",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/hapijs/hapi"


### PR DESCRIPTION
This addresses #3371 and #3359.  `pez` was version bumped to require `boom@4.x.x` in `2.1.3`, but the `npm-shrinkwrap.json` in `hapi` still points to `pez@2.1.2`.  This PR simply updates things to point to the latest `pez`.