### PR TITLE
Update Documentation for Code on onPreResponse

### DIFF
--- a/API.md
+++ b/API.md
@@ -3631,7 +3631,7 @@ const preResponse = function (request, reply) {
           message: (error.output.statusCode === 404 ? 'page not found' : 'something went wrong')
       };
 
-      return reply.view('error', ctx);
+      return reply.view('error', ctx).code(error.output.statusCode);
 };
 
 server.ext('onPreResponse', preResponse);


### PR DESCRIPTION
Updated the code slightly to include `.code(error.output.statusCode)` at the end of the reply, because with that code the templates are rendered and a 200 status code is sent instead of something like 404 or 500.