### PR TITLE
do not attach request decorations to the prototype

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -79,9 +79,14 @@ exports = module.exports = internals.Request = class {
     static generate(server, req, res, options) {
 
         const request = new internals.Request(server, req, res, options);
+        const proto = Object.getPrototypeOf(request);
+
+        // Give request access to all decorations without adding them to
+        // the Request prototype.
+        Object.setPrototypeOf(request, server._core._decorations.request);
+        Object.setPrototypeOf(server._core._decorations.request, proto);
 
         // Decorate
-
         if (server._core._decorations.requestApply) {
             const properties = Object.keys(server._core._decorations.requestApply);
             for (let i = 0; i < properties.length; ++i) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -151,9 +151,6 @@ internals.Server = class {
                 this._core._decorations.requestApply = this._core._decorations.requestApply || {};
                 this._core._decorations.requestApply[property] = method;
             }
-            else {
-                Request.prototype[property] = method;
-            }
         }
         else if (type === 'toolkit') {
 

--- a/test/request.js
+++ b/test/request.js
@@ -71,6 +71,35 @@ describe('Request.Generator', () => {
         expect(res.statusCode).to.equal(200);
         expect(res.result).to.equal(3);
     });
+
+    it('does not share decorations between servers via prototypes', async () => {
+
+        const server1 = Hapi.server();
+        const server2 = Hapi.server();
+        const route = {
+            method: 'GET',
+            path: '/',
+            handler: (request) => {
+
+                return Object.keys(Object.getPrototypeOf(request));
+            }
+        };
+        let res;
+
+        server1.decorate('request', 'x1', 1);
+        server2.decorate('request', 'x2', 2);
+
+        server1.route(route);
+        server2.route(route);
+
+        res = await server1.inject('/');
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.equal(['x1']);
+
+        res = await server2.inject('/');
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.equal(['x2']);
+    });
 });
 
 describe('Request', () => {


### PR DESCRIPTION
This commit prevents request decorations from being attached
to the `Request` prototype. This was leading to decorations being
leaked between servers in the same process.

Fixes: https://github.com/hapijs/hapi/issues/3718

Note: I haven't benchmarked this change.