### PR TITLE
Attempt to fix #3399 where it crashes on route prerequisites when no domain is present

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -54,7 +54,7 @@ internals.prerequisites = function (request, callback) {
         }, nextSet);
     };
 
-    const domain = process.domain;      // Save a reference to the current domain
+    const domain = request.domain;      // Save a reference to the current domain
 
     Items.serial(request._route._prerequisites, each, (err) => {
 
@@ -62,7 +62,7 @@ internals.prerequisites = function (request, callback) {
             return callback(err);
         }
 
-        const wrapped = domain.bind(internals.handler);
+        const wrapped = domain ? domain.bind(internals.handler) : internals.handler;
         return wrapped(request, callback);
     });
 };

--- a/test/handler.js
+++ b/test/handler.js
@@ -81,6 +81,45 @@ describe('handler', () => {
                 expect(res.statusCode).to.equal(500);
             });
         });
+
+        it('works without a domain', (done) => {
+
+            const pre = function (req, reply) {
+
+                reply('pre');
+            };
+
+            const handler = function (req, reply) {
+
+                reply('working').code(200);
+            };
+
+            // this will cause the test to stop on error but is needed to test #3399
+            const domain = process.domain;
+            process.domain = undefined;
+
+            const server = new Hapi.Server({ useDomains: false });
+            server.connection();
+
+            server.route({
+                method: 'get',
+                path: '/',
+                config: {
+                    pre: [{
+                        method: pre
+                    }],
+                    handler
+                }
+            });
+
+            server.inject('/', (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                process.domain = domain;
+                done();
+            });
+
+        });
     });
 
     describe('handler()', () => {


### PR DESCRIPTION
I wrote a failing test witch match the description on #3399 and added a check to see if domain exists before binding. I also changed `domain = process.domain` to `domain = request.domain` to prevent the test domain from being used.

I'm sorry in advance if this fix is no good, I just recently started to studying the hapi internals