### PR TITLE
do not attach request decorations to a shared prototype, alternative approach.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -103,6 +103,8 @@ exports = module.exports = internals.Core = class {
             }
         };
 
+        this.Request = class extends Request {};
+
         this._debug();
         this._decorations = { handler: {}, request: {}, server: {}, toolkit: {}, requestApply: null };
         this._initializeCache();

--- a/lib/request.js
+++ b/lib/request.js
@@ -78,7 +78,7 @@ exports = module.exports = internals.Request = class {
 
     static generate(server, req, res, options) {
 
-        const request = new internals.Request(server, req, res, options);
+        const request = new server._core.Request(server, req, res, options);
 
         // Decorate
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -152,7 +152,7 @@ internals.Server = class {
                 this._core._decorations.requestApply[property] = method;
             }
             else {
-                Request.prototype[property] = method;
+                this._core.Request.prototype[property] = method;
             }
         }
         else if (type === 'toolkit') {

--- a/test/request.js
+++ b/test/request.js
@@ -71,6 +71,35 @@ describe('Request.Generator', () => {
         expect(res.statusCode).to.equal(200);
         expect(res.result).to.equal(3);
     });
+
+    it('does not share decorations between servers via prototypes', async () => {
+
+        const server1 = Hapi.server();
+        const server2 = Hapi.server();
+        const route = {
+            method: 'GET',
+            path: '/',
+            handler: (request) => {
+
+                return Object.keys(Object.getPrototypeOf(request));
+            }
+        };
+        let res;
+
+        server1.decorate('request', 'x1', 1);
+        server2.decorate('request', 'x2', 2);
+
+        server1.route(route);
+        server2.route(route);
+
+        res = await server1.inject('/');
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.equal(['x1']);
+
+        res = await server2.inject('/');
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.equal(['x2']);
+    });
 });
 
 describe('Request', () => {


### PR DESCRIPTION
Here I'm piggy-backing the discussion in #3795 and the initial work @cjihrig did to fix/test #3718.

This change prevents request decorations from being attached to the shared `Request` prototype. This was leading to decorations being leaked between servers in the same process.