### PR TITLE
Bump shrinkwrapped moment version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -42,7 +42,7 @@
                     "version": "2.2.1"
                 },
                 "moment": {
-                    "version": "2.14.1"
+                    "version": "2.17.0"
                 }
             }
         },


### PR DESCRIPTION
moment was shrinkwrapped to version 2.14.1 which has a ReDOS vulnerability described here: https://snyk.io/vuln/npm:moment:20161019.

This commit bumps the shrinkwrapped version to the most recent version of moment, 2.17.0.