### PR TITLE
support a header to override request.id

### DIFF
--- a/API.md
+++ b/API.md
@@ -155,6 +155,9 @@ Creates a new `Server` object where:
            which is used to store configuration values and `connection.plugins` which is meant for
            storing run-time state.
 
+        - `requestIdHeader` - the name of a header that can be used to override the value of
+          `request.id` for a request
+
         - <a name="connection.config.router"></a>`router` - controls how incoming request URIs are
           matched against the routing table:
             - `isCaseSensitive` - determines whether the paths '/example' and '/EXAMPLE' are

--- a/API.md
+++ b/API.md
@@ -155,9 +155,6 @@ Creates a new `Server` object where:
            which is used to store configuration values and `connection.plugins` which is meant for
            storing run-time state.
 
-        - `requestIdHeader` - the name of a header that can be used to override the value of
-          `request.id` for a request
-
         - <a name="connection.config.router"></a>`router` - controls how incoming request URIs are
           matched against the routing table:
             - `isCaseSensitive` - determines whether the paths '/example' and '/EXAMPLE' are
@@ -936,6 +933,17 @@ exports.register.attributes = {
     name: 'example',
     connections: false
 };
+```
+
+### `server.requestIdGenerator(method)`
+
+Registers a custom generator for request IDs where:
+- `method` - the function that is invoked using the signature `function(request)` and returns an ID, or `null` if the default should be used
+
+```js
+server.requestIdGenerator((request) => {
+    return request.headers['x-request-id'];
+});
 ```
 
 ### `server.decoder(encoding, decoder)`

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -38,6 +38,8 @@ exports = module.exports = internals.Connection = function (server, options) {
     this.settings = options;                                                        // options cloned in server.connection()
     this.server = server;
 
+    this.generateRequestId = this._defaultRequestIdGenerator;
+
     // Normalize settings
 
     this.settings.labels = Hoek.unique(this.settings.labels || []);                 // Remove duplicates
@@ -52,10 +54,6 @@ exports = module.exports = internals.Connection = function (server, options) {
 
     if (this.settings.autoListen === undefined) {
         this.settings.autoListen = true;
-    }
-
-    if (this.settings.requestIdHeader) {
-        this.settings.requestIdHeader = this.settings.requestIdHeader.toLowerCase();
     }
 
     Hoek.assert(this.settings.autoListen || !this.settings.port, 'Cannot specify port when autoListen is false');
@@ -278,6 +276,25 @@ internals.Connection.prototype._dispatch = function (options) {
             });
         }
     };
+};
+
+
+internals.Connection.prototype.requestIdGenerator = function (requestIdGenerator) {
+
+    this.generateRequestId = function (req) {
+
+        return requestIdGenerator(req) || this._defaultRequestIdGenerator();
+    };
+};
+
+
+internals.Connection.prototype._defaultRequestIdGenerator = function () {
+
+    const value = Date.now() + ':' + this.info.id + ':' + this._requestCounter.value++;
+    if (this._requestCounter.value > this._requestCounter.max) {
+        this._requestCounter.value = this._requestCounter.min;
+    }
+    return value;
 };
 
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -54,6 +54,10 @@ exports = module.exports = internals.Connection = function (server, options) {
         this.settings.autoListen = true;
     }
 
+    if (this.settings.requestIdHeader) {
+        this.settings.requestIdHeader = this.settings.requestIdHeader.toLowerCase();
+    }
+
     Hoek.assert(this.settings.autoListen || !this.settings.port, 'Cannot specify port when autoListen is false');
     Hoek.assert(this.settings.autoListen || !this.settings.address, 'Cannot specify address when autoListen is false');
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -356,6 +356,12 @@ internals.Plugin.prototype.decoder = function (encoding, decoder) {
 };
 
 
+internals.Plugin.prototype.requestIdGenerator = function (method) {
+
+    this._apply('requestIdGenerator', Connection.prototype.requestIdGenerator, [method]);
+};
+
+
 internals.Plugin.prototype.decorate = function (type, property, method, options) {
 
     Hoek.assert(['reply', 'request', 'server'].indexOf(type) !== -1, 'Unknown decoration type:', type);

--- a/lib/request.js
+++ b/lib/request.js
@@ -84,13 +84,7 @@ internals.Request = function (connection, req, res, options) {
     this._setMethod(req.method);                                                    // Sets: this.method
     this.headers = req.headers;
 
-    this.id = now + ':' + connection.info.id + ':' + connection._requestCounter.value++;
-    if (connection.settings.requestIdHeader) {
-        this.id = req.headers[connection.settings.requestIdHeader] || this.id;
-    }
-    if (connection._requestCounter.value > connection._requestCounter.max) {
-        connection._requestCounter.value = connection._requestCounter.min;
-    }
+    this.id = connection.generateRequestId(req);
 
     this.app = (options.app ? Hoek.shallow(options.app) : {});              // Place for application-specific state without conflicts with hapi, should not be used by plugins
     this.plugins = (options.plugins ? Hoek.shallow(options.plugins) : {});  // Place for plugins to store state without conflicts with hapi, should be namespaced using plugin name

--- a/lib/request.js
+++ b/lib/request.js
@@ -85,6 +85,9 @@ internals.Request = function (connection, req, res, options) {
     this.headers = req.headers;
 
     this.id = now + ':' + connection.info.id + ':' + connection._requestCounter.value++;
+    if (connection.settings.requestIdHeader) {
+        this.id = req.headers[connection.settings.requestIdHeader] || this.id;
+    }
     if (connection._requestCounter.value > connection._requestCounter.max) {
         connection._requestCounter.value = connection._requestCounter.min;
     }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -183,6 +183,7 @@ internals.routeBase = Joi.object({
 internals.connectionBase = Joi.object({
     app: Joi.object().allow(null),
     compression: Joi.boolean(),
+    requestIdHeader: Joi.string(),
     load: Joi.object(),
     plugins: Joi.object(),
     router: Joi.object({

--- a/test/request.js
+++ b/test/request.js
@@ -198,6 +198,47 @@ describe('Request', () => {
         });
     });
 
+    it('ignores specified request id header when not set', (done) => {
+
+        const handler = function (request, reply) {
+
+            return reply(request.id);
+        };
+
+        const server = new Hapi.Server({
+            connections: { requestIdHeader: 'X-Request-Id' }
+        });
+        server.connection();
+        server.connections[0]._requestCounter = { value: 10, min: 10, max: 11 };
+        server.route({ method: 'GET', path: '/', handler });
+        server.inject('/', (res) => {
+
+            expect(res.result).to.match(/10$/);
+            done();
+        });
+    });
+
+    it('uses specified request id header when set', (done) => {
+
+        const handler = function (request, reply) {
+
+            return reply(request.id);
+        };
+
+        const server = new Hapi.Server({
+            connections: { requestIdHeader: 'X-Request-Id' }
+        });
+        server.connection();
+        server.route({ method: 'GET', path: '/', handler });
+
+        const headers = { 'X-Request-Id': 'theRequestId' };
+        server.inject({ url: '/', headers }, (res) => {
+
+            expect(res.result).to.equal('theRequestId');
+            done();
+        });
+    });
+
     describe('_execute()', () => {
 
         it('returns 400 on invalid path', (done) => {

--- a/test/request.js
+++ b/test/request.js
@@ -198,19 +198,24 @@ describe('Request', () => {
         });
     });
 
-    it('ignores specified request id header when not set', (done) => {
+    it('generates unique request id when generator returns null', (done) => {
 
         const handler = function (request, reply) {
 
             return reply(request.id);
         };
 
-        const server = new Hapi.Server({
-            connections: { requestIdHeader: 'X-Request-Id' }
-        });
+        const server = new Hapi.Server();
         server.connection();
         server.connections[0]._requestCounter = { value: 10, min: 10, max: 11 };
         server.route({ method: 'GET', path: '/', handler });
+
+        const generator = function (request) {
+
+            return null;
+        };
+
+        server.requestIdGenerator(generator);
         server.inject('/', (res) => {
 
             expect(res.result).to.match(/10$/);
@@ -218,20 +223,24 @@ describe('Request', () => {
         });
     });
 
-    it('uses specified request id header when set', (done) => {
+    it('uses specified request id generator when set', (done) => {
 
         const handler = function (request, reply) {
 
             return reply(request.id);
         };
 
-        const server = new Hapi.Server({
-            connections: { requestIdHeader: 'X-Request-Id' }
-        });
+        const server = new Hapi.Server();
         server.connection();
         server.route({ method: 'GET', path: '/', handler });
 
+        const generator = function (request) {
+
+            return request.headers['x-request-id'];
+        };
+
         const headers = { 'X-Request-Id': 'theRequestId' };
+        server.requestIdGenerator(generator);
         server.inject({ url: '/', headers }, (res) => {
 
             expect(res.result).to.equal('theRequestId');


### PR DESCRIPTION
I'd like to pass a custom `request.id` value via a request header such as `X-Request-Id`, that enables request tracing across a series of internal service calls, instead of using the generated ID of each.

There are plugins to enable this, such as https://www.npmjs.com/package/hapi-request-id, however this is dependent on the order of the plugins if a different `onRequest` extension needs to use the `request.id`. These also don't take effect in time to be used by the initial `received` logging statement at the end of the `Request` constructor.

I've created a patch that covers this capability. I'm interested to hear if this makes sense, and if so whether there might be a better place than `connection.settings` to configure it. Another possibility I considered was whether to supply a function to generate the ID rather than using a header, but was unclear where that might belong.

Thanks!