### PR TITLE
Do not use raw request in api docs example

### DIFF
--- a/API.md
+++ b/API.md
@@ -3064,7 +3064,7 @@ server.connection({ port: 80 });
 
 const onRequest = function (request, reply) {
 
-    const uri = request.raw.req.url;
+    const uri = request.url.href;
     const parsed = Url.parse(uri, false);
     parsed.query = Qs.parse(parsed.query);
     request.setUrl(parsed);


### PR DESCRIPTION
This can cause weird issues when you rewrite the url in plugins and then rewrite it again in example to the raw url.