### PR TITLE
Bind request continuation methods to current domain

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -64,13 +64,32 @@ internals.Reply.prototype.decorate = function (property, method) {
 
 internals.Reply.prototype.interface = function (request, realm, options, next) {        // next(err || response, data);
 
-    const reply = (err, response, data) => {
+    let reply = (err, response, data) => {
 
         Hoek.assert(data === undefined || options.data, 'Reply interface does not allow a third argument');
 
         reply._data = data;                 // Held for later
         return reply.response(err !== null && err !== undefined ? err : response);
     };
+
+    const domain = request.domain;
+
+    if (domain) {
+        reply = domain.bind(reply);
+
+        reply.close = domain.bind(internals.close);
+        reply.continue = domain.bind(internals.continue);
+        reply.redirect = domain.bind(internals.redirect);
+        reply.response = domain.bind(internals.response);
+        reply.entity = domain.bind(internals.entity);
+    }
+    else {
+        reply.close = internals.close;
+        reply.continue = internals.continue;
+        reply.redirect = internals.redirect;
+        reply.response = internals.response;
+        reply.entity = internals.entity;
+    }
 
     reply._settings = options;
     reply._replied = false;
@@ -79,13 +98,8 @@ internals.Reply.prototype.interface = function (request, realm, options, next) {
     reply.realm = realm;
     reply.request = request;
 
-    reply.close = internals.close;
-    reply.continue = internals.continue;
     reply.state = internals.state;
     reply.unstate = internals.unstate;
-    reply.redirect = internals.redirect;
-    reply.response = internals.response;
-    reply.entity = internals.entity;
 
     if (this._decorations) {
         const methods = Object.keys(this._decorations);

--- a/test/handler.js
+++ b/test/handler.js
@@ -561,6 +561,48 @@ describe('handler', () => {
             });
         });
 
+        it('returns 500 if prerequisite loses domain binding', (done) => {
+
+            const pre1 = function (request, reply) {
+
+                Promise.resolve().then(() => {
+
+                    reply('Hello');
+                });
+            };
+
+            const pre2 = function (request, reply) {
+
+                a.b.c = 0;
+            };
+
+            const handler = function (request, reply) {
+
+                return reply(request.pre.m1);
+            };
+
+
+            const server = new Hapi.Server({ debug: false });
+            server.connection();
+            server.route({
+                method: 'GET',
+                path: '/',
+                config: {
+                    pre: [
+                        [{ method: pre1, assign: 'm1' }],
+                        { method: pre2, assign: 'm2' }
+                    ],
+                    handler
+                }
+            });
+
+            server.inject('/', (res) => {
+
+                expect(res.result.statusCode).to.equal(500);
+                done();
+            });
+        });
+
         it('returns a user record using server method', (done) => {
 
             const server = new Hapi.Server();


### PR DESCRIPTION
Fix for https://github.com/hapijs/discuss/issues/445.

This ensures that any built-in request continuation methods are called using the correct domain. This is needed since promises lose the domain binding when eg. `reply()` is called inside a `.then()`.