### PR TITLE
Fixed a typo in the documentation's example code

### DIFF
--- a/API.md
+++ b/API.md
@@ -595,7 +595,7 @@ const scheme = function (server, options) {
                 throw Boom.unauthorized(null, 'Custom');
             }
 
-            return h.authenticated{ credentials: { user: 'john' } });
+            return h.authenticated({ credentials: { user: 'john' } });
         }
     };
 };


### PR DESCRIPTION
It was missing a "(".