### PR TITLE
Future-proof hapi for node v16, rely on res close rather than req

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -308,7 +308,7 @@ exports = module.exports = internals.Request = class {
             this.raw.req.on('end', internals.event.bind(this.raw.req, this._eventContext, 'end'));
         }
 
-        this.raw.req.on('close', internals.event.bind(this.raw.req, this._eventContext, 'close'));
+        this.raw.res.on('close', internals.event.bind(this.raw.res, this._eventContext, 'close'));
         this.raw.req.on('error', internals.event.bind(this.raw.req, this._eventContext, 'error'));
         this.raw.req.on('aborted', internals.event.bind(this.raw.req, this._eventContext, 'abort'));
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@hapi/hoek": "9.x.x",
     "@hapi/mimos": "5.x.x",
     "@hapi/podium": "^4.1.1",
-    "@hapi/shot": "^5.0.1",
+    "@hapi/shot": "^5.0.5",
     "@hapi/somever": "3.x.x",
     "@hapi/statehood": "^7.0.3",
     "@hapi/subtext": "^7.0.3",
@@ -42,8 +42,8 @@
     "@hapi/inert": "^6.0.2",
     "@hapi/joi-legacy-test": "npm:@hapi/joi@15.x.x",
     "@hapi/lab": "24.x.x",
-    "@hapi/wreck": "17.x.x",
     "@hapi/vision": "^6.0.1",
+    "@hapi/wreck": "17.x.x",
     "handlebars": "^4.5.3",
     "joi": "17.x.x"
   },


### PR DESCRIPTION
There was a regression in node v15.5.0 which broke hapi.  We learned that this was considered a bug in node v15, but that a comparable change would land in node v16.  As such, we now rely on res rather than req to handle premature `'close'` events.  This small alteration should be compatible with node v12+, and is not considered a breaking change.  This relies on a change within shot referenced below.

Refs: https://github.com/hapijs/hapi/issues/4208  https://github.com/hapijs/shot/pull/139 https://github.com/nodejs/node/pull/33035