### PR TITLE
[update-routes-config] Update API reference to use route.options

### DIFF
--- a/API.md
+++ b/API.md
@@ -1032,7 +1032,7 @@ server.auth.strategy('default', 'custom');
 server.route({
     method: 'GET',
     path: '/',
-    config: {
+    options: {
         auth: 'default',
         handler: function (request, h) {
 
@@ -1970,7 +1970,7 @@ const server = Hapi.server();
 server.route({
     method: 'GET',
     path: '/',
-    config: {
+    options: {
         id: 'root',
         handler: () => 'ok'
     }
@@ -1995,7 +1995,7 @@ const server = Hapi.server();
 server.route({
     method: 'GET',
     path: '/',
-    config: {
+    options: {
         id: 'root',
         handler: () => 'ok'
     }
@@ -2245,7 +2245,7 @@ const user = {
     }
 };
 
-server.route({ method: 'GET', path: '/user', config: user });
+server.route({ method: 'GET', path: '/user', options: user });
 
 // An array of routes
 
@@ -3109,7 +3109,7 @@ const pre3 = function (request, h) {
 server.route({
     method: 'GET',
     path: '/',
-    config: {
+    options: {
         pre: [
             [
                 // m1 and m2 executed in parallel
@@ -3959,7 +3959,7 @@ const server = Hapi.server({ port: 80 });
 server.route({
     method: 'GET',
     path: '/',
-    config: {
+    options: {
         cache: { expiresIn: 5000 },
         handler: function (request, h) {
 


### PR DESCRIPTION
I recently noticed some API reference examples were using `route.config` instead of `route.options` even though the documentation uses [route.options](https://hapi.dev/api/?v=19.1.1#route-options) to document them. 

Reading the hapi 17 [release notes](https://github.com/hapijs/hapi/issues/3658) looks like the former is to be deprecated in future versions, so went ahead and updated the usage examples.