### PR TITLE
Ensure request.info.cors is set for special routes

### DIFF
--- a/API.md
+++ b/API.md
@@ -4621,9 +4621,10 @@ Request information:
 - `cors` - if CORS is enabled for the route, contains the following:
     - `isOriginMatch` - `true` if the request 'Origin' header matches the configured CORS
       restrictions. Set to `false` if no 'Origin' header is found or if it does not match.
-      Note that this is only available after the `'onRequest'` extension point as CORS is
-      configured per-route and no routing decisions are made at that point in the request
-      lifecycle.
+      Note that this set based upon the server's CORS defaults
+      ([`server.options.routes`](#server.options.routes)) until after the `'onRequest'` extension
+      point, as CORS is configured per-route and no routing decisions are made at that point in
+      the request lifecycle.
 
 - `host` - content of the HTTP 'Host' header (e.g. 'example.com:8080').
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -72,6 +72,8 @@ exports = module.exports = internals.Request = class {
             error: null
         };
 
+        this._setCorsInfo();
+
         // Parse request url
 
         this.setUrl(req.url, this._core.settings.router.stripTrailingSlash);
@@ -216,11 +218,14 @@ exports = module.exports = internals.Request = class {
         this.params = match.params || {};
         this.paramsArray = match.paramsArray || [];
 
-        if (this.route.settings.cors) {
-            this.info.cors = {
-                isOriginMatch: Cors.matchOrigin(this.headers.origin, this.route.settings.cors)
-            };
-        }
+        this._setCorsInfo();
+    }
+
+    _setCorsInfo() {
+
+        this.info.cors = !this.route.settings.cors ? null : {
+            isOriginMatch: Cors.matchOrigin(this.headers.origin, this.route.settings.cors)
+        };
     }
 
     _setTimeouts() {

--- a/test/cors.js
+++ b/test/cors.js
@@ -60,7 +60,6 @@ describe('CORS', () => {
 
     it('returns headers on single route', async () => {
 
-
         const server = Hapi.server();
         server.route({ method: 'GET', path: '/a', handler: () => 'ok', options: { cors: true } });
         server.route({ method: 'GET', path: '/b', handler: () => 'ok' });
@@ -139,7 +138,7 @@ describe('CORS', () => {
         expect(res.headers['access-control-allow-credentials']).to.equal('true');
     });
 
-    it('combines connection defaults with route config', async () => {
+    it('combines server defaults with route config', async () => {
 
         const server = Hapi.server({ routes: { cors: { origin: ['http://example.com/'] } } });
         server.route({ method: 'GET', path: '/', handler: () => null, options: { cors: { credentials: true } } });
@@ -191,6 +190,74 @@ describe('CORS', () => {
         const res2 = await server.inject({ url: '/', headers: { origin: 'http://example.domain.com' } });
         expect(res2.statusCode).to.equal(404);
         expect(res2.headers['access-control-allow-origin']).to.exist();
+    });
+
+    it('sets request info based upon server default and route settings', async () => {
+
+        const handler = (request) => ([request.app.cors, request.info.cors]);
+        const onRequest = (request, h) => {
+
+            request.app.cors = request.info.cors;
+            return h.continue;
+        };
+
+        // Default CORS on
+
+        const server1 = Hapi.server({ routes: { cors: { origin: ['http://*.domain.com'] } } });
+        server1.route([
+            {
+                method: 'GET',
+                path: '/off',
+                handler,
+                options: {
+                    cors: false
+                }
+            },
+            {
+                method: 'GET',
+                path: '/default',
+                handler
+            }
+        ]);
+
+        server1.ext('onRequest', onRequest);
+
+        const res1 = await server1.inject({ url: '/off', headers: { origin: 'http://example.domain.com' } });
+        expect(res1.statusCode).to.equal(200);
+        expect(res1.result).to.equal([{ isOriginMatch: true }, null]);
+
+        const res2 = await server1.inject({ url: '/default', headers: { origin: 'http://example.domain.com' } });
+        expect(res2.statusCode).to.equal(200);
+        expect(res2.result).to.equal([{ isOriginMatch: true }, { isOriginMatch: true }]);
+
+        // Default CORS off
+
+        const server2 = Hapi.server({ routes: { cors: false } });
+        server2.route([
+            {
+                method: 'GET',
+                path: '/default',
+                handler
+            },
+            {
+                method: 'GET',
+                path: '/on',
+                handler,
+                options: {
+                    cors: { origin: ['http://*.domain.com'] }
+                }
+            }
+        ]);
+
+        server2.ext('onRequest', onRequest);
+
+        const res3 = await server2.inject({ url: '/default', headers: { origin: 'http://no-match-domain.com' } });
+        expect(res3.statusCode).to.equal(200);
+        expect(res3.result).to.equal([null, null]);
+
+        const res4 = await server2.inject({ url: '/on', headers: { origin: 'http://no-match-domain.com' } });
+        expect(res4.statusCode).to.equal(200);
+        expect(res4.result).to.equal([null, { isOriginMatch: false }]);
     });
 
     describe('headers()', () => {


### PR DESCRIPTION
Enclosed is a fix for #3813.

When an error occurs in `onRequest` hapi would throw because it expected `request.info.cors` to exist, but the route (and its CORS info) naturally hadn't been looked-up yet.  The bug was introduced in the fix for #3792, which made server CORS defaults apply to the special "notFound" route, which is the effective route during `onRequest`.

The fix here is to set `request.info.cors` prior to `onRequest` based upon the server's default CORS settings.  An alternative fix would be to compute `isOriginMatch` when attempting to set CORS headers specifically in the case of a special "notFound", rather than attempting to read it off of `request.info.cors`.