### PR TITLE
Add validation for cookies

### DIFF
--- a/API.md
+++ b/API.md
@@ -531,7 +531,7 @@ Default value:
 
 Sets the default configuration for every state (cookie) set explicitly via
 [`server.state()`](#server.state()) or implicitly (without definition) using the
-[state configuration](#server.state()) object.
+[state configuration](#server.state()) object, except for `validate` property.
 
 #### <a name="server.options.tls" /> `server.options.tls`
 
@@ -2631,6 +2631,9 @@ across multiple requests. Registers a cookie definitions where:
     - `iron` - options for `'iron'` encoding. Defaults to
        [`require('iron').defaults`](https://github.com/hueniverse/iron#options).
 
+    - `validate` - [**joi**](https://github.com/hapijs/joi) validation object. 
+       Defaults to `undefined` (no validation).
+
     - `ignoreErrors` - if `true`, errors are ignored and treated as missing cookies.
 
     - `clearInvalid` - if `true`, automatically instruct the client to remove invalid
@@ -2643,8 +2646,8 @@ across multiple requests. Registers a cookie definitions where:
 
 Return value: none.
 
-State defaults can be modified via the [server.options.state](#server.options.state) configuration
-option.
+State defaults, except for `validate`, can be modified via the
+[server.options.state](#server.options.state) configuration option.
 
 ```js
 const Hapi = require('hapi');

--- a/test/state.js
+++ b/test/state.js
@@ -4,6 +4,7 @@
 
 const Code = require('code');
 const Hapi = require('..');
+const Joi = require('joi');
 const Lab = require('lab');
 
 
@@ -65,6 +66,16 @@ describe('state', () => {
         server.state('vab', { encoding: 'base64json', clearInvalid: true });
         server.route({ method: 'GET', path: '/', handler: (request) => request.state });
         const res = await server.inject({ method: 'GET', url: '/', headers: { cookie: 'vab' } });
+        expect(res.statusCode).to.equal(400);
+        expect(res.headers['set-cookie']).to.not.exists();
+    });
+
+    it('rejects request when cookie validation fails', async () => {
+
+        const server = Hapi.server();
+        server.state('a', { validate: Joi.string().valid('b') });
+        server.route({ method: 'GET', path: '/', handler: (request) => request.state });
+        const res = await server.inject({ method: 'GET', url: '/', headers: { cookie: 'a=a' } });
         expect(res.statusCode).to.equal(400);
         expect(res.headers['set-cookie']).to.not.exists();
     });


### PR DESCRIPTION
Closes #3832.
Requires https://github.com/hapijs/statehood/pull/51.

So I implemented this the way it was proposed in https://github.com/hapijs/discuss/issues/727... but maybe a better way would be to add it into the route config, the same way as `query`, `params`, etc are validated? Alt. impl: https://github.com/hapijs/hapi/pull/3882
