### PR TITLE
fix(cors): emptyStatusCode not being taken into account for OPTIONS requests

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -141,6 +141,7 @@ internals.handler = function (request, h) {
     response._header('access-control-allow-methods', method);
     response._header('access-control-allow-headers', settings._headersString);
     response._header('access-control-max-age', settings.maxAge);
+    response.code(route.settings.response.emptyStatusCode);
 
     if (settings.credentials) {
         response._header('access-control-allow-credentials', 'true');

--- a/test/cors.js
+++ b/test/cors.js
@@ -35,6 +35,22 @@ describe('CORS', () => {
         server.route({ method: 'GET', path: '/', handler });
 
         const res = await server.inject({ method: 'OPTIONS', url: '/', headers: { origin: 'http://example.com/', 'access-control-request-method': 'GET' } });
+        expect(res.statusCode).to.equal(204);
+        expect(res.headers['access-control-allow-origin']).to.equal('http://example.com/');
+    });
+
+    it('returns OPTIONS response with correct status code for pre-defined emptyStatusCode', async () => {
+
+        const handler = function () {
+
+            throw Boom.badRequest();
+        };
+
+        const server = Hapi.server({ routes: { cors: true } });
+        server.route({ method: 'GET', path: '/', handler, options: { response: { emptyStatusCode: 200 } } });
+
+        const res = await server.inject({ method: 'OPTIONS', url: '/', headers: { origin: 'http://example.com/', 'access-control-request-method': 'GET' } });
+        expect(res.statusCode).to.equal(200);
         expect(res.headers['access-control-allow-origin']).to.equal('http://example.com/');
     });
 


### PR DESCRIPTION
With #3919 the default status code for empty responses changed from `200` to `204` while still giving the user the ability to override this behaviour by using the `emptyStatusCode` response setting. This setting however isn't being taken into account when using CORS and OPTIONS requests. This pull request fixes this glitch.