### PR TITLE
Allow undefined handler and prehandler response values

### DIFF
--- a/lib/toolkit.js
+++ b/lib/toolkit.js
@@ -48,10 +48,6 @@ exports = module.exports = internals.Manager = class {
 
         // Process response
 
-        if (response === undefined) {
-            response = Boom.badImplementation(`${method.name} method did not return a value, a promise, or throw an error`);
-        }
-
         if (options.continue &&
             response === this.continue) {
 

--- a/test/toolkit.js
+++ b/test/toolkit.js
@@ -10,7 +10,6 @@ const Handlebars = require('handlebars');
 const Hapi = require('..');
 const Inert = require('inert');
 const Lab = require('lab');
-const Teamwork = require('teamwork');
 const Vision = require('vision');
 
 
@@ -102,25 +101,6 @@ describe('Toolkit', () => {
                 server.route({ method: 'GET', path: '/', handler });
                 const res = await server.inject('/');
                 expect(res.statusCode).to.equal(500);
-            });
-
-            it('includes method name when method missing return', async () => {
-
-                const team = new Teamwork();
-                const myErrorHandler = () => {};
-
-                const server = Hapi.server({ debug: false });
-                server.route({ method: 'GET', path: '/', handler: myErrorHandler });
-
-                server.events.on({ name: 'request', channels: 'error' }, (request, err) => {
-
-                    team.attend(err);
-                });
-
-                const res = await server.inject('/');
-                expect(res.statusCode).to.equal(500);
-                const err = await team.work;
-                expect(err.error.message).to.contain('myErrorHandler');
             });
         });
     });


### PR DESCRIPTION
There isn't anything inherently wrong with a handler or pre-handler that
doesn't need to modify the response. As an example, a pre-handler may
simply enforce RBAC privileges:

```JS
const checkWriteAccess = request => {
  if (request.params.admin) {
    throw Boom.unauthorized();
  }
}
```

(This is admittedly bad security design, but imagine a proper RBAC
mechanism)

Likewise, a handler that doesn't return a value may be used for a route
that returns an empty 204 response.