### PR TITLE
Fix server method registered as object without options

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -38,7 +38,7 @@ exports = module.exports = internals.Methods = class {
         }
     }
 
-    _add(name, method, options, realm) {
+    _add(name, method, options = {}, realm) {
 
         Hoek.assert(typeof method === 'function', 'method must be a function');
         Hoek.assert(typeof name === 'string', 'name must be a string');

--- a/lib/server.js
+++ b/lib/server.js
@@ -326,7 +326,7 @@ internals.Server = class {
         return match.route.public;
     }
 
-    method(name, method, options = {}) {
+    method(name, method, options) {
 
         return this._core.methods.add(name, method, options, this.realm);
     }

--- a/test/methods.js
+++ b/test/methods.js
@@ -92,6 +92,30 @@ describe('Methods', () => {
         expect(result).to.equal(6);
     });
 
+    it('registers a method using an object argument (no options)', () => {
+
+        const server = Hapi.server();
+        server.method({ name: 'add', method: (a, b) => a + b });
+
+        const result = server.methods.add(1, 5);
+        expect(result).to.equal(6);
+    });
+
+    it('registers a method using an array argument (no options)', () => {
+
+        const server = Hapi.server();
+        server.method([
+            { name: 'add', method: (a, b) => a + b },
+            { name: 'subtract', method: (a, b) => a - b }
+        ]);
+
+        const addResult = server.methods.add(1, 5);
+        expect(addResult).to.equal(6);
+
+        const subtractResult = server.methods.subtract(1, 5);
+        expect(subtractResult).to.equal(-4);
+    });
+
     it('registers a method (promise)', async () => {
 
         const add = function (a, b) {


### PR DESCRIPTION
Currently (hapi v17.1.1, node v8, OSX) the following error occurs when attempting to register a server method of the form [`server.method({ name, method })`](https://github.com/hapijs/hapi/blob/master/API.md#-servermethodmethods) (without `options`),
```
      Cannot read property 'generateKey' of undefined

      at module.exports.internals.Methods._add (/hapi/lib/methods.js:51:40)
      at module.exports.internals.Methods.add (/hapi/lib/methods.js:37:18)
      at internals.Server.method (/hapi/lib/server.js:331:35)
      at it (/hapi/test/methods.js:98:16)
```

This PR offers a proposed fix and tests.