### PR TITLE
Minor server.method documentation fix

### DIFF
--- a/API.md
+++ b/API.md
@@ -2242,7 +2242,7 @@ async function example() {
         generateKey: (array) => array.join(',')
     };
 
-    server.method('sumObj', addArray, );
+    server.method('sumObj', addArray, options);
 
     console.log(await server.methods.sumObj([5, 6]));     // 11
 }


### PR DESCRIPTION
The `options` object was left behind causing a syntax error.