### PR TITLE
Fix several request.url property issues on setUrl()

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -198,19 +198,32 @@ Hoek.inherits(internals.Request, Podium);
 
 internals.Request.prototype._setUrl = function (url, stripTrailingSlash) {
 
-    this.url = (typeof url === 'string' ? Url.parse(url, true) : url);
-    this.query = this.url.query;
-    this.path = this.url.pathname || '';                                                            // pathname excludes query
+    url = (typeof url === 'string' ? Url.parse(url, true) : Hoek.clone(url));
+
+    // Apply path modifications
+
+    let path = this.connection._router.normalize(url.pathname || '');        // pathname excludes query
 
     if (stripTrailingSlash &&
-        this.path.length > 1 &&
-        this.path[this.path.length - 1] === '/') {
+        path.length > 1 &&
+        path[path.length - 1] === '/') {
 
-        this.path = this.path.slice(0, -1);
-        this.url.pathname = this.path;
+        path = path.slice(0, -1);
     }
 
-    this.path = this.connection._router.normalize(this.path);
+    // Update derived url properties
+
+    if (path !== url.pathname) {
+        url.pathname = path;
+        url.path = url.search ? path + url.search : path;
+        url.href = Url.format(url);
+    }
+
+    // Store request properties
+
+    this.url = url;
+    this.query = url.query;
+    this.path = url.pathname;
 };
 
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -224,6 +224,17 @@ internals.Request.prototype._setUrl = function (url, stripTrailingSlash) {
     this.url = url;
     this.query = url.query;
     this.path = url.pathname;
+
+    if (url.hostname) {
+        this.info.hostname = url.hostname;
+        if (url.port) {
+            this.info.host = url.host;
+        }
+        else {
+            const split = this.info.host.split(':');
+            this.info.host = split.length > 1 ? `${url.hostname}:${split[1]}` : url.host;
+        }
+    }
 };
 
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -227,13 +227,7 @@ internals.Request.prototype._setUrl = function (url, stripTrailingSlash) {
 
     if (url.hostname) {
         this.info.hostname = url.hostname;
-        if (url.port) {
-            this.info.host = url.host;
-        }
-        else {
-            const split = this.info.host.split(':');
-            this.info.host = split.length > 1 ? `${url.hostname}:${split[1]}` : url.host;
-        }
+        this.info.host = url.host;
     }
 };
 

--- a/test/request.js
+++ b/test/request.js
@@ -963,6 +963,7 @@ describe('Request', () => {
             const normPath = '/%0%1%2%3%4%5%6%7%8%9%a%b%c%d%e%f%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20!%22%23$%25&\'()*+,-.%2F0123456789:;%3C=%3E%3F@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F%80%81%82%83%84%85%86%87%88%89%8A%8B%8C%8D%8E%8F%90%91%92%93%94%95%96%97%98%99%9A%9B%9C%9D%9E%9F%A0%A1%A2%A3%A4%A5%A6%A7%A8%A9%AA%AB%AC%AD%AE%AF%B0%B1%B2%B3%B4%B5%B6%B7%B8%B9%BA%BB%BC%BD%BE%BF%C0%C1%C2%C3%C4%C5%C6%C7%C8%C9%CA%CB%CC%CD%CE%CF%D0%D1%D2%D3%D4%D5%D6%D7%D8%D9%DA%DB%DC%DD%DE%DF%E0%E1%E2%E3%E4%E5%E6%E7%E8%E9%EA%EB%EC%ED%EE%EF%F0%F1%F2%F3%F4%F5%F6%F7%F8%F9%FA%FB%FC%FD%FE%FF%0%1%2%3%4%5%6%7%8%9%A%B%C%D%E%F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20!%22%23$%25&\'()*+,-.%2F0123456789:;%3C=%3E%3F@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F%80%81%82%83%84%85%86%87%88%89%8A%8B%8C%8D%8E%8F%90%91%92%93%94%95%96%97%98%99%9A%9B%9C%9D%9E%9F%A0%A1%A2%A3%A4%A5%A6%A7%A8%A9%AA%AB%AC%AD%AE%AF%B0%B1%B2%B3%B4%B5%B6%B7%B8%B9%BA%BB%BC%BD%BE%BF%C0%C1%C2%C3%C4%C5%C6%C7%C8%C9%CA%CB%CC%CD%CE%CF%D0%D1%D2%D3%D4%D5%D6%D7%D8%D9%DA%DB%DC%DD%DE%DF%E0%E1%E2%E3%E4%E5%E6%E7%E8%E9%EA%EB%EC%ED%EE%EF%F0%F1%F2%F3%F4%F5%F6%F7%F8%F9%FA%FB%FC%FD%FE%FF';
 
             const url = 'http://localhost' + rawPath + '?param1=something';
+            const normUrl = 'http://localhost' + normPath + '?param1=something';
 
             const server = new Hapi.Server();
             server.connection();
@@ -978,7 +979,7 @@ describe('Request', () => {
 
             server.inject('/', (res) => {
 
-                expect(res.payload).to.equal(url + '|' + normPath + '|something');
+                expect(res.payload).to.equal(normUrl + '|' + normPath + '|something');
                 done();
             });
         });
@@ -1049,6 +1050,37 @@ describe('Request', () => {
             server.inject('/test/?a=b', (res) => {
 
                 expect(res.statusCode).to.equal(200);
+                done();
+            });
+        });
+
+        it('clones passed url', (done) => {
+
+            const urlObject = {
+                protocol: 'http:',
+                pathname: '/%41'
+            };
+            const passedUrl = Hoek.clone(urlObject);
+            let requestUrl;
+
+            const server = new Hapi.Server();
+            server.connection();
+            const onRequest = function (request, reply) {
+
+                request.setUrl(passedUrl);
+                requestUrl = request.url;
+
+                return reply.continue();
+            };
+
+            server.ext('onRequest', onRequest);
+
+            server.inject('/', (res) => {
+
+                expect(res.statusCode).to.equal(404);
+                expect(passedUrl).to.equal(urlObject);
+                expect(requestUrl).to.not.shallow.equal(passedUrl);
+                expect(requestUrl).to.not.equal(urlObject);
                 done();
             });
         });

--- a/test/request.js
+++ b/test/request.js
@@ -957,7 +957,7 @@ describe('Request', () => {
             });
         });
 
-        it('host info update preserves port number', (done) => {
+        it('updates host info when set without port number', (done) => {
 
             const url = 'http://redirected/';
             const server = new Hapi.Server();
@@ -978,7 +978,7 @@ describe('Request', () => {
 
                 server.inject({ url: '/', headers: { host: 'initial' } }, (res2) => {
 
-                    expect(res1.payload).to.equal(url + '|/|initial:123|redirected:123|redirected');
+                    expect(res1.payload).to.equal(url + '|/|initial:123|redirected|redirected');
                     expect(res2.payload).to.equal(url + '|/|initial|redirected|redirected');
                     done();
                 });


### PR DESCRIPTION
This PR fixes this following issues in the `request.setUrl()` method:

 * The passed url object is not cloned.
 * Trailing slash stripping should be done after normalization (important if hapijs/call#29 is implemented).
 * Always update pathname derived url properties when path is modified.

This should make for a safer and more consistent `request.setUrl()` experience.