### PR TITLE
headers: avoid sending null content-type

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -122,7 +122,7 @@ exports.type = function (request) {
 
     const response = request.response;
     const type = response.contentType;
-    if (type !== response.headers['content-type']) {
+    if (type !== null && type !== response.headers['content-type']) {
         response.type(type);
     }
 };

--- a/test/headers.js
+++ b/test/headers.js
@@ -523,5 +523,15 @@ describe('Headers', () => {
             const res = await server.inject('/?callback=me');
             expect(res.payload).to.equal('test');
         });
+
+        it('does not set content-type by default on 204 response', async () => {
+
+            const server = Hapi.server();
+            server.route({ method: 'GET', path: '/', handler: (request, h) => h.response().code(204) });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(204);
+            expect(res.headers['content-type']).to.equal(undefined);
+        });
     });
 });


### PR DESCRIPTION
This commit prevents a null content-type header from being sent back.

Fixes: https://github.com/hapijs/hapi/issues/4133
Refs: https://github.com/hapijs/hapi/commit/ed0688c596d65ada38bea000ab6726c823a0abd9