### PR TITLE
allow decoration of reply with non functions

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -105,7 +105,7 @@ internals.Reply.prototype.interface = function (request, realm, options, next) {
         for (let i = 0; i < methods.length; ++i) {
             const method = methods[i];
             const decoration = this._decorations[method];
-            reply[method] = (domain ? domain.bind(decoration) : decoration);
+            reply[method] = (domain && typeof decoration === 'function') ? domain.bind(decoration) : decoration;
         }
     }
 

--- a/test/reply.js
+++ b/test/reply.js
@@ -26,6 +26,30 @@ const expect = Code.expect;
 
 describe('Reply', () => {
 
+    it('decorates reply with non function', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+
+        server.decorate('reply', 'abc', 123);
+
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: function (request, reply) {
+
+                return reply(reply.abc);
+            }
+        });
+
+        server.inject('/', (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal(123);
+            done();
+        });
+    });
+
     it('throws when reply called twice', (done) => {
 
         const handler = function (request, reply) {


### PR DESCRIPTION
After 16.2.0, it's not possible to decorate the reply object with something different to a function. This is due to the work originated on https://github.com/hapijs/hapi/pull/3448 where all reply methods are being bound to the request domain.
After that @hueniverse made a change to make sure that decorator methods are also bound to the domain, but it expects that any decoration added to the reply is also a function.
We were able to fix our issue by checking first that the decoration is in fact a function, and only bound it if that's the case.
I'm not sure if this is really a fix and if it's expected to be able to decorate the reply with something different to a function. I see that you always name the decoration as "method", but on the [docs](https://hapijs.com/api#serverdecoratetype-property-method-options) you mention the method argument for the decorate function can be

> the extension function or other value

which makes me thing that adding anything that's not a function is expected.
If the accepted behavior is to only allow functions to decorate the reply, then I'd be happy to contribute by adding an assertion on `decorate` to expect only functions and updating the docs to make that clear.

