### PR TITLE
Loosen sample and modify peer validator in the routeBase schema

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -163,13 +163,12 @@ internals.routeBase = Joi.object({
         modify: Joi.boolean(),
         options: Joi.object().default(),
         ranges: Joi.boolean().default(true),
-        sample: Joi.number().min(0).max(100),
+        sample: Joi.number().min(0).max(100).when('modify', { is: true, then: Joi.forbidden() }),
         schema: Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(true, false),
         status: Joi.object().pattern(/\d\d\d/, Joi.alternatives(Joi.object(), Joi.array(), Joi.func()).allow(true, false))
     })
         .default()
-        .without('modify', 'sample')
-        .assert('options.stripUnknown', Joi.when('modify', { is: true, otherwise: Joi.forbidden() }), 'meet requirement of having peer modify set to true'),
+        .assert('options.stripUnknown', Joi.when('modify', { is: true, otherwise: [Joi.boolean().valid(false), Joi.forbidden()] }), 'meet requirement of having peer modify set to true'),
     security: Joi.object({
         hsts: Joi.alternatives([
             Joi.object({

--- a/test/validation.js
+++ b/test/validation.js
@@ -1123,7 +1123,29 @@ describe('validation', () => {
                     },
                     handler: () => ({ a: 1, b: 2 })
                 });
-            }).to.throw(/"modify" conflict with forbidden peer "sample"/);
+            }).to.throw(/"sample" is not allowed/);
+        });
+
+        it('do not throws on sample with false response modify', () => {
+
+            const server = Hapi.server({ debug: false });
+            expect(() => {
+
+                server.route({
+                    method: 'GET',
+                    path: '/',
+                    config: {
+                        response: {
+                            schema: Joi.object({
+                                a: Joi.number()
+                            }).options({ stripUnknown: true }),
+                            modify: false,
+                            sample: 90
+                        }
+                    },
+                    handler: () => ({ a: 1, b: 2 })
+                });
+            }).to.not.throw();
         });
 
         it('validates response using custom validation function', async () => {


### PR DESCRIPTION
It fixes #3567

- Make `routeBase` schema allows `sample` props when `modify` is set to false
- Make `options.stripUnknown` assertion allows `false` value when `modify` is set to false
