### PR TITLE
Fixes typo on server.auth.settings.default description

### DIFF
--- a/API.md
+++ b/API.md
@@ -611,7 +611,7 @@ console.log(server.auth.api.default.settings.x);    // 5
 
 Access: read only.
 
-Contains the default authentication configuration is a default strategy was set via
+Contains the default authentication configuration if a default strategy was set via
 [`server.auth.default()`](#server.auth.default()).
 
 #### <a name="server.decorations" /> `server.decorations`


### PR DESCRIPTION
There looks to be a typo in:

> Contains the default authentication configuration **is** a default strategy was set via server.auth.default().

PR changes it to:
> Contains the default authentication configuration **if** a default strategy was set via server.auth.default().
