### PR TITLE
Implement `isInjected` read-only request property to indicate request…

### DIFF
--- a/API.md
+++ b/API.md
@@ -4585,7 +4585,7 @@ Note that the `request.info` object is not meant to be modified.
 
 Access: read only.
 
-When `true`, indicates request was created via [`server.inject`](#server.inject()).  Defaults to `false`.
+When `true`, indicates request was created via [`server.inject`](#server.inject()). 
 
 #### <a name="request.logs" /> `request.logs`
 

--- a/API.md
+++ b/API.md
@@ -4585,7 +4585,7 @@ Note that the `request.info` object is not meant to be modified.
 
 Access: read only.
 
-When `true`, indicates request was created via [`server.inject`](#server.inject()). 
+`true` if the request was created via [`server.inject`](#server.inject()), and `false` otherwise.
 
 #### <a name="request.logs" /> `request.logs`
 

--- a/API.md
+++ b/API.md
@@ -4585,7 +4585,7 @@ Note that the `request.info` object is not meant to be modified.
 
 Access: read only.
 
-`true` if the request was created via [`server.inject`](#server.inject()), and `false` otherwise.
+`true` if the request was created via [`server.inject()`](#server.inject()), and `false` otherwise.
 
 #### <a name="request.logs" /> `request.logs`
 

--- a/API.md
+++ b/API.md
@@ -4581,6 +4581,12 @@ Request information:
 
 Note that the `request.info` object is not meant to be modified.
 
+#### <a name="request.isInjected" /> `request.isInjected`
+
+Access: read only.
+
+When `true`, indicates request was created via [`server.inject`](#server.inject()).  Defaults to `false`.
+
 #### <a name="request.logs" /> `request.logs`
 
 Access: read only.

--- a/lib/request.js
+++ b/lib/request.js
@@ -29,6 +29,7 @@ exports = module.exports = internals.Request = class {
         this._eventContext = { request: this };
         this._events = null;                                                                                // Assigned an emitter when request.events is accessed
         this._expectContinue = !!options.expectContinue;
+        this._isInjected = !!options.isInjected;
         this._isPayloadPending = !!(req.headers['content-length'] || req.headers['transfer-encoding']);     // Changes to false when incoming payload fully processed
         this._isReplied = false;                                                                            // true when response processing started
         this._route = this._core.router.specials.notFound.route;                                            // Used prior to routing (only settings are used, not the handler)
@@ -39,7 +40,6 @@ exports = module.exports = internals.Request = class {
 
         this.app = options.app ? Object.assign({}, options.app) : {};                                       // Place for application-specific state without conflicts with hapi, should not be used by plugins (shallow cloned)
         this.headers = req.headers;
-        this.isInjected = !!options.isInjected;
         this.jsonp = null;
         this.logs = [];
         this.method = req.method.toLowerCase();
@@ -100,6 +100,11 @@ exports = module.exports = internals.Request = class {
         }
 
         return this._events;
+    }
+
+    get isInjected() {
+
+        return this._isInjected;
     }
 
     get url() {

--- a/lib/request.js
+++ b/lib/request.js
@@ -15,7 +15,7 @@ const Transmit = require('./transmit');
 
 const internals = {
     events: Podium.validate(['finish', { name: 'peek', spread: true }, 'disconnect']),
-    reserved: ['server', 'url', 'query', 'path', 'method', 'mime', 'setUrl', 'setMethod', 'headers', 'id', 'app', 'plugins', 'route', 'auth', 'pre', 'preResponses', 'info', 'orig', 'params', 'paramsArray', 'payload', 'state', 'jsonp', 'response', 'raw', 'domain', 'log', 'logs', 'generateResponse']
+    reserved: ['server', 'url', 'query', 'path', 'method', 'mime', 'setUrl', 'setMethod', 'headers', 'id', 'app', 'plugins', 'route', 'auth', 'pre', 'preResponses', 'info', 'isInjected', 'orig', 'params', 'paramsArray', 'payload', 'state', 'jsonp', 'response', 'raw', 'domain', 'log', 'logs', 'generateResponse']
 };
 
 
@@ -39,6 +39,7 @@ exports = module.exports = internals.Request = class {
 
         this.app = options.app ? Object.assign({}, options.app) : {};                                       // Place for application-specific state without conflicts with hapi, should not be used by plugins (shallow cloned)
         this.headers = req.headers;
+        this.isInjected = !!options.isInjected;
         this.jsonp = null;
         this.logs = [];
         this.method = req.method.toLowerCase();

--- a/lib/server.js
+++ b/lib/server.js
@@ -340,7 +340,8 @@ internals.Server = class {
             auth: options.auth,
             allowInternals: options.allowInternals,
             app: options.app,
-            plugins: options.plugins
+            plugins: options.plugins,
+            isInjected: true
         });
 
         const res = await Shot.inject(needle, settings);

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -6,7 +6,6 @@ const Ammo = require('@hapi/ammo');
 const Boom = require('@hapi/boom');
 const Bounce = require('@hapi/bounce');
 const Hoek = require('@hapi/hoek');
-const Shot = require('@hapi/shot');
 const Teamwork = require('@hapi/teamwork');
 
 const Config = require('./config');
@@ -94,7 +93,7 @@ internals.transmit = function (response) {
 
     // Connection: close
 
-    const isInjection = Shot.isInjection(request.raw.req);
+    const isInjection = request.isInjected;
     if (!(isInjection || request._core.started) ||
         request._isPayloadPending && !request.raw.req._readableState.ended) {
 

--- a/test/core.js
+++ b/test/core.js
@@ -1134,6 +1134,20 @@ describe('Core', () => {
             expect(res.result).to.be.true();
         });
 
+        it('sets `request.isInjected = true` for requests created via `server.inject`', async () => {
+
+            const server = Hapi.server();
+            server.route({ method: 'GET', path: '/', handler: (request) => request.isInjected });
+
+            const options = {
+                url: '/'
+            };
+
+            const res = await server.inject(options);
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.be.true();
+        });
+
         it('sets app settings', async () => {
 
             const server = Hapi.server();

--- a/test/core.js
+++ b/test/core.js
@@ -1151,25 +1151,25 @@ describe('Core', () => {
         it('`request.isInjected` access is read-only', async () => {
 
             const server = Hapi.server();
-            let request = null;
-            server.route({ method: 'GET', path: '/', handler: (_request) => {
+            server.route({ method: 'GET', path: '/', handler: (request) => {
 
-                request = _request; // hoist request object to perform illegal assignment assertion
-                return true;
+                const illegalAssignment = () => {
+
+                    request.isInjected = false;
+                };
+
+                expect(illegalAssignment).to.throw('Cannot set property isInjected of [object Object] which has only a getter');
+
+                return request.isInjected;
             } });
 
             const options = {
                 url: '/'
             };
 
-            await server.inject(options); // invokes side effect from handler to hoist request object for assertion
-
-            const illegalAssignment = () => {
-
-                request.isInjected = false;
-            };
-
-            expect(illegalAssignment).to.throw('Cannot set property isInjected of [object Object] which has only a getter');
+            const res = await server.inject(options);
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.be.true();
         });
 
         it('sets `request.isInjected = false` for normal request', async () => {

--- a/test/core.js
+++ b/test/core.js
@@ -1116,7 +1116,7 @@ describe('Core', () => {
             expect(options.auth.artifacts).to.exist();
         });
 
-        it('sets isInjected', async () => {
+        it('sets `request.auth.isInjected = true` when `auth` option is defined', async () => {
 
             const server = Hapi.server();
             server.route({ method: 'GET', path: '/', handler: (request) => request.auth.isInjected });
@@ -1146,6 +1146,19 @@ describe('Core', () => {
             const res = await server.inject(options);
             expect(res.statusCode).to.equal(200);
             expect(res.result).to.be.true();
+        });
+
+        it('sets `request.isInjected = false` for normal request', async () => {
+
+            const server = Hapi.server();
+            server.route({ method: 'GET', path: '/', handler: (request) => request.isInjected });
+
+            await server.start();
+
+            const { payload } = await Wreck.get(`http://localhost:${server.info.port}/`);
+            expect(payload.toString()).to.equal('false');
+
+            await server.stop();
         });
 
         it('sets app settings', async () => {

--- a/test/core.js
+++ b/test/core.js
@@ -1153,12 +1153,12 @@ describe('Core', () => {
             const server = Hapi.server();
             server.route({ method: 'GET', path: '/', handler: (request) => {
 
-                try {
+                const illegalAssignment = () => {
+
                     request.isInjected = false;
-                }
-                catch (e) {
-                    // silence error to keep unit test output clean.  We expect above line to fail because isInjected() is getter type
-                }
+                };
+
+                expect(illegalAssignment).to.throw('Cannot set property isInjected of [object Object] which has only a getter');
 
                 return request.isInjected;
             } });

--- a/test/core.js
+++ b/test/core.js
@@ -1151,25 +1151,25 @@ describe('Core', () => {
         it('`request.isInjected` access is read-only', async () => {
 
             const server = Hapi.server();
-            server.route({ method: 'GET', path: '/', handler: (request) => {
+            let request = null;
+            server.route({ method: 'GET', path: '/', handler: (_request) => {
 
-                const illegalAssignment = () => {
-
-                    request.isInjected = false;
-                };
-
-                expect(illegalAssignment).to.throw('Cannot set property isInjected of [object Object] which has only a getter');
-
-                return request.isInjected;
+                request = _request; // hoist request object to perform illegal assignment assertion
+                return true;
             } });
 
             const options = {
                 url: '/'
             };
 
-            const res = await server.inject(options);
-            expect(res.statusCode).to.equal(200);
-            expect(res.result).to.be.true();
+            await server.inject(options); // invokes side effect from handler to hoist request object for assertion
+
+            const illegalAssignment = () => {
+
+                request.isInjected = false;
+            };
+
+            expect(illegalAssignment).to.throw('Cannot set property isInjected of [object Object] which has only a getter');
         });
 
         it('sets `request.isInjected = false` for normal request', async () => {

--- a/test/core.js
+++ b/test/core.js
@@ -1148,6 +1148,30 @@ describe('Core', () => {
             expect(res.result).to.be.true();
         });
 
+        it('`request.isInjected` access is read-only', async () => {
+
+            const server = Hapi.server();
+            server.route({ method: 'GET', path: '/', handler: (request) => {
+
+                try {
+                    request.isInjected = false;
+                }
+                catch (e) {
+                    // silence error to keep unit test output clean.  We expect above line to fail because isInjected() is getter type
+                }
+
+                return request.isInjected;
+            } });
+
+            const options = {
+                url: '/'
+            };
+
+            const res = await server.inject(options);
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.be.true();
+        });
+
         it('sets `request.isInjected = false` for normal request', async () => {
 
             const server = Hapi.server();


### PR DESCRIPTION
Closes #4116 

Implements `isInjected` read-only request property to indicate request is injected by `server.inject()`