### PR TITLE
Add PATCH to `created` status, better error msg

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -294,7 +294,7 @@ exports = module.exports = internals.Response = class {
 
         Hoek.assert(this.request.method === 'post' ||
             this.request.method === 'put' ||
-            this.request === 'patch', 'Cannot return 201 status codes for ' + this.request.method.toUpperCase());
+            this.request.method === 'patch', 'Cannot return 201 status codes for ' + this.request.method.toUpperCase());
 
         this.statusCode = 201;
         this.location(location);

--- a/lib/response.js
+++ b/lib/response.js
@@ -292,7 +292,9 @@ exports = module.exports = internals.Response = class {
 
     created(location) {
 
-        Hoek.assert(this.request.method === 'post' || this.request.method === 'put', 'Cannot create resource on GET');
+        Hoek.assert(this.request.method === 'post' ||
+            this.request.method === 'put' ||
+            this.request === 'patch', 'Cannot return 201 status codes for ' + this.request.method.toUpperCase());
 
         this.statusCode = 201;
         this.location(location);

--- a/test/response.js
+++ b/test/response.js
@@ -248,13 +248,13 @@ describe('Response', () => {
             
             const handler = (request, h) => {
 
-                return h.response().created('/something');
+                return h.response({ a: 1 }).created();
             };
-
-            const server = Hapi.server({ debug: false });
+            const server = Hapi.server();
             server.route({ method: 'PUT', path: '/', handler });
 
-            const res = await server.inject('/');
+            const res = await server.inject({ method: 'PUT', url: '/' });
+            expect(res.result).to.equal({ a: 1 });
             expect(res.statusCode).to.equal(201);
         });
         
@@ -262,13 +262,13 @@ describe('Response', () => {
             
             const handler = (request, h) => {
 
-                return h.response().created('/something');
+                return h.response({ a: 1 }).created();
             };
-
-            const server = Hapi.server({ debug: false });
+            const server = Hapi.server();
             server.route({ method: 'PATCH', path: '/', handler });
 
-            const res = await server.inject('/');
+            const res = await server.inject({ method: 'PUT', url: '/' });
+            expect(res.result).to.equal({ a: 1 });
             expect(res.statusCode).to.equal(201);
         });
     });

--- a/test/response.js
+++ b/test/response.js
@@ -243,6 +243,34 @@ describe('Response', () => {
             const res = await server.inject('/');
             expect(res.statusCode).to.equal(500);
         });
+        
+        it("doesn't return an error on created with PUT", async () => {
+            
+            const handler = (request, h) => {
+
+                return h.response().created('/something');
+            };
+
+            const server = Hapi.server({ debug: false });
+            server.route({ method: 'PUT', path: '/', handler });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(201);
+        });
+        
+        it("doesn't return an error on created with PATCH", async () => {
+            
+            const handler = (request, h) => {
+
+                return h.response().created('/something');
+            };
+
+            const server = Hapi.server({ debug: false });
+            server.route({ method: 'PATCH', path: '/', handler });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(201);
+        });
     });
 
     describe('state()', () => {

--- a/test/response.js
+++ b/test/response.js
@@ -243,9 +243,9 @@ describe('Response', () => {
             const res = await server.inject('/');
             expect(res.statusCode).to.equal(500);
         });
-        
-        it("doesn't return an error on created with PUT", async () => {
-            
+
+        it('doesn\'t return an error on created with PUT', async () => {
+
             const handler = (request, h) => {
 
                 return h.response({ a: 1 }).created();
@@ -257,9 +257,9 @@ describe('Response', () => {
             expect(res.result).to.equal({ a: 1 });
             expect(res.statusCode).to.equal(201);
         });
-        
-        it("doesn't return an error on created with PATCH", async () => {
-            
+
+        it('doesn\'t return an error on created with PATCH', async () => {
+
             const handler = (request, h) => {
 
                 return h.response({ a: 1 }).created();

--- a/test/response.js
+++ b/test/response.js
@@ -267,7 +267,7 @@ describe('Response', () => {
             const server = Hapi.server();
             server.route({ method: 'PATCH', path: '/', handler });
 
-            const res = await server.inject({ method: 'PUT', url: '/' });
+            const res = await server.inject({ method: 'PATCH', url: '/' });
             expect(res.result).to.equal({ a: 1 });
             expect(res.statusCode).to.equal(201);
         });


### PR DESCRIPTION
The `created` status code helper should also be valid at least for `PATCH` calls. 

BTW: Should this assertion even exist? I'd be in favor of getting rid of it and allow developers break the rules as they see fit.