### PR TITLE
Add payload fail action custom handler

### DIFF
--- a/API.md
+++ b/API.md
@@ -2591,6 +2591,11 @@ following options:
         - `'error'` - return a Bad Request (400) error response. This is the default value.
         - `'log'` - report the error but continue processing the request.
         - `'ignore'` - take no action and continue processing the request.
+        - a custom error handler function with the signature
+          `function(request, reply, error)` where:
+            - `request` - the [request object](#request-object).
+            - `reply` - the continuation [reply interface](#reply-interface).
+            - `error` - the error returned during payload parsing.
     - `defaultContentType` - the default 'Content-Type' HTTP header value is not present.
       Defaults to `'application/json'`.
     - `compression` - an object where each key is a content-encoding name and each value is an

--- a/lib/route.js
+++ b/lib/route.js
@@ -411,16 +411,34 @@ internals.payload = function (request, next) {
             return next();
         }
 
-        const failAction = request.route.settings.payload.failAction;         // failAction: 'error', 'log', 'ignore'
-        if (failAction !== 'ignore') {
-            request._log(['payload', 'error'], err);
+        // failAction: 'error', 'log', 'ignore', function (request, reply, error)
+
+        const failAction = request.route.settings.payload.failAction;
+        if (failAction === 'ignore') {
+            return next();
         }
 
-        if (failAction === 'error') {
+        request._log(['payload', 'error'], err);
+
+        // Log only
+
+        if (failAction === 'log') {
+            return next();
+        }
+
+        // Return error
+
+        if (typeof failAction !== 'function') {
             return next(err);
         }
 
-        return next();
+        // Custom handler
+
+        request._protect.run(next, (exit) => {
+
+            const reply = request.server._replier.interface(request, request.route.realm, {}, exit);
+            failAction(request, reply, error);
+        });
     };
 
     Subtext.parse(request.raw.req, request._tap(), request.route.settings.payload, (err, parsed) => {

--- a/lib/route.js
+++ b/lib/route.js
@@ -437,7 +437,7 @@ internals.payload = function (request, next) {
         request._protect.run(next, (exit) => {
 
             const reply = request.server._replier.interface(request, request.route.realm, {}, exit);
-            failAction(request, reply, error);
+            failAction(request, reply, err);
         });
     };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -112,7 +112,10 @@ internals.routeBase = Joi.object({
         override: Joi.string(),
         maxBytes: Joi.number().integer().positive(),
         uploads: Joi.string(),
-        failAction: Joi.string().valid('error', 'log', 'ignore'),
+        failAction: [
+            Joi.string().valid('error', 'log', 'ignore'),
+            Joi.func()
+        ],
         timeout: Joi.number().integer().positive().allow(false),
         defaultContentType: Joi.string(),
         compression: Joi.object().pattern(/.+/, Joi.object())

--- a/test/route.js
+++ b/test/route.js
@@ -240,7 +240,7 @@ describe('Route', () => {
             expect(res.statusCode).to.equal(200);
             expect(logged).to.be.an.object();
             expect(logged.data).to.be.an.error('Invalid request payload JSON format');
-            expect(logged.data.data).to.be.an.error(SyntaxError, 'Unexpected token a in JSON at position 1');
+            expect(logged.data.data).to.be.an.error(SyntaxError, /^Unexpected token a/);
             done();
         });
     });

--- a/test/route.js
+++ b/test/route.js
@@ -182,6 +182,126 @@ describe('Route', () => {
         done();
     });
 
+    it('ignores payload parsing errors', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.route({
+            method: 'POST',
+            path: '/',
+            handler: function (request, reply) {
+
+                return reply('ok');
+            },
+            config: {
+                payload: {
+                    parse: true,
+                    failAction: 'ignore'
+                }
+            }
+        });
+
+        server.inject({ method: 'POST', url: '/', payload: '{a:"abc"}' }, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    it('logs payload parsing errors', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.route({
+            method: 'POST',
+            path: '/',
+            handler: function (request, reply) {
+
+                return reply('ok');
+            },
+            config: {
+                payload: {
+                    parse: true,
+                    failAction: 'log'
+                }
+            }
+        });
+
+        let logged;
+        server.on('request-internal', (request, event, tags) => {
+
+            if (tags.payload && tags.error) {
+                logged = event;
+            }
+        });
+
+        server.inject({ method: 'POST', url: '/', payload: '{a:"abc"}' }, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(logged).to.be.an.object();
+            expect(logged.data).to.be.an.error('Invalid request payload JSON format');
+            expect(logged.data.data).to.be.an.error(SyntaxError, 'Unexpected token a in JSON at position 1');
+            done();
+        });
+    });
+
+    it('returns payload parsing errors', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.route({
+            method: 'POST',
+            path: '/',
+            handler: function (request, reply) {
+
+                return reply('ok');
+            },
+            config: {
+                payload: {
+                    parse: true,
+                    failAction: 'error'
+                }
+            }
+        });
+
+        server.inject({ method: 'POST', url: '/', payload: '{a:"abc"}' }, (res) => {
+
+            expect(res.statusCode).to.equal(400);
+            expect(res.result.message).to.equal('Invalid request payload JSON format');
+            done();
+        });
+    });
+
+    it('replaces payload parsing errors with custom handler', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.route({
+            method: 'POST',
+            path: '/',
+            handler: function (request, reply) {
+
+                return reply('ok');
+            },
+            config: {
+                payload: {
+                    parse: true,
+                    failAction: function (request, reply, error) {
+
+                        return reply('This is a custom error').code(418);
+                    }
+                }
+            }
+        });
+
+        server.inject({ method: 'POST', url: '/', payload: '{a:"abc"}' }, (res) => {
+
+            expect(res.statusCode).to.equal(418);
+            expect(res.result).to.equal('This is a custom error');
+            done();
+        });
+    });
+
     it('throws when validation is set on GET', (done) => {
 
         const server = new Hapi.Server();


### PR DESCRIPTION
Hi All,

This PR adds a custom handler implementation to the route payload failAction, much like the route validate failAction. It addresses #3509.

I have also added tests for the three string failAction types, along with a test for the new functionality.

I'm consistently getting an error in one test locally that was present before I made these changes:

```
Failed tests:

  757) transmission transmit() handles stream errors on the response after the response has been piped (inject):

      Timed out (3000ms) - transmission transmit() handles stream errors on the response after the response has been piped (inject)
```

Just a head's up.

Thanks!