### PR TITLE
Add yarn to the Travis tests matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
 install: case "$PACKAGE_MANAGER" in
            npm) npm install ;;
            yarn)
-             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-             echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-             apt-get update
-             apt-get install yarn
-             yarn --pure-lockfile
+             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - ;
+             echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list ;
+             apt-get update ;
+             apt-get install yarn ;
+             yarn --pure-lockfile ;
            ;;
          esac
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ env:
 
 install: case "$PACKAGE_MANAGER" in
            npm) npm install ;;
-           yarn) yarn --pure-lockfile ;;
+           yarn)
+             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+             echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+             apt-get update
+             apt-get install yarn
+             yarn --pure-lockfile
+           ;;
          esac
 
 script: case "$PACKAGE_MANAGER" in

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,18 @@ node_js:
   - "8"
   - "node"
 
+env:
+  - PACKAGE_MANAGER=npm
+  - PACKAGE_MANAGER=yarn
+
+install: case "$PACKAGE_MANAGER" in
+           npm) npm install ;;
+           yarn) yarn --pure-lockfile ;;
+         esac
+
+script: case "$PACKAGE_MANAGER" in
+          npm) npm test ;;
+          yarn) yarn test ;;
+        esac
+
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ env:
 install: case "$PACKAGE_MANAGER" in
            npm) npm install ;;
            yarn)
-             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - ;
-             echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list ;
-             apt-get update ;
-             apt-get install yarn ;
+             npm install --global yarn@0.27.5 ;
              yarn --pure-lockfile ;
            ;;
          esac


### PR DESCRIPTION
It has been reported [here](https://github.com/hapijs/hapi/issues/3552#issuecomment-317126792) that installing Hapi with Yarn is not tested on the CI.

This PR adds Yarn to the Travis tests matrix.

This allows us to make sure Hapi can successfully be installed with the two main package managers. This patch is flexible and allows us to add more in the future if need be.