### PR TITLE
allow tests using lsof to pass on ENOENT

### DIFF
--- a/test/core.js
+++ b/test/core.js
@@ -12,6 +12,7 @@ const Path = require('path');
 const TLS = require('tls');
 
 const Boom = require('boom');
+const Bounce = require('bounce');
 const Code = require('code');
 const Handlebars = require('handlebars');
 const Hapi = require('..');
@@ -1489,6 +1490,13 @@ describe('Core', () => {
 
                     const cmd = ChildProcess.spawn('lsof', ['-p', process.pid]);
                     let lsof = '';
+
+                    cmd.on('error', (err) => {
+
+                        // Allow the test to pass on platforms with no lsof
+                        Bounce.ignore(err, { errno: 'ENOENT' });
+                    });
+
                     cmd.stdout.on('data', (buffer) => {
 
                         lsof += buffer.toString();

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -10,6 +10,7 @@ const Stream = require('stream');
 const Zlib = require('zlib');
 
 const Boom = require('boom');
+const Bounce = require('bounce');
 const Code = require('code');
 const Hapi = require('..');
 const Hoek = require('hoek');
@@ -78,6 +79,13 @@ describe('transmission', () => {
 
                 const cmd = ChildProcess.spawn('lsof', ['-p', process.pid]);
                 let lsof = '';
+
+                cmd.on('error', (err) => {
+
+                    // Allow the test to pass on platforms with no lsof
+                    Bounce.ignore(err, { errno: 'ENOENT' });
+                });
+
                 cmd.stdout.on('data', (buffer) => {
 
                     lsof += buffer.toString();
@@ -112,6 +120,13 @@ describe('transmission', () => {
 
                 const cmd = ChildProcess.spawn('lsof', ['-p', process.pid]);
                 let lsof = '';
+
+                cmd.on('error', (err) => {
+
+                    // Allow the test to pass on platforms with no lsof
+                    Bounce.ignore(err, { errno: 'ENOENT' });
+                });
+
                 cmd.stdout.on('data', (buffer) => {
 
                     lsof += buffer.toString();


### PR DESCRIPTION
The tests are currently skipped on Windows, but there are no guarantees that `lsof` exists on the system executing the tests.

Refs: https://github.com/nodejs/citgm/pull/436