### PR TITLE
Correct server state configuration option

### DIFF
--- a/API.md
+++ b/API.md
@@ -1937,7 +1937,7 @@ across multiple requests. Registers a cookie definitions where:
       violation of [RFC 6265](https://tools.ietf.org/html/rfc6265). Defaults to `true`.
     - `passThrough` - used by proxy plugins (e.g. [**h2o2**](https://github.com/hapijs/h2o2)).
 
-State defaults can be modified via the server `connections.routes.state` configuration option.
+State defaults can be modified via the server `connections.state` configuration option.
 
 ```js
 const Hapi = require('hapi');


### PR DESCRIPTION
I got this error when putting `state` under the server's `connections.routes`:
```
Error: Invalid server options {
  "connections": {
    "router": {
      "isCaseSensitive": false,
      "stripTrailingSlash": true
    },
    "routes": {
      "state": {
        "isHttpOnly" [1]: false
      }
    }
  }
}

[1] "isHttpOnly" is not allowed
```

However it works when I put `state` under the server's `connections` (https://hapijs.com/api/16.6.2#new-serveroptions), like this:
```
{
  connections: {
    router: {
      isCaseSensitive: false,
      stripTrailingSlash: true
    },
    state: {
      isHttpOnly: false
    }
  }
}
```

I'm confused since I thought `state` can be used as a route option (https://hapijs.com/api/16.6.2#route-options)