### PR TITLE
Use rest parameter for optimized code

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -52,9 +52,9 @@ internals.Methods.prototype._add = function (name, method, options, realm) {
     settings.generateKey = settings.generateKey || internals.generateKey;
     const bind = settings.bind || realm.settings.bind || null;
 
-    const apply = function () {
+    const apply = function (...args) {
 
-        return method.apply(bind, arguments);
+        return method.apply(bind, args);
     };
 
     const bound = bind ? apply : method;
@@ -63,20 +63,13 @@ internals.Methods.prototype._add = function (name, method, options, realm) {
 
     let normalized = bound;
     if (settings.callback === false) {                                          // Defaults to true
-        normalized = function (/* arg1, arg2, ..., argn, methodNext */) {
-
-            const args = [];
-            for (let i = 0; i < arguments.length - 1; ++i) {
-                args.push(arguments[i]);
-            }
-
-            const methodNext = arguments[arguments.length - 1];
+        normalized = function (...methods /* arg1, arg2, ..., argn, methodNext */) {
 
             let result = null;
             let error = null;
 
             try {
-                result = method.apply(bind, args);
+                result = method.apply(bind, methods);
             }
             catch (err) {
                 error = err;
@@ -86,6 +79,8 @@ internals.Methods.prototype._add = function (name, method, options, realm) {
                 error = result;
                 result = null;
             }
+
+            const methodNext = methods[methods.length - 1];
 
             if (error ||
                 typeof result !== 'object' ||
@@ -180,11 +175,11 @@ internals.Methods.prototype._assign = function (name, method, normalized) {
 };
 
 
-internals.generateKey = function () {
+internals.generateKey = function (...args) {
 
     let key = '';
-    for (let i = 0; i < arguments.length; ++i) {
-        const arg = arguments[i];
+    for (let i = 0; i < args.length; ++i) {
+        const arg = args[i];
         if (typeof arg !== 'string' &&
             typeof arg !== 'number' &&
             typeof arg !== 'boolean') {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -99,12 +99,7 @@ internals.Plugin.prototype._single = function () {
 };
 
 
-internals.Plugin.prototype.select = function (/* labels */) {
-
-    let labels = [];
-    for (let i = 0; i < arguments.length; ++i) {
-        labels.push(arguments[i]);
-    }
+internals.Plugin.prototype.select = function (...labels /* labels */) {
 
     labels = Hoek.flatten(labels);
     return this._select(labels);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "web"
   ],
   "engines": {
-    "node": ">=4.8.0"
+    "node": ">=8.3.0"
   },
   "dependencies": {
     "accept": "^2.1.4",


### PR DESCRIPTION
As @cjihrig suggested, this is **breaking changes** toward Hapi 17.0.0 release by using Node 8.3. 

Hapi will be in 17.0.0, toward this release we can use Node version 8 above. In Node 8.3, we can use rest parameter to destruct arguments and avoid workaround solution to optimized arguments. 

Implementation reference: https://github.com/davidmarkclements/v8-perf
PR reference: https://github.com/hapijs/hapi/pull/3576