### PR TITLE
Replace new Buffer()

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -44,7 +44,7 @@ const internals = {
         'start',
         'stop'
     ],
-    badRequestResponse: new Buffer('HTTP/1.1 400 Bad Request\r\n\r\n', 'ascii')
+    badRequestResponse: Buffer.from('HTTP/1.1 400 Bad Request\r\n\r\n', 'ascii')
 };
 
 

--- a/test/payload.js
+++ b/test/payload.js
@@ -132,7 +132,7 @@ describe('payload', () => {
 
     it('returns 413 with response when payload is not consumed', async () => {
 
-        const payload = new Buffer(10 * 1024 * 1024).toString();
+        const payload = Buffer.alloc(10 * 1024 * 1024).toString();
 
         const server = Hapi.server();
         server.route({ method: 'POST', path: '/', options: { handler: () => null, payload: { maxBytes: 1024 * 1024 } } });
@@ -487,7 +487,7 @@ describe('payload', () => {
 
     it('signals connection close when payload is unconsumed', async () => {
 
-        const payload = new Buffer(1024);
+        const payload = Buffer.alloc(1024);
         const server = Hapi.server();
         server.route({ method: 'POST', path: '/', options: { handler: () => 'ok', payload: { maxBytes: 1024, output: 'stream', parse: false } } });
 

--- a/test/response.js
+++ b/test/response.js
@@ -201,7 +201,7 @@ describe('Response', () => {
 
             const handler = (request, h) => {
 
-                return h.response('ok').header('set-cookie', new Buffer(decodeURIComponent('%E0%B4%8Aset-cookie:%20foo=bar')));
+                return h.response('ok').header('set-cookie', Buffer.from(decodeURIComponent('%E0%B4%8Aset-cookie:%20foo=bar')));
             };
 
             const server = Hapi.server();

--- a/test/server.js
+++ b/test/server.js
@@ -822,7 +822,7 @@ describe('Server', () => {
             const res1 = await server.inject('/');
             expect(res1.statusCode).to.equal(401);
 
-            const res2 = await server.inject({ method: 'GET', url: '/', headers: { authorization: 'Basic ' + (new Buffer('john:12345', 'utf8')).toString('base64') } });
+            const res2 = await server.inject({ method: 'GET', url: '/', headers: { authorization: 'Basic ' + (Buffer.from('john:12345', 'utf8')).toString('base64') } });
             expect(res2.statusCode).to.equal(200);
             expect(res2.result).to.equal('authenticated!');
         });
@@ -1520,7 +1520,7 @@ describe('Server', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await new Promise((resolve) => Zlib.gzip(new Buffer(data), (ignoreErr, compressed) => resolve(compressed)));
+            const zipped = await new Promise((resolve) => Zlib.gzip(Buffer.from(data), (ignoreErr, compressed) => resolve(compressed)));
             const { res, payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip, deflate, test' }, payload: data });
             expect(res.headers['content-encoding']).to.equal('test');
             expect(payload.toString()).to.equal(zipped.toString());
@@ -2654,7 +2654,7 @@ internals.plugins = {
                             throw Boom.badRequest('Bad HTTP authentication header format', 'Basic');
                         }
 
-                        const credentialsParts = new Buffer(parts[1], 'base64').toString().split(':');
+                        const credentialsParts = Buffer.from(parts[1], 'base64').toString().split(':');
                         if (credentialsParts.length !== 2) {
                             throw Boom.badRequest('Bad header internal syntax', 'Basic');
                         }

--- a/test/toolkit.js
+++ b/test/toolkit.js
@@ -183,7 +183,7 @@ describe('Toolkit', () => {
 
                 const handler = (request, h) => {
 
-                    return h.response(new Buffer('Tada1')).code(299);
+                    return h.response(Buffer.from('Tada1')).code(299);
                 };
 
                 const server = Hapi.server();

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -378,7 +378,7 @@ describe('transmission', () => {
         it('returns an JSONP response when response is a buffer', async () => {
 
             const server = Hapi.server();
-            server.route({ method: 'GET', path: '/', options: { jsonp: 'callback', handler: () => new Buffer('value') } });
+            server.route({ method: 'GET', path: '/', options: { jsonp: 'callback', handler: () => Buffer.from('value') } });
 
             const res = await server.inject('/?callback=me');
             expect(res.payload).to.equal('/**/me(value);');
@@ -752,7 +752,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
 
             const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip' }, payload: data });
             expect(payload.toString()).to.equal(zipped.toString());
@@ -768,7 +768,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
             const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip' } });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
@@ -809,7 +809,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const deflated = await internals.compress('deflate', new Buffer(data));
+            const deflated = await internals.compress('deflate', Buffer.from(data));
             const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'deflate' }, payload: data });
             expect(payload.toString()).to.equal(deflated.toString());
             await server.stop();
@@ -823,7 +823,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const deflated = await internals.compress('deflate', new Buffer(data));
+            const deflated = await internals.compress('deflate', Buffer.from(data));
             const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'deflate' } });
             expect(payload.toString()).to.equal(deflated.toString());
             await server.stop();
@@ -837,7 +837,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
             const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5' }, payload: data });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
@@ -851,7 +851,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
             const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5' } });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
@@ -865,7 +865,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const deflated = await internals.compress('deflate', new Buffer(data));
+            const deflated = await internals.compress('deflate', Buffer.from(data));
             const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5' }, payload: data });
             expect(payload.toString()).to.equal(deflated.toString());
             await server.stop();
@@ -879,7 +879,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const deflated = await internals.compress('deflate', new Buffer(data));
+            const deflated = await internals.compress('deflate', Buffer.from(data));
             const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5' } });
             expect(payload.toString()).to.equal(deflated.toString());
             await server.stop();
@@ -893,7 +893,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
             const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'deflate, gzip' }, payload: data });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
@@ -907,7 +907,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
             const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'deflate, gzip' } });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
@@ -928,7 +928,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
             const err1 = await expect(Wreck.get(uri, { headers: { 'accept-encoding': 'gzip' } })).to.reject();
             expect(err1.data.payload.toString()).to.equal(zipped.toString());
 
@@ -953,7 +953,7 @@ describe('transmission', () => {
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
             const err1 = await expect(Wreck.get(uri, { headers: { 'accept-encoding': 'gzip' } })).to.reject();
             expect(err1.data.payload.toString()).to.equal(zipped.toString());
 
@@ -998,7 +998,7 @@ describe('transmission', () => {
         it('returns a gzip response when forced by the handler', async () => {
 
             const data = '{"test":"true"}';
-            const zipped = await internals.compress('gzip', new Buffer(data));
+            const zipped = await internals.compress('gzip', Buffer.from(data));
             const server = Hapi.server({ compression: { minBytes: 1 } });
             server.route({ method: 'POST', path: '/', handler: (request, h) => h.response(zipped).type('text/plain').header('content-encoding', 'gzip') });
             await server.start();


### PR DESCRIPTION
Hi,
This is my first PR to hapi.js, after I posted in the discuss project ([Link](https://github.com/hapijs/discuss/issues/631)) 

This PR is related to the issue with using `new Buffer()`. As you probably know, `new Buffer()` has been deprecated due to security issues and replaced by `Buffer.from()`.

The changes:
- replaced all new Buffer(string) with Buffer.from(string)
- replaced all new Buffer(size) with Buffer.alloc(size)

I followed the "contributing guidelines" including tests.
