### PR TITLE
fix(transmit test): add missing await on team.work

### DIFF
--- a/test/transmit.js
+++ b/test/transmit.js
@@ -1340,6 +1340,7 @@ describe('transmission', () => {
 
             const res = await Wreck.request('GET', 'http://localhost:' + server.info.port);
             res.on('data', (chunk) => { });
+            await team.work;
             await server.stop();
         });
 


### PR DESCRIPTION
This break the test and shows the test doesn't actually work on node 10.
This points out something I bought up in https://github.com/hapijs/hapi/issues/3899
This test is also broken on v16 on node 10 for probably the same reason.