### PR TITLE
fix(auth): properly populate request.auth on failed auth

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -461,12 +461,13 @@ internals.validate = function (err, result, name, config, request, errors) {    
             return internals.missing;
         }
 
+        request.auth.isAuthenticated = false;
+        request.auth.strategy = name;
+        request.auth.credentials = result.credentials;
+        request.auth.artifacts = result.artifacts;
+        request.auth.error = err;
+
         if (config.mode === 'try') {
-            request.auth.isAuthenticated = false;
-            request.auth.strategy = name;
-            request.auth.credentials = result.credentials;
-            request.auth.artifacts = result.artifacts;
-            request.auth.error = err;
             request._log(['auth', 'unauthenticated', 'try', name], err);
             return;
         }


### PR DESCRIPTION
Currently request.auth is only populated on failed auth if the mode is set to 'try'
This will make that object always populated, regardless of auth mode.