### PR TITLE
add header validation step to request lifecycle in API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -2320,6 +2320,7 @@ Each incoming request passes through a pre-defined list of steps, along with opt
 - Read and parse payload
 - Authenticate request payload
 - **`'onPostAuth'`** extension point
+- Validate headers
 - Validate path parameters
 - Validate query
 - Validate payload


### PR DESCRIPTION
The step to validate request headers is currently missing within the request lifecylce list (in `API.md`).

[Adri’s tweet](https://twitter.com/AdriVanHoudt_/status/899522763584655361) made me recognize it :)