### PR TITLE
Attempt to fix #3431 when pre with failAction log or ignored won't assign to request.pre

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -277,7 +277,7 @@ internals.pre = function (pre) {
             }
 
             if (pre.assign) {
-                request.pre[pre.assign] = response.source;
+                request.pre[pre.assign] = response instanceof Error ? response : response.source;
                 request.preResponses[pre.assign] = response;
             }
 

--- a/test/handler.js
+++ b/test/handler.js
@@ -960,6 +960,7 @@ describe('handler', () => {
                 config: {
                     pre: [
                         {
+                            assign: 'before',
                             method: function (request, reply) {
 
                                 return reply(Boom.forbidden());
@@ -969,7 +970,7 @@ describe('handler', () => {
                     ],
                     handler: function (request, reply) {
 
-                        return reply('ok');
+                        return reply(request.pre.before instanceof Error ? 'had pre error' : 'ok');
                     }
                 }
             });
@@ -977,6 +978,7 @@ describe('handler', () => {
             server.inject('/', (res) => {
 
                 expect(res.statusCode).to.equal(200);
+                expect(res.payload).to.equal('had pre error');
                 done();
             });
         });
@@ -1001,7 +1003,7 @@ describe('handler', () => {
                     ],
                     handler: function (request, reply) {
 
-                        return reply('ok');
+                        return reply(request.pre.before instanceof Error ? 'had pre error' : 'ok');
                     }
                 }
             });
@@ -1013,13 +1015,14 @@ describe('handler', () => {
                     tags.error) {
 
                     expect(event.data.assign).to.equal('before');
-                    done();
                 }
             });
 
             server.inject('/', (res) => {
 
                 expect(res.statusCode).to.equal(200);
+                expect(res.payload).to.equal('had pre error');
+                done();
             });
         });
 


### PR DESCRIPTION
 

docs say that about pre config:
>### Route prerequisites
> [...]
> ... pre can be assigned a mixed array of:
>
>objects with:
>- method - the function to call (or short-hand method string as described below). the function signature is identical to a route handler as described in Route handler.
>- assign - key name to assign the result of the function to within request.pre.
>- failAction - determines how to handle errors returned by the method. Allowed values are:
>    - 'error' - returns the error response back to the client. This is the default value.
>    - 'log' - logs the error but continues processing the request. If assign is used, the error will be assigned.
>    - 'ignore' - takes no special action. If assign is used, the error will be assigned.


So when `failAction` is `log` or `ignore`:
>  If assign is used, the error will be assigned.

But that is not happening. 

There is another PR trying to solve this issue by changing the docs to match the implementation (#3439).
I, however, think that in this case it make more sense to fix the implementation.

This PR is the result of the discussion that happened on the issue #3431