### PR TITLE
Add support for Content-Security-Policy header directives

### DIFF
--- a/API.md
+++ b/API.md
@@ -3405,6 +3405,20 @@ following options:
     - `'strict-origin-when-cross-origin'` - same as `'origin-when-cross-origin'` but the client is instructed to omit the referrer when going from HTTPS to HTTP.
     - `'unsafe-url'` - instructs the client to always include the referrer with the full URL.
 
+- `csp` - controls the ['Content-Security-Policy'](https://www.w3.org/TR/CSP3/) header, an object of which the following directives can be set (types are `string`, defaults are `none`):
+    - `child` - governs the creation of nested browsing contexts.
+    - `connect` - restricts the URLs which can be loaded using script interfaces.
+    - `default` - serves as a fallback for the other fetch directives.
+    - `font` - restricts the URLs from which font resources may be loaded.
+    - `frame` - restricts the URLs which may be loaded into nested browsing contexts.
+    - `image` - restricts the URLs from which image resources may be loaded.
+    - `manifest` - restricts the URLs from which application manifests may be loaded.
+    - `media` - restricts the URLs from which video, audio, and associated text track resources may be loaded.
+    - `object` - restricts the URLs from which plugin content may be loaded.
+    - `script` - restricts the locations from which scripts may be executed.
+    - `style` - restricts the locations from which style may be applied to a Document.
+    - `worker` - restricts the URLs which may be loaded as a Worker, SharedWorker, or ServiceWorker.
+
 ### <a name="route.options.state" /> `route.options.state`
 
 Default value: `{ parse: true, failAction: 'error' }`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -199,6 +199,24 @@ internals.routeBase = Joi.object({
                 'unsafe-url', 'same-origin', 'origin', 'strict-origin',
                 'origin-when-cross-origin', 'strict-origin-when-cross-origin')
         ])
+            .default(false),
+        csp: Joi.alternatives([
+            Joi.boolean().valid(false),
+            Joi.object({
+                child: Joi.string(),
+                connect: Joi.string(),
+                default: Joi.string(),
+                font: Joi.string(),
+                frame: Joi.string(),
+                image: Joi.string(),
+                manifest: Joi.string(),
+                media: Joi.string(),
+                object: Joi.string(),
+                script: Joi.string(),
+                style: Joi.string(),
+                worker: Joi.string()
+            })
+        ])
             .default(false)
     })
         .allow(null, false, true)

--- a/lib/security.js
+++ b/lib/security.js
@@ -53,6 +53,14 @@ exports.route = function (settings) {
         }
     }
 
+    if (security.csp) {
+        let directives = '';
+        for (const key in security.csp) {
+            directives += `${key}-src ${security.csp[key]}; `;
+        }
+        security._csp = directives.trimRight();
+    }
+
     return security;
 };
 
@@ -84,5 +92,9 @@ exports.headers = function (request) {
 
     if (security.referrer !== false) {
         response._header('referrer-policy', security.referrer, { override: false });
+    }
+
+    if (security._csp) {
+        response._header('content-security-policy', security._csp, { override: false });
     }
 };

--- a/test/core.js
+++ b/test/core.js
@@ -303,6 +303,7 @@ describe('Core', () => {
         expect(server.settings.routes.security.xss).to.be.false();
         expect(server.settings.routes.security.xframe).to.equal('deny');
         expect(server.settings.routes.security.referrer).to.equal(false);
+        expect(server.settings.routes.security.referrer).to.be.false();
     });
 
     describe('_debug()', () => {


### PR DESCRIPTION
Add support for content-security-policy header with unit testing and documentation.

These are necessary for browsers to verify origins and block the loading of undesirable content on webpages.