### PR TITLE
remove unix domain socket before attempting to use it

### DIFF
--- a/test/core.js
+++ b/test/core.js
@@ -139,6 +139,11 @@ describe('Core', () => {
     it('creates a server listening on a unix domain socket', { skip: process.platform === 'win32' }, async () => {
 
         const port = Path.join(__dirname, 'hapi-server.socket');
+
+        if (Fs.existsSync(port)) {
+            Fs.unlinkSync(port);
+        }
+
         const server = Hapi.server({ port });
 
         expect(server.type).to.equal('socket');


### PR DESCRIPTION
This test attempts to clean up after itself, but just to be safe, remove the file before running the test.

Refs: https://github.com/nodejs/citgm/pull/436#issuecomment-413586574