### PR TITLE
Preserve original response status on error after write, fix status message

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -346,9 +346,21 @@ internals.Server = class {
         const res = await Shot.inject(needle, settings);
         const custom = res.raw.res[Config.symbol];
         if (custom) {
-            res.result = custom.result;
-            res.request = custom.request;
             delete res.raw.res[Config.symbol];
+
+            res.request = custom.request;
+
+            if (custom.result !== undefined) {
+                res.result = custom.result;
+            }
+
+            if (custom.statusCode !== undefined) {
+                res.statusCode = custom.statusCode;
+            }
+
+            if (custom.statusMessage !== undefined) {
+                res.statusMessage = custom.statusMessage;
+            }
         }
 
         if (res.result === undefined) {

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -296,7 +296,8 @@ internals.end = function (env, event, err) {
     request._setResponse(error);
 
     if (request.raw.res[Config.symbol]) {
-        request.raw.res.statusCode = error.statusCode;
+        request.raw.res[Config.symbol].statusCode = error.statusCode;
+        request.raw.res[Config.symbol].statusMessage = error.source.error;
         request.raw.res[Config.symbol].result = error.source;       // Force injected response to error
     }
 


### PR DESCRIPTION
#4182 brings-up valid concerns about the status codes reported by `server.inject()` for response errors that occur after the original status code and headers have been written.  In the past these original status codes have been completely overwritten.  Now it should be accessible on `server.inject()`'s `response.raw.res.statusCode`, which may differ from `response.statusCode` when an error happened after the status code was written.  This work additionally fixes `response.statusMessage`, which was out of sync with `response.statusCode` in these cases.

For some history on status codes reported by `server.inject()` see also https://github.com/outmoded/discuss/issues/729 https://github.com/hapijs/hapi/issues/3878 https://github.com/hapijs/hapi/issues/3561 