### PR TITLE
Update transmit.js

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -316,6 +316,9 @@ internals.end = function (env, event, err) {
 internals.writeHead = function (response) {
 
     const res = response.request.raw.res;
+    
+    if (res.finished) return;
+
     const headers = Object.keys(response.headers);
     let i = 0;
 


### PR DESCRIPTION
This prevents the message "Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client"