### PR TITLE
[server-validator-docs] Update server.validator() documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -2600,7 +2600,7 @@ Registers a server validation module used to compile raw validation rules into v
 
 Return value: none.
 
-Note: the validator is only used when validation rules are not pre-compiled schemas. When a validation rules is a function or schema object, the rule is used as-is and the validator is not used.
+Note: the validator is only used when validation rules are not pre-compiled schemas. When a validation rules is a function or schema object, the rule is used as-is and the validator is not used. Note that setting a validator inside a plugin, will cause the validator to only be applied to routes set up by the plugin.
 
 ```js
 const Hapi = require('@hapi/hapi');

--- a/API.md
+++ b/API.md
@@ -2600,9 +2600,7 @@ Registers a server validation module used to compile raw validation rules into v
 
 Return value: none.
 
-Note: the validator is only used when validation rules are not pre-compiled schemas. When a validation rules is a function or schema object, the rule is used as-is and the validator is not used.
-
-When setting a validator inside a plugin, the validator is only applied to routes set up by the plugin and plugins registered by it. Note that the validator applies only to routes added after it has been set.
+Note: the validator is only used when validation rules are not pre-compiled schemas. When a validation rules is a function or schema object, the rule is used as-is and the validator is not used. When setting a validator inside a plugin, the validator is only applied to routes set up by the plugin and plugins registered by it.
 
 ```js
 const Hapi = require('@hapi/hapi');

--- a/API.md
+++ b/API.md
@@ -2600,7 +2600,9 @@ Registers a server validation module used to compile raw validation rules into v
 
 Return value: none.
 
-Note: the validator is only used when validation rules are not pre-compiled schemas. When a validation rules is a function or schema object, the rule is used as-is and the validator is not used. Note that setting a validator inside a plugin, will cause the validator to only be applied to routes set up by the plugin.
+Note: the validator is only used when validation rules are not pre-compiled schemas. When a validation rules is a function or schema object, the rule is used as-is and the validator is not used.
+
+When setting a validator inside a plugin, the validator is only applied to routes set up by the plugin and plugins registered by it. Note that the validator applies only to routes added after it has been set.
 
 ```js
 const Hapi = require('@hapi/hapi');


### PR DESCRIPTION
While trying to use `server.validator()` and struggling a bit while combining it with plugins, I learned just after reading the [hapi@19 release notes](https://github.com/hapijs/hapi/issues/4017) that when used inside a plugin, it only affects the current plugin's routes.

I am updating the documentation by adding a note similar to the one on [server.bind](https://hapi.dev/api/?v=19.1.1#-serverbindcontext) to clarify those details.