### PR TITLE
Node 8 fixes

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -63,7 +63,7 @@
       "version": "1.2.5"
     },
     "shot": {
-      "version": "3.4.0"
+      "version": "3.4.2"
     },
     "statehood": {
       "version": "5.0.2"

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -1785,6 +1785,8 @@ describe('transmission', () => {
 
                 const stream = new Stream.Readable();
 
+                stream.destroy = undefined;    // Node 8 streams comes with a destroy method – disable for this test
+
                 stream._read = function (size) {
 
                     const chunk = new Array(size).join('x');
@@ -1965,6 +1967,8 @@ describe('transmission', () => {
                 const stream = new Stream.Readable();
                 let responded = false;
 
+                stream.destroy = undefined;    // Node 8 streams comes with a destroy method – disable for this test
+
                 stream._read = function (size) {
 
                     const chunk = new Array(size).join('x');
@@ -1984,6 +1988,7 @@ describe('transmission', () => {
 
                 stream.once('end', () => {
 
+                    expect(responded).to.be.true();
                     server.stop(done);
                 });
 


### PR DESCRIPTION
Node 8 changes the `stream.Readable` implementation a bit. Some of the tests expects the `.destroy()` method to be absent, which I fixed by always clearing it.

The more serious issue, is `server.inject()`, which can return incorrect headers. This is not a test issue, but rather a bug, which is fixed by updating to the latest `shot` release.

Closes #3510 