### PR TITLE
Decorate requests with symbols with apply=true

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -103,7 +103,7 @@ exports = module.exports = internals.Core = class {
         this.Request = class extends Request { };
 
         this._debug();
-        this._decorations = { handler: {}, request: {}, server: {}, toolkit: {}, requestApply: null };
+        this._decorations = { handler: new Map(), request: new Map(), server: new Map(), toolkit: new Map(), requestApply: null };
         this._initializeCache();
 
         this.listener = this._createListener();

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -84,7 +84,7 @@ exports.defaults = function (method, handler, core) {
 
     if (typeof handler === 'object') {
         const type = Object.keys(handler)[0];
-        const serverHandler = core._decorations.handler[type];
+        const serverHandler = core._decorations.handler.get(type);
 
         Hoek.assert(serverHandler, 'Unknown handler:', type);
 
@@ -101,7 +101,7 @@ exports.configure = function (handler, route) {
 
     if (typeof handler === 'object') {
         const type = Object.keys(handler)[0];
-        const serverHandler = route._core._decorations.handler[type];
+        const serverHandler = route._core._decorations.handler.get(type);
 
         Hoek.assert(serverHandler, 'Unknown handler:', type);
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -84,8 +84,7 @@ exports = module.exports = internals.Request = class {
         // Decorate
 
         if (server._core._decorations.requestApply) {
-            for (const property in server._core._decorations.requestApply) {
-                const assignment = server._core._decorations.requestApply[property];
+            for (const [property, assignment] of server._core._decorations.requestApply.entries()) {
                 request[property] = assignment(request);
             }
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,8 +78,8 @@ internals.Server = class {
 
         // Decorations
 
-        for (const method of core.decorations.server) {
-            this[method] = core._decorations.server[method];
+        for (const [property, method] of core._decorations.server.entries()) {
+            this[property] = method;
         }
 
         core.registerServer(this);
@@ -118,7 +118,7 @@ internals.Server = class {
         const propertyName = property.toString();
         Hoek.assert(propertyName[0] !== '_', 'Property name cannot begin with an underscore:', propertyName);
 
-        const existing = this._core._decorations[type][property];
+        const existing = this._core._decorations[type].get(property);
         if (options.extend) {
             Hoek.assert(type !== 'handler', 'Cannot extent handler decoration:', propertyName);
             Hoek.assert(existing, `Cannot extend missing ${type} decoration: ${propertyName}`);
@@ -145,8 +145,8 @@ internals.Server = class {
             Hoek.assert(!Request.reserved.includes(property), 'Cannot override built-in request interface decoration:', propertyName);
 
             if (options.apply) {
-                this._core._decorations.requestApply = this._core._decorations.requestApply || {};
-                this._core._decorations.requestApply[property] = method;
+                this._core._decorations.requestApply = this._core._decorations.requestApply || new Map();
+                this._core._decorations.requestApply.set(property, method);
             }
             else {
                 this._core.Request.prototype[property] = method;
@@ -176,7 +176,7 @@ internals.Server = class {
             });
         }
 
-        this._core._decorations[type][property] = method;
+        this._core._decorations[type].set(property, method);
         this._core.decorations[type].push(property);
     }
 

--- a/test/request.js
+++ b/test/request.js
@@ -95,6 +95,28 @@ describe('Request.Generator', () => {
         expect(res.statusCode).to.equal(200);
         expect(res.result).to.equal(['x2']);
     });
+
+    it('decorates symbols when apply=true', async () => {
+
+        const server = Hapi.server();
+        const symbol = Symbol('abc');
+
+        server.decorate('request', symbol, () => 'foo', { apply: true });
+
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: (request) => {
+
+                return request[symbol];
+            }
+        });
+
+        const res = await server.inject('/');
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.equal('foo');
+
+    });
 });
 
 describe('Request', () => {


### PR DESCRIPTION
Hello,

 This PR fixes a bug where Symbol decorations would not get added to request instances when `{ apply: true }` option was used. The issue was caused by iterating over decorations object using `for...in` which only iterates over enumerable properties (symbols are not enumerable)

Since Symbols are expected property names this PR fixes the issue above by also iterating over known symbol properties using `Object.getOwnPropertySymbols`.