### PR TITLE
support symbol properties in server.decorate()

### DIFF
--- a/API.md
+++ b/API.md
@@ -1466,7 +1466,7 @@ Extends various framework interfaces with custom methods where:
     - `'server'` - adds methods to the [Server](#server) object.
     - `'toolkit'` - adds methods to the [response toolkit](#response-toolkit).
 
-- `property` - the object decoration key name.
+- `property` - the object decoration key name or symbol.
 
 - `method` - the extension function or other value.
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -116,34 +116,36 @@ internals.Server = class {
 
         Hoek.assert(this._core.decorations[type], 'Unknown decoration type:', type);
         Hoek.assert(property, 'Missing decoration property name');
-        Hoek.assert(typeof property === 'string', 'Decoration property must be a string');
-        Hoek.assert(property[0] !== '_', 'Property name cannot begin with an underscore:', property);
+        Hoek.assert(typeof property === 'string' || typeof property === 'symbol', 'Decoration property must be a string or a symbol');
+
+        const propertyName = property.toString();
+        Hoek.assert(propertyName[0] !== '_', 'Property name cannot begin with an underscore:', propertyName);
 
         const existing = this._core._decorations[type][property];
         if (options.extend) {
-            Hoek.assert(type !== 'handler', 'Cannot extent handler decoration:', property);
-            Hoek.assert(existing, `Cannot extend missing ${type} decoration: ${property}`);
-            Hoek.assert(typeof method === 'function', `Extended ${type} decoration method must be a function: ${property}`);
+            Hoek.assert(type !== 'handler', 'Cannot extent handler decoration:', propertyName);
+            Hoek.assert(existing, `Cannot extend missing ${type} decoration: ${propertyName}`);
+            Hoek.assert(typeof method === 'function', `Extended ${type} decoration method must be a function: ${propertyName}`);
 
             method = method(existing);
         }
         else {
-            Hoek.assert(existing === undefined, `${type[0].toUpperCase() + type.slice(1)} decoration already defined: ${property}`);
+            Hoek.assert(existing === undefined, `${type[0].toUpperCase() + type.slice(1)} decoration already defined: ${propertyName}`);
         }
 
         if (type === 'handler') {
 
             // Handler
 
-            Hoek.assert(typeof method === 'function', 'Handler must be a function:', property);
+            Hoek.assert(typeof method === 'function', 'Handler must be a function:', propertyName);
             Hoek.assert(!method.defaults || typeof method.defaults === 'object' || typeof method.defaults === 'function', 'Handler defaults property must be an object or function');
-            Hoek.assert(!options.extend, 'Cannot extend handler decoration:', property);
+            Hoek.assert(!options.extend, 'Cannot extend handler decoration:', propertyName);
         }
         else if (type === 'request') {
 
             // Request
 
-            Hoek.assert(Request.reserved.indexOf(property) === -1, 'Cannot override built-in request interface decoration:', property);
+            Hoek.assert(Request.reserved.indexOf(property) === -1, 'Cannot override built-in request interface decoration:', propertyName);
 
             if (options.apply) {
                 this._core._decorations.requestApply = this._core._decorations.requestApply || {};
@@ -157,13 +159,18 @@ internals.Server = class {
 
             // Toolkit
 
-            Hoek.assert(this._core.toolkit.reserved.indexOf(property) === -1, 'Cannot override built-in toolkit decoration:', property);
+            Hoek.assert(this._core.toolkit.reserved.indexOf(property) === -1, 'Cannot override built-in toolkit decoration:', propertyName);
         }
         else {
 
             // Server
 
-            Hoek.assert(Object.getOwnPropertyNames(internals.Server.prototype).indexOf(property) === -1, 'Cannot override the built-in server interface method:', property);
+            if (typeof property === 'string') {
+                Hoek.assert(Object.getOwnPropertyNames(internals.Server.prototype).indexOf(property) === -1, 'Cannot override the built-in server interface method:', propertyName);
+            }
+            else {
+                Hoek.assert(Object.getOwnPropertySymbols(internals.Server.prototype).indexOf(property) === -1, 'Cannot override the built-in server interface method:', propertyName);
+            }
 
             this._core.instances.forEach((server) => {
 

--- a/test/request.js
+++ b/test/request.js
@@ -53,16 +53,17 @@ describe('Request.Generator', () => {
     it('decorates request with non function method', async () => {
 
         const server = Hapi.server();
+        const symbol = Symbol('abc');
 
         server.decorate('request', 'x2', 2);
-        server.decorate('request', 'abc', 1);
+        server.decorate('request', symbol, 1);
 
         server.route({
             method: 'GET',
             path: '/',
             handler: (request) => {
 
-                return request.x2 + request.abc;
+                return request.x2 + request[symbol];
             }
         });
 

--- a/test/server.js
+++ b/test/server.js
@@ -584,11 +584,12 @@ describe('Server', () => {
         it('shows decorations on request (many)', () => {
 
             const server = Hapi.server();
+            const symbol = Symbol('b');
 
             server.decorate('request', 'a', () => { });
-            server.decorate('request', 'b', () => { });
+            server.decorate('request', symbol, () => { });
 
-            expect(server.decorations.request).to.equal(['a', 'b']);
+            expect(server.decorations.request).to.equal(['a', symbol]);
         });
 
         it('shows decorations on toolkit (empty array)', () => {
@@ -610,11 +611,12 @@ describe('Server', () => {
         it('shows decorations on toolkit (many)', () => {
 
             const server = Hapi.server();
+            const symbol = Symbol('b');
 
             server.decorate('toolkit', 'a', () => { });
-            server.decorate('toolkit', 'b', () => { });
+            server.decorate('toolkit', symbol, () => { });
 
-            expect(server.decorations.toolkit).to.equal(['a', 'b']);
+            expect(server.decorations.toolkit).to.equal(['a', symbol]);
         });
 
         it('shows decorations on server (empty array)', () => {
@@ -636,11 +638,12 @@ describe('Server', () => {
         it('shows decorations on server (many)', () => {
 
             const server = Hapi.server();
+            const symbol = Symbol('b');
 
             server.decorate('server', 'a', () => { });
-            server.decorate('server', 'b', () => { });
+            server.decorate('server', symbol, () => { });
 
-            expect(server.decorations.server).to.equal(['a', 'b']);
+            expect(server.decorations.server).to.equal(['a', symbol]);
         });
     });
 


### PR DESCRIPTION
Currently, the `property` argument of `server.decorate()` must be a string. This commit adds support for symbols as well, in order to provide unique, quasi-private decorations.