### PR TITLE
explicitly destroy sockets on clientError

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -93,6 +93,7 @@ exports = module.exports = internals.Connection = function (server, options) {
     this.listener.on('clientError', (err, socket) => {
 
         this.server._log(['connection', 'client', 'error'], err);
+        socket.destroy(err);
     });
 
     // Connection information


### PR DESCRIPTION
node versions >= 6 no longer destroy sockets by default when a clientError listener is attached, we have to do so ourselves