### PR TITLE
Add negative test on registering plugin twice without `once`

### DIFF
--- a/API.md
+++ b/API.md
@@ -2191,8 +2191,9 @@ Registers a plugin where:
 - `options` - (optional) registration options (different from the options passed to the
   registration function):
 
-    - `once` - if `true`, the registration is skipped for any connection already registered with.
+    - `once` - if `true`, subsequent registrations of the same plugin are skipped without error.
       Cannot be used with plugin options. Defaults to `false`.
+      If not set to `true`, an error will be thrown the second time a plugin is registered on the server.
 
     - `routes` - modifiers applied to each route added by the plugin:
 

--- a/test/server.js
+++ b/test/server.js
@@ -635,6 +635,26 @@ describe('Server', () => {
             await expect(server.register({ plugin: a, options: {}, once: true })).to.reject();
         });
 
+        it('throws when once is false', async () => {
+
+            const b = {
+                name: 'b',
+                register: Hoek.ignore
+            };
+
+            const a = {
+                name: 'a',
+                register: function (srv, options) {
+
+                    return srv.register(b);
+                }
+            };
+
+            const server = Hapi.server();
+            await server.register(b);
+            await expect(server.register(a)).to.reject(Error, 'Plugin b already registered');
+        });
+
         it('throws when dependencies is an object', async () => {
 
             const a = {


### PR DESCRIPTION
This commit adds a negative test around registering the same plugin multiple times with `once` defaulted to `false`. This test is to clarify the intent of the `once` flag by displaying the difference in behavior when it is not set.

API.md is also updated to reflect the behavior now that `connections` are removed.


NOTE: I actually think that `once` can be deprecated entirely, and the default `Error: Plugin ___ already registered` used for all subsequent registrations. Please let me know if you'd like me to do that instead and I will close this PR and open a new one to remove `once` entirely.