### PR TITLE
Adding server.inspect to list decorated framework interfaces

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,6 +5,7 @@
     - [Server properties](#server-properties)
         - [`server.app`](#serverapp)
         - [`server.connections`](#serverconnections)
+        - [`server.decorations`](#serverdecorations)
         - [`server.info`](#serverinfo)
         - [`server.load`](#serverload)
         - [`server.listener`](#serverlistener)
@@ -27,7 +28,6 @@
     - [`server.connection([options])`](#serverconnectionoptions)
     - [`server.decoder(encoding, decoder)`](#serverencoderencoding-decoder)
     - [`server.decorate(type, property, method, [options])`](#serverdecoratetype-property-method-options)
-    - [`server.inspect(type)`](#serverinspecttype)
     - [`server.dependency(dependencies, [after])`](#serverdependencydependencies-after)
     - [`server.emit(criteria, data, [callback])`](#serveremitcriteria-data-callback)
     - [`server.encoder(encoding, encoder)`](#serverencoderencoding-encoder)
@@ -272,6 +272,30 @@ Each connection object contains:
 - `table()` -
 - `lookup()` -
 - `match()` -
+
+### `server.decorations`
+
+Provides access to the decorations already applied to various framework interfaces.  The object
+must not be modified directly, but only through [`server.decorate`](#serverdecoratetype-property-method-options)
+- `type` - the decorated interface. Supported types:
+    - `'request'` - decorations on the [Request object](#request-object).
+    - `'reply'` - decorations on the [reply interface](#reply-interface).
+    - `'server'` - decorations on the [Server](#server) object.
+
+```js
+const Hapi = require('hapi');
+const server = new Hapi.Server();
+server.connection({ port: 80 });
+
+const success = function () {
+
+    return this.response({ status: 'ok' });
+};
+
+server.decorate('reply', 'success', success);
+return server.decorations.reply;
+// returns ['success']
+```
 
 
 #### `server.info`
@@ -990,30 +1014,6 @@ server.route({
         return reply.success();
     }
 });
-```
-
-### `server.inspect(type)`
-
-Returns an array of decorations on various framework interfaces
-- `type` - the interface being inspected. Supported types:
-    - `'request'` - returns an array of decorations on the [Request object](#request-object).
-    - `'reply'` - returns an array of decorations on the [reply interface](#reply-interface).
-    - `'server'` - returns an array of decorations on the [Server](#server) object.
-
-```js
-const Hapi = require('hapi');
-const server = new Hapi.Server();
-server.connection({ port: 80 });
-
-const success = function () {
-
-    return this.response({ status: 'ok' });
-};
-
-server.decorate('reply', 'success', success);
-
-server.inspect('reply');
-// returns ['success']
 ```
 
 ### `server.dependency(dependencies, [after])`

--- a/API.md
+++ b/API.md
@@ -27,6 +27,7 @@
     - [`server.connection([options])`](#serverconnectionoptions)
     - [`server.decoder(encoding, decoder)`](#serverencoderencoding-decoder)
     - [`server.decorate(type, property, method, [options])`](#serverdecoratetype-property-method-options)
+    - [`server.inspect(type)`](#serverinspecttype)
     - [`server.dependency(dependencies, [after])`](#serverdependencydependencies-after)
     - [`server.emit(criteria, data, [callback])`](#serveremitcriteria-data-callback)
     - [`server.encoder(encoding, encoder)`](#serverencoderencoding-encoder)
@@ -989,6 +990,30 @@ server.route({
         return reply.success();
     }
 });
+```
+
+### `server.inspect(type)`
+
+Returns an array of decorations on various framework interfaces
+- `type` - the interface being inspected. Supported types:
+    - `'request'` - returns an array of decorations on the [Request object](#request-object).
+    - `'reply'` - returns an array of decorations on the [reply interface](#reply-interface).
+    - `'server'` - returns an array of decorations on the [Server](#server) object.
+
+```js
+const Hapi = require('hapi');
+const server = new Hapi.Server();
+server.connection({ port: 80 });
+
+const success = function () {
+
+    return this.response({ status: 'ok' });
+};
+
+server.decorate('reply', 'success', success);
+
+server.inspect('reply');
+// returns ['success']
 ```
 
 ### `server.dependency(dependencies, [after])`

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -29,11 +29,6 @@ exports = module.exports = internals.Plugin = function (server, connections, env
     this.root = server;
     this.app = this.root._app;
     this.connections = connections;
-    this.decorations = {
-        request: [],
-        reply: [],
-        server: []
-    };
     this.load = this.root._heavy.load;
     this.methods = this.root._methods.methods;
     this.mime = this.root._mime;
@@ -372,8 +367,7 @@ internals.Plugin.prototype.decorate = function (type, property, method, options)
 
     if (type === 'request') {
         this.root._requestor.decorate(property, method, options);
-        this.decorations[type].push(property);
-        return;
+        return this.root.decorations[type].push(property);
     }
 
     Hoek.assert(!options, 'Cannot specify options for non-request decoration');
@@ -382,8 +376,7 @@ internals.Plugin.prototype.decorate = function (type, property, method, options)
 
     if (type === 'reply') {
         this.root._replier.decorate(property, method);
-        this.decorations[type].push(property);
-        return;
+        return this.root.decorations[type].push(property);
     }
 
     // Server
@@ -392,7 +385,7 @@ internals.Plugin.prototype.decorate = function (type, property, method, options)
     Hoek.assert(this[property] === undefined && this.root[property] === undefined, 'Cannot override the built-in server interface method:', property);
 
     this.root._decorations[property] = method;
-    this.decorations[type].push(property);
+    this.root.decorations[type].push(property);
 
     this[property] = method;
     let parent = this._parent;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -29,6 +29,11 @@ exports = module.exports = internals.Plugin = function (server, connections, env
     this.root = server;
     this.app = this.root._app;
     this.connections = connections;
+    this.decorations = {
+        request: [],
+        reply: [],
+        server: []
+    };
     this.load = this.root._heavy.load;
     this.methods = this.root._methods.methods;
     this.mime = this.root._mime;
@@ -366,7 +371,9 @@ internals.Plugin.prototype.decorate = function (type, property, method, options)
     // Request
 
     if (type === 'request') {
-        return this.root._requestor.decorate(property, method, options);
+        this.root._requestor.decorate(property, method, options);
+        this.decorations[type].push(property);
+        return;
     }
 
     Hoek.assert(!options, 'Cannot specify options for non-request decoration');
@@ -374,7 +381,9 @@ internals.Plugin.prototype.decorate = function (type, property, method, options)
     // Reply
 
     if (type === 'reply') {
-        return this.root._replier.decorate(property, method);
+        this.root._replier.decorate(property, method);
+        this.decorations[type].push(property);
+        return;
     }
 
     // Server
@@ -383,6 +392,7 @@ internals.Plugin.prototype.decorate = function (type, property, method, options)
     Hoek.assert(this[property] === undefined && this.root[property] === undefined, 'Cannot override the built-in server interface method:', property);
 
     this.root._decorations[property] = method;
+    this.decorations[type].push(property);
 
     this[property] = method;
     let parent = this._parent;
@@ -391,28 +401,6 @@ internals.Plugin.prototype.decorate = function (type, property, method, options)
         parent = parent._parent;
     }
 };
-
-internals.Plugin.prototype.inspect = function (type) {
-
-    Hoek.assert(['reply', 'request', 'server'].indexOf(type) !== -1, 'Unknown decoration type:', type);
-
-    // Request
-
-    if (type === 'request') {
-        return this.root._requestor.inspect();
-    }
-
-    // Reply
-
-    if (type === 'reply') {
-        return this.root._replier.inspect();
-    }
-
-    // Server
-
-    return Object.keys(this.root._decorations);
-};
-
 
 internals.Plugin.prototype.dependency = function (dependencies, after) {
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -392,6 +392,27 @@ internals.Plugin.prototype.decorate = function (type, property, method, options)
     }
 };
 
+internals.Plugin.prototype.inspect = function (type) {
+
+    Hoek.assert(['reply', 'request', 'server'].indexOf(type) !== -1, 'Unknown decoration type:', type);
+
+    // Request
+
+    if (type === 'request') {
+        return this.root._requestor.inspect();
+    }
+
+    // Reply
+
+    if (type === 'reply') {
+        return this.root._replier.inspect();
+    }
+
+    // Server
+
+    return Object.keys(this.root._decorations);
+};
+
 
 internals.Plugin.prototype.dependency = function (dependencies, after) {
 

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -26,6 +26,12 @@ internals.Reply.prototype.decorate = function (property, method) {
     this._decorations[property] = method;
 };
 
+internals.Reply.prototype.inspect = function () {
+
+    this._decorations = this._decorations || {};
+    return Object.keys(this._decorations);
+};
+
 
 /*
     const handler = function (request, reply) {

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -26,13 +26,6 @@ internals.Reply.prototype.decorate = function (property, method) {
     this._decorations[property] = method;
 };
 
-internals.Reply.prototype.inspect = function () {
-
-    this._decorations = this._decorations || {};
-    return Object.keys(this._decorations);
-};
-
-
 /*
     const handler = function (request, reply) {
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -56,12 +56,6 @@ internals.Generator.prototype.decorate = function (property, method, options) {
     this._decorations[property] = { method, apply: options.apply };
 };
 
-internals.Generator.prototype.inspect = function () {
-
-    this._decorations = this._decorations || {};
-    return Object.keys(this._decorations);
-};
-
 
 internals.Request = function (connection, req, res, options) {
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -56,6 +56,12 @@ internals.Generator.prototype.decorate = function (property, method, options) {
     this._decorations[property] = { method, apply: options.apply };
 };
 
+internals.Generator.prototype.inspect = function () {
+
+    this._decorations = this._decorations || {};
+    return Object.keys(this._decorations);
+};
+
 
 internals.Request = function (connection, req, res, options) {
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -48,6 +48,11 @@ exports = module.exports = internals.Server = function (options) {
     this._replier = new Reply();
     this._requestor = new Request();
     this._decorations = {};
+    this.decorations = {
+        request: [],
+        reply: [],
+        server: []
+    };
     this._plugins = {};                                                             // Exposed plugin properties by name
     this._app = {};
     this._registring = false;                                                       // true while register() is waiting for plugin callbacks

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -2628,6 +2628,23 @@ describe('Plugin', () => {
             done();
         });
 
+        it('shows decorations on request (multiple connections)', (done) => {
+
+            const server = new Hapi.Server();
+
+            server.connection({ labels: ['alpha'] });
+            server.connection({ labels: ['beta'] });
+
+            const conn1 = server.select('alpha');
+            const conn2 = server.select('beta');
+
+            conn1.decorate('request', 'a', () => { });
+            conn2.decorate('request', 'b', () => { });
+
+            expect(server.decorations.request).to.equal(['a', 'b']);
+            done();
+        });
+
         it('shows decorations on reply (empty array)', (done) => {
 
             const server = new Hapi.Server();
@@ -2648,13 +2665,32 @@ describe('Plugin', () => {
             done();
         });
 
-        it('shows decorations on request (many)', (done) => {
+        it('shows decorations on reply (many)', (done) => {
 
             const server = new Hapi.Server();
             server.connection();
 
             server.decorate('reply', 'a', () => { });
             server.decorate('reply', 'b', () => { });
+
+            expect(server.decorations.reply).to.equal(['a', 'b']);
+            done();
+        });
+
+        it('shows decorations on reply (multiple connections)', (done) => {
+
+            const server = new Hapi.Server();
+
+            server.connection({ labels: ['alpha'] });
+            server.connection({ labels: ['beta'] });
+
+            expect(server.connections.length).to.equal(2);
+
+            const conn1 = server.select('alpha');
+            const conn2 = server.select('beta');
+
+            conn1.decorate('reply', 'a', () => { });
+            conn2.decorate('reply', 'b', () => { });
 
             expect(server.decorations.reply).to.equal(['a', 'b']);
             done();
@@ -2687,6 +2723,23 @@ describe('Plugin', () => {
 
             server.decorate('server', 'a', () => { });
             server.decorate('server', 'b', () => { });
+
+            expect(server.decorations.server).to.equal(['a', 'b']);
+            done();
+        });
+
+        it('shows decorations on server (multiple connections)', (done) => {
+
+            const server = new Hapi.Server();
+
+            server.connection({ labels: ['alpha'] });
+            server.connection({ labels: ['beta'] });
+
+            const conn1 = server.select('alpha');
+            const conn2 = server.select('beta');
+
+            conn1.decorate('server', 'a', () => { });
+            conn2.decorate('server', 'b', () => { });
 
             expect(server.decorations.server).to.equal(['a', 'b']);
             done();

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -2594,15 +2594,14 @@ describe('Plugin', () => {
         });
     });
 
-    describe('inspect()', () => {
+    describe('decorations ()', () => {
 
         it('shows decorations on request (empty array)', (done) => {
 
             const server = new Hapi.Server();
             server.connection();
 
-            const decorations = server.inspect('request');
-            expect(decorations).to.be.empty();
+            expect(server.decorations.request).to.be.empty();
             done();
         });
 
@@ -2613,8 +2612,7 @@ describe('Plugin', () => {
 
             server.decorate('request', 'a', () => { });
 
-            const decorations = server.inspect('request');
-            expect(decorations).to.equal(['a']);
+            expect(server.decorations.request).to.equal(['a']);
             done();
         });
 
@@ -2626,8 +2624,7 @@ describe('Plugin', () => {
             server.decorate('request', 'a', () => { });
             server.decorate('request', 'b', () => { });
 
-            const decorations = server.inspect('request');
-            expect(decorations).to.equal(['a', 'b']);
+            expect(server.decorations.request).to.equal(['a', 'b']);
             done();
         });
 
@@ -2636,8 +2633,7 @@ describe('Plugin', () => {
             const server = new Hapi.Server();
             server.connection();
 
-            const decorations = server.inspect('reply');
-            expect(decorations).to.be.empty();
+            expect(server.decorations.reply).to.be.empty();
             done();
         });
 
@@ -2648,8 +2644,7 @@ describe('Plugin', () => {
 
             server.decorate('reply', 'a', () => { });
 
-            const decorations = server.inspect('reply');
-            expect(decorations).to.equal(['a']);
+            expect(server.decorations.reply).to.equal(['a']);
             done();
         });
 
@@ -2661,8 +2656,7 @@ describe('Plugin', () => {
             server.decorate('reply', 'a', () => { });
             server.decorate('reply', 'b', () => { });
 
-            const decorations = server.inspect('reply');
-            expect(decorations).to.equal(['a', 'b']);
+            expect(server.decorations.reply).to.equal(['a', 'b']);
             done();
         });
 
@@ -2671,8 +2665,7 @@ describe('Plugin', () => {
             const server = new Hapi.Server();
             server.connection();
 
-            const decorations = server.inspect('server');
-            expect(decorations).to.be.empty();
+            expect(server.decorations.server).to.be.empty();
             done();
         });
 
@@ -2683,8 +2676,7 @@ describe('Plugin', () => {
 
             server.decorate('server', 'a', () => { });
 
-            const decorations = server.inspect('server');
-            expect(decorations).to.equal(['a']);
+            expect(server.decorations.server).to.equal(['a']);
             done();
         });
 
@@ -2696,8 +2688,7 @@ describe('Plugin', () => {
             server.decorate('server', 'a', () => { });
             server.decorate('server', 'b', () => { });
 
-            const decorations = server.inspect('server');
-            expect(decorations).to.equal(['a', 'b']);
+            expect(server.decorations.server).to.equal(['a', 'b']);
             done();
         });
     });

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -2594,6 +2594,114 @@ describe('Plugin', () => {
         });
     });
 
+    describe('inspect()', () => {
+
+        it('shows decorations on request (empty array)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            const decorations = server.inspect('request');
+            expect(decorations).to.be.empty();
+            done();
+        });
+
+        it('shows decorations on request (single)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            server.decorate('request', 'a', () => { });
+
+            const decorations = server.inspect('request');
+            expect(decorations).to.equal(['a']);
+            done();
+        });
+
+        it('shows decorations on request (many)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            server.decorate('request', 'a', () => { });
+            server.decorate('request', 'b', () => { });
+
+            const decorations = server.inspect('request');
+            expect(decorations).to.equal(['a', 'b']);
+            done();
+        });
+
+        it('shows decorations on reply (empty array)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            const decorations = server.inspect('reply');
+            expect(decorations).to.be.empty();
+            done();
+        });
+
+        it('shows decorations on reply (single)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            server.decorate('reply', 'a', () => { });
+
+            const decorations = server.inspect('reply');
+            expect(decorations).to.equal(['a']);
+            done();
+        });
+
+        it('shows decorations on request (many)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            server.decorate('reply', 'a', () => { });
+            server.decorate('reply', 'b', () => { });
+
+            const decorations = server.inspect('reply');
+            expect(decorations).to.equal(['a', 'b']);
+            done();
+        });
+
+        it('shows decorations on server (empty array)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            const decorations = server.inspect('server');
+            expect(decorations).to.be.empty();
+            done();
+        });
+
+        it('shows decorations on server (single)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            server.decorate('server', 'a', () => { });
+
+            const decorations = server.inspect('server');
+            expect(decorations).to.equal(['a']);
+            done();
+        });
+
+        it('shows decorations on server (many)', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            server.decorate('server', 'a', () => { });
+            server.decorate('server', 'b', () => { });
+
+            const decorations = server.inspect('server');
+            expect(decorations).to.equal(['a', 'b']);
+            done();
+        });
+    });
+
     describe('dependency()', () => {
 
         it('fails to register single plugin with dependencies', (done) => {


### PR DESCRIPTION
Addresses enhancement request: https://github.com/hapijs/hapi/issues/3408