### PR TITLE
Provide cover for unhandled rejections

### DIFF
--- a/API.md
+++ b/API.md
@@ -2871,23 +2871,25 @@ const handler = function (request, reply) {
 };
 ```
 
-If the handler returns a Promise then Hapi will register a `catch` handler on the promise object to catch unhandled promise rejections. The handler will `reply` with the error:
+If the handler returns a Promise then Hapi will register a `catch` handler on the promise object to catch unhandled promise rejections. The handler will `reply` with the rejected value, wrapped in a [`Boom`](https://github.com/hapijs/boom) error:
 
 ```js
 const handler = function (request, reply) {
 
-  const badPromise = () => {
+    const badPromise = () => {
 
-    new Promise(() => {
+        new Promise((resolve, reject) => {
 
-      setTimeout(() => throw new Error(), 1000);
+            // Hapi catches this...
+            throw new Error();
+
+            // ...and this...
+            return reject(new Error());
+        }
     }
-  }
 
-  // You *should* catch the rejection yourself! But hapi will
-  // return the error for you...
-  return badPromise()
-    .then((result) => { reply(result); });
+    // ...if you don't provide a 'catch'. The rejection will be wrapped in a Boom error.
+    return badPromise().then(reply);
 }
 ```
 

--- a/API.md
+++ b/API.md
@@ -2871,6 +2871,25 @@ const handler = function (request, reply) {
 };
 ```
 
+If the handler returns a Promise then Hapi will register a `catch` handler on the promise object to catch unhandled promise rejections. The handler will `reply` with the error:
+
+```js
+const handler = function (request, reply) {
+
+  const badPromise = () => {
+
+    new Promise(() => {
+
+      setTimeout(() => throw new Error(), 1000);
+    }
+  }
+
+  // You *should* catch the rejection yourself!
+  return badPromise()
+    .then((result) => { reply(result); })''
+}
+```
+
 ### Route prerequisites
 
 It is often necessary to perform prerequisite actions before the handler is called (e.g. load

--- a/API.md
+++ b/API.md
@@ -2884,11 +2884,14 @@ const handler = function (request, reply) {
     }
   }
 
-  // You *should* catch the rejection yourself!
+  // You *should* catch the rejection yourself! But hapi will
+  // return the error for you...
   return badPromise()
-    .then((result) => { reply(result); })''
+    .then((result) => { reply(result); });
 }
 ```
+
+This provides a safety net for unhandled promise rejections.
 
 ### Route prerequisites
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -5,6 +5,7 @@
 const Hoek = require('hoek');
 const Items = require('items');
 const Methods = require('./methods');
+const Promises = require('./promises');
 const Response = require('./response');
 
 
@@ -96,7 +97,12 @@ internals.handler = function (request, callback) {
 
     // Execute handler
 
-    request.route.settings.handler.call(bind, request, reply);
+    const handlerResult = request.route.settings.handler.call(bind, request, reply);
+
+    // Give hapi a fighting chance to deal with uncaught rejections.
+    if (Promises.isThennable(handlerResult)) {
+        handlerResult.catch(reply);
+    }
 };
 
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Hoek = require('hoek');
+const Boom = require('boom');
 const Items = require('items');
 const Methods = require('./methods');
 const Promises = require('./promises');
@@ -101,7 +102,18 @@ internals.handler = function (request, callback) {
 
     // Give hapi a fighting chance to deal with uncaught rejections.
     if (Promises.isThennable(handlerResult)) {
-        handlerResult.catch(reply);
+
+        handlerResult.then(null, (error) => {
+
+            //  Unhandled rejections are always Boom-ified, just like uncaught exceptions.
+            if (error instanceof Error) {
+                return reply(Boom.wrap(error));
+            }
+
+            const err = new Error('Rejected promise');
+            err.data = error;
+            return reply(Boom.wrap(err));
+        });
     }
 };
 

--- a/lib/promises.js
+++ b/lib/promises.js
@@ -24,3 +24,9 @@ exports.wrap = function (bind, method, args) {
         method.apply(bind, args ? args.concat(callback) : [callback]);
     });
 };
+
+exports.isThennable = function (candidate) {
+
+    return candidate && (typeof candidate.then === 'function') ? true : false;
+
+};

--- a/test/handler.js
+++ b/test/handler.js
@@ -169,6 +169,35 @@ describe('handler', () => {
                 done();
             });
         });
+
+        it('catches unhandled promise rejections when a promise is returned', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            const asyncOperation = function () {
+
+                return new Promise((resolve, reject) => {
+
+                    throw new Error('This should be rejected...');
+                });
+            };
+
+            const handler = function (request, reply) {
+
+                return asyncOperation()
+                  .then(reply);
+            };
+
+            server.route({ method: 'GET', path: '/', handler });
+
+            server.inject('/', (res) => {
+
+                expect(res.statusCode).to.equal(500);
+                expect(res.result.error).to.equal('Internal Server Error');
+                done();
+            });
+        });
     });
 
     describe('register()', () => {

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,0 +1,43 @@
+'use strict';
+
+// Load modules
+
+const Code = require('code');
+const Lab = require('lab');
+const Promises = require('../lib/promises');
+
+// Declare internals
+
+const internals = {};
+
+
+// Test shortcuts
+
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+
+describe('promise', () => {
+
+    it('recognises a promise as thennable', (done) => {
+
+        const promise = new Promise(() => {});
+        expect(Promises.isThennable(promise)).to.equal(true);
+
+        done();
+
+    });
+
+    it('recognises invalid input as not thennable', (done) => {
+
+        expect(Promises.isThennable(undefined)).to.equal(false);
+        expect(Promises.isThennable(null)).to.equal(false);
+        expect(Promises.isThennable({ })).to.equal(false);
+        expect(Promises.isThennable({ then: true })).to.equal(false);
+
+        done();
+
+    });
+});


### PR DESCRIPTION
This small change allows an extra degree of protection for those who might be using promises in their handlers.

## Problem Statement

Developers who are using promises in their handlers will often write handlers which look like this:

```js
function handler(request, reply) {
  doSomething
    .then((interimResult) => {
      return somethingElse(interimResult);
    })
    .then((result) => {
      reply(result.whatever);
    });
```

The challenge is that this opens up lots of opportunities for exceptions at different points to lead to uncaught promise rejections. For example:

```js
function handler(request, reply) {
  doSomething
    .then((interimResult) => {
      throw new Error('whoops...');
    })
    .then((result) => {
      reply(result.whatever);
    });
```

will lead to a timeout of the request.

## Suggested Change

Rather than attempting some kind of large scale change which adds more support for promises (which is not needed, as `reply` can take a promise), I propose allowing the handler to return a promise. If the promise is returned, then hapi can register a `catch` and `reply` with any error. This means that if the developer goofs up and forgets to catch (all to easy with the promise spec), hapi at least will attempt to deal with the error in the same way it would as if an exception was thrown.

This PR adds the support, updates the docs and tests.

## Questions

**Do we need this?**

It is possible to rewrite the dodgy code as:

```js
function handler(request, reply) {
  reply(doSomething
    .then((interimResult) => {
      return somethingElse(interimResult);
    })
    .then((result) => {
      return result.whatever;
    }));
```

However this tends to feel a little unnatural, as the natural reading order is more 'do work, reply with the result'. Fairly subjective but I've seen quite a few devs on teams default to doing it the way described in the problem statement, rather than this. It also makes doing things like changing the status code conditionally based on the result near impossible. (CMIIW!)

Of course, people could just avoid promises (which might not be a bad idea given some of the issues around how they can swallow exceptions), but at least an appreciable proportion of people are using them heavily.

**Should we ever have 'partial promise' support**

Really, if you are returning a promise in the handler it might make more sense to simply not even have the `reply` function used, and change the spec to say `if you return a promise, hapi with reply with the result or if there is an error, wrap it in Boom and then reply with that`.

This would perhaps be cleaner in some cases:

```js
function handler(req, reply) {
  return doSomething().then(r = doSomethingElse(r));
}
```

But is a larger structural change. Also, it still means we cannot easily change status codes, add headers etc.

I *think* this is a happier middle group - hapi's API stays the same, but it has a 'safety net' for promises.

## That's It!

I'd love to get any feedback on this as a potential feature. It would certainly help myself and my colleagues on some of the projects we're on at the moment, I believe it allows us to provide a safety net for potentially nasty issues (promise black holes are a pain) but am happy to take any input for changes!

## Related Issues

- https://github.com/hapijs/hapi/issues/2097
- https://github.com/hapijs/hapi/issues/2771
- https://github.com/hapijs/hapi/issues/3242
- https://github.com/hapijs/hapi/issues/3429