### PR TITLE
Fix some corner case client errors

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -77,6 +77,7 @@ exports = module.exports = internals.Core = class {
         this.router = new Call.Router(this.settings.router);
         this.phase = 'stopped';                                                         // 'stopped', 'initializing', 'initialized', 'starting', 'started', 'stopping', 'invalid'
         this.sockets = null;                                                            // Track open sockets for graceful shutdown
+        this.requests = new WeakMap();
         this.started = false;
         this.states = new Statehood.Definitions(this.settings.state);
         this.toolkit = new Toolkit();
@@ -409,7 +410,7 @@ exports = module.exports = internals.Core = class {
 
             this.sockets.forEach((connection) => {
 
-                if (!connection._isHapiProcessing) {
+                if (!this.requests.has(connection)) {
                     connection.end();
                 }
             });
@@ -462,17 +463,17 @@ exports = module.exports = internals.Core = class {
 
         return (req, res) => {
 
-            // Track socket request processing state
-
-            if (req.socket) {
-                req.socket._isHapiProcessing = true;
-                const env = { core: this, req };
-                res.on('finish', internals.onFinish.bind(res, env));
-            }
-
             // Create request
 
             const request = Request.generate(this.root, req, res, options);
+
+            // Track socket request processing state
+
+            if (req.socket) {
+                this.requests.set(req.socket, request);
+                const env = { core: this, req };
+                res.on('finish', internals.onFinish.bind(res, env));
+            }
 
             // Check load
 
@@ -502,8 +503,18 @@ exports = module.exports = internals.Core = class {
 
             this._log(['connection', 'client', 'error'], err);
 
-            if (socket.writable) {
-                socket.end(internals.badRequestResponse);
+            if (socket.readable) {
+                const request = this.requests.get(socket);
+                if (request) {
+                    const error = Boom.badRequest();
+                    error.output.headers = {
+                        connection: 'close'
+                    };
+                    request._reply(error);
+                }
+                else {
+                    socket.end(internals.badRequestResponse);
+                }
             }
             else {
                 socket.destroy(err);
@@ -634,7 +645,7 @@ internals.onFinish = function (env) {
 
     const { core, req } = env;
 
-    req.socket._isHapiProcessing = false;
+    core.requests.delete(req.socket);
     if (!core.started) {
         req.socket.end();
     }

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -16,6 +16,7 @@ exports.drain = function (stream) {
     stream.on('readable', internals.read);
     stream.on('error', internals.end);
     stream.on('end', internals.end);
+    stream.on('close', internals.end);
 
     return team.work;
 };
@@ -23,7 +24,7 @@ exports.drain = function (stream) {
 
 internals.read = function () {
 
-    this.read();
+    while (this.read()) { }
 };
 
 
@@ -32,6 +33,7 @@ internals.end = function () {
     this.removeListener('readable', internals.read);
     this.removeListener('error', internals.end);
     this.removeListener('end', internals.end);
+    this.removeListener('close', internals.end);
 
     this[internals.team].attend();
 };

--- a/test/request.js
+++ b/test/request.js
@@ -1774,7 +1774,12 @@ describe('Request', () => {
                 });
             });
 
-            const req = Http.request('http://localhost:' + server.info.port, { headers: { 'content-length': 42 } });
+            const req = Http.request({
+                hostname: 'localhost',
+                port: server.info.port,
+                method: 'GET',
+                headers: { 'content-length': 42 }
+            });
             req.on('error', Hoek.ignore);
             req.flushHeaders();
 


### PR DESCRIPTION
It turns out that the trigger in #3969 does indeed contain a bug. Namely that a request, that is aborted during the request lifecycle, can cause a timeout, and log a 503 response even though nothing was ever sent down the wire.

Further investigation found that this was caused by the stream draining code in the default handler, which never completes if the stream is aborted. This in turn means that the `_lifecycle()` call in `request._execute()` never returns, and thus skips the call to `_reply()` that would clear the timeout timer.

The other part of the patch relates to the `clientError` handling. Here I found a case where a client can receive a `400 Bad Request` response, while the server logs it as a regular response.
This is because, contrary to the node docs, the `clientError` event can be triggered while processing an `request` on the socket, which hapi doesn't expect.

I have updated the handler, to send a `400 Bad Request` response through any outstanding requests instead of writing it directly to the socket, which seems to fix the issue.