### PR TITLE
chore(improvement): no need to loop arguments

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -101,12 +101,7 @@ internals.Plugin.prototype._single = function () {
 
 internals.Plugin.prototype.select = function (/* labels */) {
 
-    let labels = [];
-    for (let i = 0; i < arguments.length; ++i) {
-        labels.push(arguments[i]);
-    }
-
-    labels = Hoek.flatten(labels);
+    const labels = Hoek.flatten(arguments);
     return this._select(labels);
 };
 


### PR DESCRIPTION
This PR is minor improvement to current Hapi code in `plugin.js`. If the intent is to pass all `arguments` from select. We can just process flattened on `arguments` variable without having redeclaring and put it into temporary variables. CMIIW.
