### PR TITLE
Add support for Referrer-Policy security header

### DIFF
--- a/API.md
+++ b/API.md
@@ -2674,6 +2674,8 @@ following options:
       'noopen'.
     - `noSniff` - boolean controlling the 'X-Content-Type-Options' header. Defaults to
       `true` setting the header to its only and default option, 'nosniff'.
+    - `referrerPolicy` - controls the 'Referrer-Policy' header. When set to `true` the header will
+      be set to `origin`, you may also specify a string value of 'no-referrer', 'no-referrer-when-downgrade', 'origin', 'origin-when-cross-origin', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', or 'unsafe-url'. Defaults to `origin`.
 
 - <a name="route.config.state"></a>`state` - HTTP state management (cookies) allows
   the server to store information on the client which is sent back to the server with every

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -81,7 +81,8 @@ exports.security = {
     xframe: 'deny',
     xss: true,
     noOpen: true,
-    noSniff: true
+    noSniff: true,
+    referrerPolicy: 'origin'
 };
 
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -215,6 +215,15 @@ exports = module.exports = internals.Route = function (route, connection, plugin
                 security._xframe = security.xframe.rule.toUpperCase();
             }
         }
+
+        if (security.referrerPolicy) {
+            if (security.referrerPolicy === true) {
+                security._referrerPolicy = 'origin';
+            }
+            else {
+                security._referrerPolicy = security.referrerPolicy.toLowerCase();
+            }
+        }
     }
 
     // Handler

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -152,6 +152,12 @@ internals.routeBase = Joi.object({
                 source: Joi.string()
             })
         ],
+        referrerPolicy: [
+            Joi.boolean(),
+            Joi.string().valid('no-referrer', 'no-referrer-when-downgrade', 'origin',
+                                'origin-when-cross-origin', 'same-origin', 'strict-origin',
+                                'strict-origin-when-cross-origin', 'unsafe-url')
+        ],
         xss: Joi.boolean(),
         noOpen: Joi.boolean(),
         noSniff: Joi.boolean()

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -393,6 +393,10 @@ internals.security = function (response) {
             response._header('x-frame-options', security._xframe, { override: false });
         }
 
+        if (security._referrerPolicy) {
+            response._header('referrer-policy', security._referrerPolicy, { override: false });
+        }
+
         if (security.xss) {
             response._header('x-xss-protection', '1; mode=block', { override: false });
         }

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -2854,6 +2854,7 @@ describe('transmission', () => {
                 expect(res.headers['x-xss-protection']).to.not.exist();
                 expect(res.headers['x-download-options']).to.not.exist();
                 expect(res.headers['x-content-type-options']).to.not.exist();
+                expect(res.headers['referrer-policy']).to.not.exist();
                 done();
             });
         });
@@ -2878,6 +2879,7 @@ describe('transmission', () => {
                 expect(res.headers['x-xss-protection']).to.equal('1; mode=block');
                 expect(res.headers['x-download-options']).to.equal('noopen');
                 expect(res.headers['x-content-type-options']).to.equal('nosniff');
+                expect(res.headers['referrer-policy']).to.equal('origin');
                 done();
             });
         });
@@ -2906,12 +2908,13 @@ describe('transmission', () => {
                 expect(res.headers['x-xss-protection']).to.not.exist();
                 expect(res.headers['x-download-options']).to.not.exist();
                 expect(res.headers['x-content-type-options']).to.not.exist();
+                expect(res.headers['referrer-policy']).to.not.exist();
                 done();
             });
 
         });
 
-        it('does not return hsts header when secuirty.hsts is false', (done) => {
+        it('does not return hsts header when security.hsts is false', (done) => {
 
             const handler = function (request, reply) {
 
@@ -2931,6 +2934,7 @@ describe('transmission', () => {
                 expect(res.headers['x-xss-protection']).to.equal('1; mode=block');
                 expect(res.headers['x-download-options']).to.equal('noopen');
                 expect(res.headers['x-content-type-options']).to.equal('nosniff');
+                expect(res.headers['referrer-policy']).to.equal('origin');
                 done();
             });
 
@@ -3096,6 +3100,7 @@ describe('transmission', () => {
                 expect(res.headers['x-xss-protection']).to.equal('1; mode=block');
                 expect(res.headers['x-download-options']).to.equal('noopen');
                 expect(res.headers['x-content-type-options']).to.equal('nosniff');
+                expect(res.headers['referrer-policy']).to.equal('origin');
                 done();
             });
         });
@@ -3260,6 +3265,67 @@ describe('transmission', () => {
                 expect(res.headers['x-frame-options']).to.equal('DENY');
                 expect(res.headers['x-download-options']).to.equal('noopen');
                 expect(res.headers['x-content-type-options']).to.equal('nosniff');
+                expect(res.headers['referrer-policy']).to.equal('origin');
+                done();
+            });
+        });
+
+        it('does not set the referrer-policy header if referrerPolicy is false', (done) => {
+
+            const handler = function (request, reply) {
+
+                return reply('Test');
+            };
+
+            const server = new Hapi.Server();
+            server.connection({ routes: { security: { referrerPolicy: false } } });
+            server.route({ method: 'GET', path: '/', handler });
+
+            server.inject({ url: '/' }, (res) => {
+
+                expect(res.result).to.exist();
+                expect(res.result).to.equal('Test');
+                expect(res.headers['referrer-policy']).to.not.exist();
+                done();
+            });
+        });
+
+        it('returns the default referrer policy header when security.referrerPolicy is true', (done) => {
+
+            const handler = function (request, reply) {
+
+                return reply('Test');
+            };
+
+            const server = new Hapi.Server();
+            server.connection({ routes: { security: { referrerPolicy: true } } });
+            server.route({ method: 'GET', path: '/', handler });
+
+            server.inject({ url: '/' }, (res) => {
+
+                expect(res.result).to.exist();
+                expect(res.result).to.equal('Test');
+                expect(res.headers['referrer-policy']).to.equal('origin');
+                done();
+            });
+        });
+
+        it('returns correct referrer policy header when security.referrerPolicy is a string', (done) => {
+
+            const handler = function (request, reply) {
+
+                return reply('Test');
+            };
+
+            const server = new Hapi.Server();
+            server.connection({ routes: { security: { referrerPolicy: 'strict-origin' } } });
+            server.route({ method: 'GET', path: '/', handler });
+
+            server.inject({ url: '/' }, (res) => {
+
+                expect(res.result).to.exist();
+                expect(res.result).to.equal('Test');
+                expect(res.headers['referrer-policy']).to.equal('strict-origin');
                 done();
             });
         });


### PR DESCRIPTION
This PR adds support for Referrer-Policy security header.
The allowed values were taken from the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy).

The default value was set to `origin` because it's a middle ground between sending the full URL and not sending the referrer at all, but it's up to debate.