### PR TITLE
Fix typo in API.md attach -> attack

### DIFF
--- a/API.md
+++ b/API.md
@@ -3263,7 +3263,7 @@ Determines if the incoming payload is processed or presented raw. Available valu
 
 Default value: `'error'`.
 
-Sets handling of incoming payload that may contain a prototype poisoning security attach. Available
+Sets handling of incoming payload that may contain a prototype poisoning security attack. Available
 values:
 
 - `'error'` - returns a `400` bad request error when the payload contains a prototype.


### PR DESCRIPTION
Was reviewing the diff for the [v18.1.0](https://github.com/hapijs/hapi/compare/v18.0.1...v18.1.0) release and noticed this. Just wanted to quickly grab the fix there.