### PR TITLE
[default-scope] Accept default scope as a valid route scope

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -418,8 +418,16 @@ exports = module.exports = internals.Auth = class {
 
 internals.setupScope = function (access) {
 
+    // No scopes
+
     if (!access.scope) {
         return false;
+    }
+
+    // Already setup
+
+    if (!Array.isArray(access.scope)) {
+        return access.scope;
     }
 
     const scope = {};


### PR DESCRIPTION
**How to reproduce?**
When a default scope is specified by the default strategy (`server.auth.default()`) and a route is configured with auth options (but not `access.scope`), the default scope is not taking effect and instead throws an error as described by #4083.

**Root cause**
Default strategy's scopes are [parsed](https://github.com/hapijs/hapi/blob/master/lib/auth.js#L419), changing the original value from an array (access.scope = []) to an object (access.scope = { ... }). When a route does not specify it's own scopes, the default strategy scopes are used, but at that point they are no longer an array.

**Fix**
This PR fixes the issue by ignoring `access.scope` if it has already been setup in default strategy