### PR TITLE
Updated documentation on prerequisites. They are kicked off asynchron…

### DIFF
--- a/API.md
+++ b/API.md
@@ -2977,7 +2977,11 @@ Note that prerequisites do not follow the same rules of the normal
 [reply interface](#reply-interface). In all other cases, calling `reply()` with or without a value
 will use the result as the response sent back to the client. In a prerequisite method, calling
 `reply()` will assign the returned value to the provided `assign` key. If the returned value is an
-error, the `failAction` setting determines the behavior. To force the return value as the response
+error, the `failAction` setting determines the behavior.
+
+Prerequisites are not parallel. They are kicked off asynchronously. However, prerequisite methods can have parallel operations within them. The Handler gets the reply once all prerequisite metods are done.
+
+To force the return value as the response
 and skip any other prerequisites and the handler, use the `reply().takeover()` method.
 
 The reason for the difference in the reply interface behavior is to allow reusing handlers and

--- a/API.md
+++ b/API.md
@@ -2979,7 +2979,7 @@ will use the result as the response sent back to the client. In a prerequisite m
 `reply()` will assign the returned value to the provided `assign` key. If the returned value is an
 error, the `failAction` setting determines the behavior.
 
-Prerequisites are not parallel. They are kicked off asynchronously. However, prerequisite methods can have parallel operations within them. The Handler gets the reply once all prerequisite metods are done.
+Prerequisites are not parallel. They are kicked off asynchronously. However, prerequisite methods can have parallel operations within them. The Handler gets the reply once all prerequisite methods are done.
 
 To force the return value as the response
 and skip any other prerequisites and the handler, use the `reply().takeover()` method.


### PR DESCRIPTION
Last night, I attended a talk given by https://github.com/codesleuth called "Being Asynchronous" which lead me to question how prerequisites work in Hapi. I had been told that they were Asynchronous, but the documentation says:

https://hapijs.com/api#route-prerequisites

To force the return value as the response and skip any other prerequisites and the handler, use the reply().takeover() method.
This appears to be a mistake. As I understand it you cannot skip functions run in parallel.

Prerequisites are not parallel. They are kicked off asynchronously. However, those prerequisite methods might have parallel operations within them. The Handler gets the reply once all those prerequisites are done. I would like to update the documentation to state this.

Many thanks,
Rob

(my first pull request on an open source project! :D)