### PR TITLE
Support joi 11 paths arrays. Fixes #3581.

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -86,7 +86,8 @@ internals.input = function (source, request, next) {
         error.output.payload.validation = { source, keys: [] };
         if (err.details) {
             for (let i = 0; i < err.details.length; ++i) {
-                error.output.payload.validation.keys.push(Hoek.escapeHtml(err.details[i].path));
+                const path = err.details[i].path;
+                error.output.payload.validation.keys.push(Hoek.escapeHtml(Array.isArray(path) ? path.join('.') : path));
             }
         }
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -614,6 +614,41 @@ describe('validation', () => {
         });
     });
 
+    it('fails on invalid input (with joi 11 error)', (done) => {
+
+        // Fake the joi 11 format
+        const joiFakeError = new Error();
+        joiFakeError.details = [{ path: ['foo', 'bar'] }];
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: function (request, reply) {
+
+                return reply('ok');
+            },
+            config: {
+                validate: {
+                    query: {
+                        a: Joi.number().error(joiFakeError)
+                    }
+                }
+            }
+        });
+
+        server.inject('/?a=abc', (res) => {
+
+            expect(res.statusCode).to.equal(400);
+            expect(res.result.validation).to.equal({
+                source: 'query',
+                keys: ['foo.bar']
+            });
+            done();
+        });
+    });
+
     it('ignores invalid input', (done) => {
 
         const server = new Hapi.Server();


### PR DESCRIPTION
I went with preserving the old response format, but this begs the question of whether it should send back keys as strings or array of strings now that it's possible. Thoughts ?