### PR TITLE
Use WHATWG URL for request.url

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -157,6 +157,7 @@ internals.routeBase = Joi.object({
     })
         .default(),
     plugins: Joi.object(),
+    queryParser: Joi.func().allow(null).default(null),
     response: Joi.object({
         emptyStatusCode: Joi.valid(200, 204).default(200),
         failAction: internals.failAction,

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,8 +2,6 @@
 
 // Load modules
 
-const Url = require('url');
-
 const Boom = require('boom');
 const Bounce = require('bounce');
 const Hoek = require('hoek');
@@ -74,7 +72,13 @@ exports = module.exports = internals.Request = class {
 
         // Parse request url
 
-        this.setUrl(req.url, this._core.settings.router.stripTrailingSlash);
+        try {
+            this.setUrl(req.url, this._core.settings.router.stripTrailingSlash);
+        }
+        catch (err) {
+            Bounce.ignore(err, 'boom');
+            this.url = err;
+        }
     }
 
     static generate(server, req, res, options) {
@@ -109,11 +113,31 @@ exports = module.exports = internals.Request = class {
 
         Hoek.assert(this.params === null, 'Cannot change request URL after routing');
 
-        url = (typeof url === 'string' ? Url.parse(url, true) : Hoek.clone(url));
+        if (url instanceof URL) {
+            url = `${url}`;
+        }
+
+        Hoek.assert(typeof url === 'string', 'Url must be a string or URL object');
+
+        const parseFull = url.length === 0 || url[0] !== '/';
+        try {
+            if (parseFull) {
+                url = new URL(url);
+            }
+            else {
+                const hostname = this.info.host || `${this._core.info.host}:${this._core.info.port}`;
+                url = new URL(url, `${this._core.info.protocol}://${hostname}`);
+            }
+        }
+        catch (err) {
+            Bounce.ignore(err, TypeError);
+
+            throw Boom.boomify(err, { statusCode: 400 });
+        }
 
         // Apply path modifications
 
-        let path = this._core.router.normalize(url.pathname || '');        // pathname excludes query
+        let path = this._core.router.normalize(url.pathname);        // pathname excludes query
 
         if (stripTrailingSlash &&
             path.length > 1 &&
@@ -122,21 +146,19 @@ exports = module.exports = internals.Request = class {
             path = path.slice(0, -1);
         }
 
-        // Update derived url properties
-
-        if (path !== url.pathname) {
-            url.pathname = path;
-            url.path = url.search ? path + url.search : path;
-            url.href = Url.format(url);
-        }
+        url.pathname = path;
 
         // Store request properties
 
         this.url = url;
-        this.query = url.query;
-        this.path = url.pathname;
+        this.path = path;
 
-        if (url.hostname) {
+        this.query = Object.create(null);
+        for (const [key, value] of this.url.searchParams) {
+            this.query[key] = value;
+        }
+
+        if (parseFull) {
             this.info.hostname = url.hostname;
             this.info.host = url.host;
         }
@@ -185,10 +207,8 @@ exports = module.exports = internals.Request = class {
 
         // Validate path
 
-        if (!this.path ||
-            this.path[0] !== '/') {
-
-            throw Boom.badRequest('Invalid path');
+        if (this.url instanceof Error) {
+            throw this.url;
         }
     }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { URL, URLSearchParams } = require('url');
+
 // Load modules
 
 const Boom = require('boom');

--- a/lib/request.js
+++ b/lib/request.js
@@ -114,7 +114,7 @@ exports = module.exports = internals.Request = class {
         Hoek.assert(this.params === null, 'Cannot change request URL after routing');
 
         if (url instanceof URL) {
-            url = `${url}`;
+            url = url.href;
         }
 
         Hoek.assert(typeof url === 'string', 'Url must be a string or URL object');
@@ -153,11 +153,6 @@ exports = module.exports = internals.Request = class {
         this.url = url;
         this.path = path;
 
-        this.query = Object.create(null);
-        for (const [key, value] of this.url.searchParams) {
-            this.query[key] = value;
-        }
-
         if (parseFull) {
             this.info.hostname = url.hostname;
             this.info.host = url.host;
@@ -185,6 +180,7 @@ exports = module.exports = internals.Request = class {
         }
 
         this._lookup();
+        this._queryParse();
         this._setTimeouts();
         await this._lifecycle(this._route._cycle, false);
         this._reply();
@@ -240,6 +236,46 @@ exports = module.exports = internals.Request = class {
             this.info.cors = {
                 isOriginMatch: Cors.matchOrigin(this.headers.origin, this.route.settings.cors)
             };
+        }
+    }
+
+    _queryParse() {
+
+        const { queryParser } = this._route.settings;
+
+        const baseParser = (iterator) => {
+
+            const query = Object.create(null);
+            for (let [key, value] of iterator) {
+                const entry = query[key];
+                if (entry !== undefined) {
+                    value = [].concat(entry, value);
+                }
+
+                query[key] = value;
+            }
+
+            return query;
+        };
+
+        if (queryParser) {
+            try {
+                let result = queryParser(this);
+
+                Hoek.assert(typeof result === 'object' && result !== null, 'Parsed query must be an object');
+
+                if (result instanceof URLSearchParams || result instanceof Map) {
+                    result = baseParser(result);
+                }
+
+                this.query = result;
+            }
+            catch (err) {
+                return this._reply(err);
+            }
+        }
+        else {
+            this.query = baseParser(this.url.searchParams);
         }
     }
 

--- a/test/request.js
+++ b/test/request.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { URL, URLSearchParams } = require('url');
+
 // Load modules
 
 const Http = require('http');


### PR DESCRIPTION
I had a look into what it would take to update hapi to use the [WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api) since `Url.parse()` [is being deprecated](https://github.com/nodejs/node/pull/22715), and node 8 already supports the replacement API.

As far as I can tell, the only directly affected api is the `request.url` property, and the `setUrl()` method.

PR details:

 * All usage of old style **URL** objects, and `Url.parse()` has been replaced with the new **URL** API. There is no legacy support.
 * Added a `route.queryParser` option to retain ability to customize the query parsing. The return value is validated so that `request.query` will always be an object.
 * `request.url` property is no longer relative, since the **URL** constructor won't create relative URLs.
 * `setUrl` throws a `badRequest` error if the URL parsing fails.