### PR TITLE
Customize validation error code

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -70,7 +70,8 @@ exports.connection = {
             server: false                           // Determines how long to wait for server request processing. Disabled by default
         },
         validate: {
-            options: {}                             // Joi validation options
+            options: {},                            // Joi validation options
+            errorStatusCode: 400                    // Default status code returned when validation failed
         }
     }
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -175,7 +175,8 @@ internals.routeBase = Joi.object({
             Joi.func()
         ],
         errorFields: Joi.object(),
-        options: Joi.object()
+        options: Joi.object(),
+        errorStatusCode: Joi.number()
     })
 });
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -80,7 +80,12 @@ internals.input = function (source, request, next) {
 
         // Prepare error
 
-        const error = (err.isBoom ? err : Boom.badRequest(err.message, err));
+        const boomFromError = (err) => {
+
+            return Boom.create(request.route.settings.validate.errorStatusCode, err.message, err);
+        };
+
+        const error = (err.isBoom ? err : boomFromError(err));
         error.output.payload.validation = { source, keys: [] };
         if (err.details) {
             for (let i = 0; i < err.details.length; ++i) {

--- a/test/validation.js
+++ b/test/validation.js
@@ -215,6 +215,33 @@ describe('validation', () => {
         });
     });
 
+    it('fails with globally set up error code if provided', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection({ routes: { validate: { errorStatusCode: 422 } } });
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: function (request, reply) {
+
+                return reply('ok');
+            },
+            config: {
+                validate: {
+                    query: {
+                        a: Joi.number()
+                    }
+                }
+            }
+        });
+
+        server.inject('/?a=abc', (res) => {
+
+            expect(res.statusCode).to.equal(422);
+            done();
+        });
+    });
+
     it('retains custom validation error', (done) => {
 
         const server = new Hapi.Server();


### PR DESCRIPTION
This feature would allow set up the default validation error code, which i find to be beneficial for some users (like myself). Im not sure if I put the option in the right place, since
i have been just using Hapi.js from yesterday. If you think the improvement would be beneficial, feel free to guide me where would be the best place to put the option.

Thanks