### PR TITLE
v19.1.1 Server API options display issue on hapi.dev

### DIFF
--- a/API.md
+++ b/API.md
@@ -142,7 +142,7 @@ Default value: the operating system hostname and if not available, to `'localhos
 The public hostname or IP address. Used to set [`server.info.host`](#server.info) and
 [`server.info.uri`](#server.info) and as [`address`](#server.options.address) if none is provided.
 
-### <a name="server.options.info.remote" /> `server.options.info.remote`
+#### <a name="server.options.info.remote" /> `server.options.info.remote`
 
 Default value: `false`.
 


### PR DESCRIPTION
This should resolve a documentation layout issue on hapi.dev. It seems like all of the options displayed after `server.options.host` are displayed improperly in the sidebar, leading it to look like the options disappeared in v19.1.1:

![](https://p2.f0.n0.cdn.getcloudapp.com/items/OAuB0weg/Image%202020-05-31%20at%206.54.27%20PM.png?v=2c6f3390f61956c09b67d2d29202b419)

I'm guessing the parser started parsing a new tree upon encountering the H3.

I have not tested the change, however it seems like this change 1) is very low risk and 2) is the formatting that seems most consistent with the rest of the docs, in addition to most likely fixing the issue.