### PR TITLE
Add test for base64json cookie setting and parsing

### DIFF
--- a/API.md
+++ b/API.md
@@ -3442,7 +3442,8 @@ The response object provides the following methods:
     - `count` - the number of spaces to indent nested object keys. Defaults to no indentation.
 - `state(name, value, [options])` - sets an HTTP cookie where:
     - `name` - the cookie name.
-    - `value` - the cookie value. If no `encoding` is defined, must be a string.
+    - `value` - the cookie value. If no `encoding` is defined, must be a string. See
+      [`server.state()`](#serverstatename-options) for supported `encoding` values.
     - `options` - optional configuration. If the state was previously registered with the server
       using [`server.state()`](#serverstatename-options),
       the specified keys in `options` override those same keys in the server definition (but not

--- a/test/state.js
+++ b/test/state.js
@@ -40,6 +40,45 @@ describe('state', () => {
         });
     });
 
+    it('sets a cookie value to a base64json string representation of an object', (done) => {
+
+        const handler = function (request, reply) {
+
+            return reply('ok').state('data', { b: 3 });
+        };
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.state('data', { encoding: 'base64json' });
+        server.route({ method: 'GET', path: '/', handler });
+
+        server.inject('/', (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.headers['set-cookie']).to.equal(['data=eyJiIjozfQ==; Secure; HttpOnly; SameSite=Strict']);
+            done();
+        });
+    });
+
+    it('parses base64json cookies', (done) => {
+
+        const handler = function (request, reply) {
+
+            return reply(request.state);
+        };
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.state('data', { encoding: 'base64json' });
+        server.route({ method: 'GET', path: '/', handler });
+        server.inject({ method: 'GET', url: '/', headers: { cookie: 'data=eyJiIjozfQ==' } }, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result.data).to.equal({ b: 3 });
+            done();
+        });
+    });
+
     it('skips parsing cookies', (done) => {
 
         const handler = function (request, reply) {


### PR DESCRIPTION
I don't know if this kind of PR is appreciated?  I saw the example of setting a cookie using an object in the [helpful tutorial docs](https://hapijs.com/tutorials/cookies?lang=en_US) and thought it would be worth while to have it in the hapi tests?