### PR TITLE
Defer 100-continue signalling until payload parsing

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -88,6 +88,7 @@ exports = module.exports = internals.Connection = function (server, options) {
 
     this.listener = this.settings.listener || (this.settings.tls ? Https.createServer(this.settings.tls) : Http.createServer());
     this.listener.on('request', this._dispatch());
+    this.listener.on('checkContinue', this._dispatch({ expectContinue: true }));
     this._init();
 
     this.listener.on('clientError', (err, socket) => {

--- a/lib/request.js
+++ b/lib/request.js
@@ -132,6 +132,7 @@ internals.Request = function (connection, req, res, options) {
     this._entity = {};                  // Entity information set via reply.entity()
     this._logger = [];
     this._allowInternals = !!options.allowInternals;
+    this._expectContinue = !!options.expectContinue;
     this._isPayloadPending = true;      // false when incoming payload fully processed
     this._isBailed = false;             // true when lifecycle should end
     this._isReplied = false;            // true when response processing started

--- a/lib/route.js
+++ b/lib/route.js
@@ -398,6 +398,10 @@ internals.payload = function (request, next) {
         return next();
     }
 
+    if (request._expectContinue) {
+        request.raw.res.writeContinue();
+    }
+
     const onParsed = (err, parsed) => {
 
         request.mime = parsed.mime;

--- a/test/payload.js
+++ b/test/payload.js
@@ -191,6 +191,34 @@ describe('payload', () => {
         });
     });
 
+    it('handles expect 100-continue', (done) => {
+
+        const handler = function (request, reply) {
+
+            return reply(request.payload);
+        };
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.route({ method: 'POST', path: '/', config: { handler } });
+
+        server.start((err) => {
+
+            expect(err).to.not.exist();
+
+            const uri = 'http://localhost:' + server.info.port;
+
+            Wreck.post(uri, { payload: { hello: true }, headers: { expect: '100-continue' } }, (err, res, body) => {
+
+                expect(err).to.not.exist();
+                expect(res.statusCode).to.equal(200);
+                expect(body.toString()).to.equal('{"hello":true}');
+
+                server.stop(done);
+            });
+        });
+    });
+
     it('peeks at unparsed data', (done) => {
 
         let data = null;


### PR DESCRIPTION
This patch enables clients that use the `expect: 100-continue` header to defer and possibly completely omit uploading data if the request fails before the "payload parsing" stage.

It can be further deferred, but this requires changes to subtext (see https://github.com/hapijs/subtext/issues/46).