### PR TITLE
Mention response.charset() clear behavior

### DIFF
--- a/API.md
+++ b/API.md
@@ -4325,7 +4325,7 @@ Return value: the current response object.
 
 Sets the 'Content-Type' HTTP header 'charset' property where:
 
-- `charset` - the charset property value.
+- `charset` - the charset property value. When `charset` value is falsy, it will prevent hapi from using its default charset setting.
 
 Return value: the current response object.
 


### PR DESCRIPTION
Someone opened a PR on DefinitelyTyped repo regarding an undocumented behavior of `response.charset()` in the typings. It's also undocumented in the API documentation so I thought we ought to add it. Source: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52285#issuecomment-816824526
