### PR TITLE
fix: check if _isPayloadSupported is set

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -54,7 +54,8 @@ exports.content = async function (request) {
             response._header('content-length', response._payload.size(), { override: false });
         }
 
-        if (!response._isPayloadSupported()) {
+        if (response._isPayloadSupported &&
+            !response._isPayloadSupported()) {
             response._close();                              // Close unused file streams
             response._payload = new internals.Empty();      // Set empty stream
         }

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -35,7 +35,7 @@ exports.cache = function (request) {
 exports.content = async function (request) {
 
     const response = request.response;
-    if (response._isPayloadSupported() ||
+    if ((response._isPayloadSupported && response._isPayloadSupported()) ||
         request.method === 'head') {
 
         await response._marshal();


### PR DESCRIPTION
I noticed that in certain cases the server crashes because it tries to access `response._isPayloadSupported` but it is not a function. Unfortunately, I wasn't really able to reproduce the issue and find the root cause but I checked the request object immediately before it crashes and the `response` property looks like this:
```
  response: Error: Request aborted
      at IncomingMessage.internals.event (/Users/Julian/Documents/dev/projects/myapprovals/myapprovals-server/node_modules/@hapi/hapi/lib/request.js:717:30)
      at IncomingMessage.emit (events.js:314:20)
      at IncomingMessage.EventEmitter.emit (domain.js:486:12)
      at abortIncoming (_http_server.js:535:9)
      at socketOnEnd (_http_server.js:551:5)
      at TLSSocket.emit (events.js:326:22)
      at TLSSocket.EventEmitter.emit (domain.js:486:12)
      at endReadableNT (_stream_readable.js:1244:12)
      at processTicksAndRejections (internal/process/task_queues.js:80:21) {
    data: null,
    isBoom: true,
    isServer: false,
    output: { statusCode: 499, payload: [Object], headers: {} }
  },
```

So it might be related to aborted requests.