### PR TITLE
Fix tests for citgm

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const ChildProcess = require('child_process');
+
+const internals = {};
+
+internals.hasLsof = () => {
+
+    try {
+        ChildProcess.execSync(`lsof -p ${process.pid}`, { stdio: 'ignore' });
+    }
+    catch (err) {
+        return false;
+    }
+
+    return true;
+};
+
+exports.hasLsof = internals.hasLsof();

--- a/test/core.js
+++ b/test/core.js
@@ -1705,7 +1705,7 @@ describe('Core', () => {
                     cmd.on('error', (err) => {
 
                         // Allow the test to pass on platforms with no lsof
-                        Bounce.ignore(err, { errno: 'ENOENT' });
+                        Bounce.ignore(err, { code: 'ENOENT' });
                     });
 
                     cmd.stdout.on('data', (buffer) => {

--- a/test/core.js
+++ b/test/core.js
@@ -11,7 +11,6 @@ const Stream = require('stream');
 const TLS = require('tls');
 
 const Boom = require('@hapi/boom');
-const Bounce = require('@hapi/bounce');
 const CatboxMemory = require('@hapi/catbox-memory');
 const Code = require('@hapi/code');
 const Handlebars = require('handlebars');
@@ -22,6 +21,7 @@ const Lab = require('@hapi/lab');
 const Vision = require('@hapi/vision');
 const Wreck = require('@hapi/wreck');
 
+const Common = require('./common');
 
 const internals = {};
 
@@ -1679,7 +1679,7 @@ describe('Core', () => {
                 expect(res.result.isBoom).to.equal(true);
             });
 
-            it('cleans unused file stream when response is overridden', { skip: process.platform === 'win32' }, async () => {
+            it('cleans unused file stream when response is overridden', { skip: !Common.hasLsof }, async () => {
 
                 const server = Hapi.server();
                 await server.register(Inert);
@@ -1701,12 +1701,6 @@ describe('Core', () => {
 
                     const cmd = ChildProcess.spawn('lsof', ['-p', process.pid]);
                     let lsof = '';
-
-                    cmd.on('error', (err) => {
-
-                        // Allow the test to pass on platforms with no lsof
-                        Bounce.ignore(err, { code: 'ENOENT' });
-                    });
 
                     cmd.stdout.on('data', (buffer) => {
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -8,7 +8,6 @@ const Stream = require('stream');
 const Zlib = require('zlib');
 
 const Boom = require('@hapi/boom');
-const Bounce = require('@hapi/bounce');
 const Code = require('@hapi/code');
 const Hapi = require('..');
 const Hoek = require('@hapi/hoek');
@@ -17,6 +16,7 @@ const Lab = require('@hapi/lab');
 const Teamwork = require('@hapi/teamwork');
 const Wreck = require('@hapi/wreck');
 
+const Common = require('./common');
 
 const internals = {};
 
@@ -86,7 +86,7 @@ describe('transmission', () => {
             expect(res.statusCode).to.equal(200);
         });
 
-        it('closes file handlers when not reading file stream', { skip: process.platform === 'win32' }, async () => {
+        it('closes file handlers when not reading file stream', { skip: !Common.hasLsof }, async () => {
 
             const server = Hapi.server();
             await server.register(Inert);
@@ -100,12 +100,6 @@ describe('transmission', () => {
 
                 const cmd = ChildProcess.spawn('lsof', ['-p', process.pid]);
                 let lsof = '';
-
-                cmd.on('error', (err) => {
-
-                    // Allow the test to pass on platforms with no lsof
-                    Bounce.ignore(err, { code: 'ENOENT' });
-                });
 
                 cmd.stdout.on('data', (buffer) => {
 
@@ -128,7 +122,7 @@ describe('transmission', () => {
             });
         });
 
-        it('closes file handlers when not using a manually open file stream', { skip: process.platform === 'win32' }, async () => {
+        it('closes file handlers when not using a manually open file stream', { skip: !Common.hasLsof }, async () => {
 
             const server = Hapi.server();
             server.route({ method: 'GET', path: '/file', handler: (request, h) => h.response(Fs.createReadStream(__dirname + '/../package.json')).header('etag', 'abc') });
@@ -141,12 +135,6 @@ describe('transmission', () => {
 
                 const cmd = ChildProcess.spawn('lsof', ['-p', process.pid]);
                 let lsof = '';
-
-                cmd.on('error', (err) => {
-
-                    // Allow the test to pass on platforms with no lsof
-                    Bounce.ignore(err, { code: 'ENOENT' });
-                });
 
                 cmd.stdout.on('data', (buffer) => {
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -104,7 +104,7 @@ describe('transmission', () => {
                 cmd.on('error', (err) => {
 
                     // Allow the test to pass on platforms with no lsof
-                    Bounce.ignore(err, { errno: 'ENOENT' });
+                    Bounce.ignore(err, { code: 'ENOENT' });
                 });
 
                 cmd.stdout.on('data', (buffer) => {
@@ -145,7 +145,7 @@ describe('transmission', () => {
                 cmd.on('error', (err) => {
 
                     // Allow the test to pass on platforms with no lsof
-                    Bounce.ignore(err, { errno: 'ENOENT' });
+                    Bounce.ignore(err, { code: 'ENOENT' });
                 });
 
                 cmd.stdout.on('data', (buffer) => {


### PR DESCRIPTION
There are a few issues to fix for failures in citgm:

1. Tests that rely on lsof on node v14.  @cjihrig previously made a fix for this in https://github.com/hapijs/hapi/pull/3744, but on node v14 the way to detect this error changed. https://github.com/nodejs/citgm/pull/436#issuecomment-754156977
2. Some flaky/failing tests on macos and AIX.  As far as I can tell the issue here is flakiness due to timing-dependent tests and slow IO in CI.  I attempted to make these tests less timing-dependent and to better cleanup after themselves, which allows them to be retryable.  I would love some review of these changes, as they are some of the more complex tests in the hapi test suite. https://github.com/nodejs/citgm/pull/436#issuecomment-751786801

CC @AdriVanHoudt I know in https://github.com/nodejs/citgm/pull/436 you were able to reproduce the macos issues.  If you have time and would be open to trying out these changes it would be very much appreciated.