### PR TITLE
Reflect change of team name

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -30,7 +30,7 @@
 - Manny Pamintuan
 - Max Fierro
 - Nicklas Laine Overgaard
-- NZZ Storytelling
+- NZZ Visuals
 - Paulo Vieira
 - Peter Ka
 - [quickytools](https://www.quickytools.com)


### PR DESCRIPTION
NZZ Storytelling is now called NZZ Visuals, see https://twitter.com/nzzvisuals/status/1042026666434994176.