### PR TITLE
Fixed validation of server's Joi options

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -132,7 +132,22 @@ internals.routeBase = Joi.object({
         status: Joi.object().pattern(/\d\d\d/, Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(true, false))
     })
         .without('modify', 'sample')
-        .assert('options.stripUnknown', Joi.ref('modify'), 'meet requirement of having peer modify set to true'),
+        .assert('options.stripUnknown', Joi.alternatives().when('modify', {
+            is: Joi.boolean().only(true).required(),
+            then: Joi.alternatives().try(
+                Joi.boolean(),
+                Joi.object()
+            )
+                .optional(),
+            otherwise: Joi.alternatives().try(
+                Joi.boolean().only(false),
+                Joi.object({
+                    objects: Joi.boolean().only(false),
+                    arrays: Joi.boolean().only(false)
+                })
+            )
+                .optional()
+        }), 'meet requirement of having peer modify set to true'),
     security: Joi.object({
         hsts: [
             Joi.object({

--- a/test/validation.js
+++ b/test/validation.js
@@ -1884,6 +1884,130 @@ describe('validation', () => {
         done();
     });
 
+    it('throws on options.stripUnknown.arrays without modify', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+
+        expect(() => {
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: function (request, reply) {
+
+                    return reply('ok');
+                },
+                config: {
+                    response: {
+                        schema: Joi.string(),
+                        options: {
+                            stripUnknown: {
+                                arrays: true
+                            }
+                        }
+                    }
+                }
+            });
+        }).to.throw(/"options.stripUnknown" failed to meet requirement of having peer modify set to true/);
+
+        done();
+    });
+
+    it('throws on options.stripUnknown.objects without modify', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+
+        expect(() => {
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: function (request, reply) {
+
+                    return reply('ok');
+                },
+                config: {
+                    response: {
+                        schema: Joi.string(),
+                        options: {
+                            stripUnknown: {
+                                objects: true
+                            }
+                        }
+                    }
+                }
+            });
+        }).to.throw(/"options.stripUnknown" failed to meet requirement of having peer modify set to true/);
+
+        done();
+    });
+
+    it('validates on options.stripUnknown.arrays/objects with modify', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+
+        expect(() => {
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: function (request, reply) {
+
+                    return reply('ok');
+                },
+                config: {
+                    response: {
+                        schema: Joi.string(),
+                        modify: true,
+                        options: {
+                            stripUnknown: {
+                                arrays: true,
+                                objects: true
+                            }
+                        }
+                    }
+                }
+            });
+        }).not.to.throw();
+
+        done();
+    });
+
+    it('validates without options.stripUnknown.arrays/objects with modify', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+
+        expect(() => {
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: function (request, reply) {
+
+                    return reply('ok');
+                },
+                config: {
+                    response: {
+                        schema: Joi.string(),
+                        modify: true,
+                        options: {
+                            stripUnknown: {
+                                arrays: false,
+                                objects: false
+                            }
+                        }
+                    }
+                }
+            });
+        }).not.to.throw();
+
+        done();
+    });
+
     it('binds route validate function to a context', (done) => {
 
         const server = new Hapi.Server();


### PR DESCRIPTION
I encountered an error when trying to pass this to my server:
```js
// ...
{
  modify: true,
  options: {
    stripUnknown: {
      objects: true,
      arrays: false
    }
  }
}
```
...telling me `stripUnknown` didn't `meet requirement of having peer modify set to true`.

It happened the validation made in Hapi was asserting stripUnknown was matching the validation of `modify`: a boolean. However, the documentation specifies `stripUnknwon` can also take an object.


Just to make a remark about my commit; I'm kind of disappointed to provide the validations for the inner values of the object [here](https://github.com/hapijs/hapi/compare/master...Brigad:validationOptions/stripUnknown?expand=1#diff-f412f4722a52cf22ed3d0a9a694b837dR144) because I feel like this is not the job it is intended to. Especially since I'm not doing it [there](https://github.com/hapijs/hapi/compare/master...Brigad:validationOptions/stripUnknown?expand=1#diff-f412f4722a52cf22ed3d0a9a694b837dR139) as it is resolved later by Joi itself.
I would  prefer to stick with a simple:
```js
// ...
otherwise: Joi.boolean().only(false)
```
Any preference?