### PR TITLE
fix response.message(httpMessage)

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -329,15 +329,15 @@ internals.writeHead = function (response) {
         return Boom.boomify(err);
     }
 
+    if (response.settings.message) {
+        res.statusMessage = response.settings.message;
+    }
+
     try {
         res.writeHead(response.statusCode);
     }
     catch (err) {
         return Boom.boomify(err);
-    }
-
-    if (response.settings.message) {
-        res.statusMessage = response.settings.message;
     }
 
     return null;

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -2555,6 +2555,35 @@ describe('transmission', () => {
         });
     });
 
+    describe('writeHead()', () => {
+
+        it('set custom statusMessage', (done) => {
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            const handler = function (request, reply) {
+
+                return reply({}).message('Great');
+            };
+
+            server.route({ method: 'GET', path: '/', handler });
+            server.start((err) => {
+
+                expect(err).to.not.exist();
+
+                const uri = 'http://localhost:' + server.info.port;
+
+                Wreck.get(uri, {}, (err, res) => {
+
+                    expect(err).to.not.exist();
+                    expect(res.statusMessage).to.equal('Great');
+                    server.stop(done);
+                });
+            });
+        });
+    });
+
     describe('cache()', () => {
 
         it('sets max-age value (method and route)', (done) => {


### PR DESCRIPTION
res.statusMessage should assign before calling res.writeHead() explicitly. see https://nodejs.org/api/http.html#http_response_statusmessage