### PR TITLE
Add support for Chrome Apps and WebExtensions

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -98,7 +98,7 @@ exports = module.exports = internals.Response = class {
             this.variety = 'buffer';
             this._contentType = 'application/octet-stream';
         }
-        else if (source instanceof Stream) {
+        else if (Streams.isReadableStream(source)) {
             this.variety = 'stream';
             this._contentType = 'application/octet-stream';
         }
@@ -529,7 +529,7 @@ exports = module.exports = internals.Response = class {
 
         // Stream source
 
-        if (source instanceof Stream) {
+        if (Streams.isStream(source)) {
             if (typeof source._read !== 'function') {
                 throw Boom.badImplementation('Stream must have a readable interface');
             }
@@ -607,7 +607,7 @@ exports = module.exports = internals.Response = class {
         }
 
         const stream = this._payload || this.source;
-        if (stream instanceof Stream) {
+        if (Streams.isReadableStream(stream)) {
             internals.Response.drain(stream);
         }
     }

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -7,6 +7,20 @@ const internals = {
     team: Symbol('team')
 };
 
+exports.isStream = function (stream) {
+
+    return stream !== null &&
+    typeof stream === 'object' &&
+    typeof stream.pipe === 'function';
+};
+
+exports.isReadableStream = function (stream) {
+
+    return exports.isStream(stream) &&
+    stream.readable !== false &&
+    typeof stream._read === 'function' &&
+    typeof stream._readableState === 'object';
+};
 
 exports.drain = function (stream) {
 


### PR DESCRIPTION
Stream detection via `stream instanceof Stream` does not work correctly in browser contexts such as Chrome Apps or [WebExtensions in browsers exposing `chrome.sockets`](https://github.com/ipfs-shipyard/ipfs-companion/issues/664),  especially when different `stream` polyfils are used and mixed together.

This change replaces `instanceof Stream` checks with feature-detection of stream contract, enabling Hapi to be used in browserified form in Chrome Apps and other browser environments.

cc https://github.com/ipfs-shipyard/ipfs-companion/issues/716