### PR TITLE
Allow for res to have already closed during transmission

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -24,6 +24,7 @@ exports = module.exports = internals.Request = class {
     constructor(server, req, res, options) {
 
         this._allowInternals = !!options.allowInternals;
+        this._closed = false;                                                                               // true once the response has closed (esp. early) and will not emit any more events
         this._core = server._core;
         this._entity = null;                                                                                // Entity information set via h.entity()
         this._eventContext = { request: this };
@@ -311,6 +312,7 @@ exports = module.exports = internals.Request = class {
         this.raw.req.on('close', internals.event.bind(this.raw.req, this._eventContext, 'close'));
         this.raw.req.on('error', internals.event.bind(this.raw.req, this._eventContext, 'error'));
         this.raw.req.on('aborted', internals.event.bind(this.raw.req, this._eventContext, 'abort'));
+        this.raw.res.once('close', internals.closed.bind(this.raw.res, this));
     }
 
     _lookup() {
@@ -686,6 +688,11 @@ internals.Info = class {
     }
 };
 
+
+internals.closed = function (request) {
+
+    request._closed = true;
+};
 
 internals.event = function ({ request }, event, err) {
 

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -244,6 +244,13 @@ internals.pipe = function (request, stream) {
 
     const env = { stream, request, team };
 
+    if (request._closed) {
+        // No more events will be fired, so we proactively close-up shop
+        request.raw.res.end(); // Ensure res is finished so internals.end() doesn't think we're responding
+        internals.end(env, 'close');
+        return team.work;
+    }
+
     const aborted = internals.end.bind(null, env, 'aborted');
     const close = internals.end.bind(null, env, 'close');
     const end = internals.end.bind(null, env, null);

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -538,10 +538,15 @@ describe('transmission', () => {
             // Use state autoValue function to intercept marshal stage
 
             server.state('always', {
-                autoValue() {
+                async autoValue(request) {
 
-                    client.destroy();
-                    return team.work;               // Continue once the request has been aborted
+                    const close = new Teamwork.Team();
+                    request.raw.res.once('close', () => close.attend());
+
+                    client.destroy();               // Will trigger abort then close. Prior to node v15.7.0 the res close came
+                    await close.work;               // asynchronously after req abort, but since then it comes in the same tick.
+
+                    return team.work;               // Continue marshalling once the request has been aborted and response closed.
                 }
             });
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -543,8 +543,10 @@ describe('transmission', () => {
                     const close = new Teamwork.Team();
                     request.raw.res.once('close', () => close.attend());
 
-                    client.destroy();               // Will trigger abort then close. Prior to node v15.7.0 the res close came
-                    await close.work;               // asynchronously after req abort, but since then it comes in the same tick.
+                    // Will trigger abort then close. Prior to node v15.7.0 the res close came
+                    // asynchronously after req abort, but since then it comes in the same tick.
+                    client.destroy();
+                    await close.work;
 
                     return team.work;               // Continue marshalling once the request has been aborted and response closed.
                 }


### PR DESCRIPTION
There's a fun story here!

In https://github.com/nodejs/citgm/pull/436 it was brought to our attention that node v15.7.0 caused a test to reliably fail in hapi's test suite.  I found that the test fails due to the relative timing of request `abort` versus response `close` timing: prior to node v15.7.0 the response would close in a later tick than the request would abort, and now these occur in the same tick.  This means that during hapi's transmission step, where it would typically still assume that the request or response would still have some events to emit (namely, a response `close`), that there would be no more event from `req` and `res`.  The first thing I did was adjust this test to remove the timing discrepancy across node versions, so that it always takes the most aggressive approach that we see occurring in node v15.7.0 (always aborts _and closes_ during marshaling).

I searched for a nice node-builtin way to detect this case, but I didn't find anything that stuck.  The most promising one was to check for `res.destroyed`, but it turns out that this was set in node v15, but not in node v14.  So I decided to add some state to hapi's request that tracks whether the response is closed, which to the best of my knowledge indicates that we can't expect to see any more events from `req` and `res`.

I ensured this code path continued to go through hapi's ending routine as though `close` were emitted, even though it ends-up being a no-op.  Honestly, adding some more state to `request` to track this and triggering a `finish` on `res` was not my favorite approach, but it was hard for me to find something more appropriate.  Certainly open to suggestions.  One aspect that I wouldn't mind some review on is whether the new event listener could introduce some kind of leak since it doesn't stop referencing `request` as the other listeners do through `_eventContext`— I think we're all good there, but it was on my mind.  @kanongil of course no pressure, but if you do have time to take a look, I think you are one of the people best-suited to review this area of hapi and any input you have would be appreciated.