### PR TITLE
exclude connection header in response passThrough

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -464,7 +464,10 @@ exports = module.exports = internals.Response = class {
 
                     for (let i = 0; i < headerKeys.length; ++i) {
                         const key = headerKeys[i];
-                        this.header(key.toLowerCase(), Hoek.clone(this.source.headers[key]));     // Clone arrays
+                        const lower = key.toLowerCase();
+                        if (lower !== 'connection'){                                      // Do not copy per-hop connection options
+                            this.header(lower, Hoek.clone(this.source.headers[key]));     // Clone arrays
+                        }
                     }
 
                     headerKeys = Object.keys(localHeaders);


### PR DESCRIPTION
When a hapi.js server is acting as a proxy or gateway, and a handler calls the reply/responder interface with a stream that is an IncomingMessage from an upstream, I believe the default behavior of the passThrough mode should be to not copy the connection header.

The semantics of the Connection header are that it represents per-hop connection options, and that a proxy or gateway MUST remove any connection options before forwarding a message (in this case a response to its client).  Basically connection options (usually keep-alive or close) should be negotiated between the server/client and between the server/upstream independent of each other.

The semantics of the Connection header are actually a little more complicated than that, because the header is supposed to be able to container tokens representing *other* headers that are per-hop. But I do not have that use case myself, so I did not undertake to implement that.

