### PR TITLE
Update test suite to cover node v16

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -18,9 +18,10 @@ jobs:
     name: ${{ matrix.os }} node@${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          check-latest: ${{ matrix.node == '*' }}
       - name: install
         run: npm install
       - name: test

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@hapi/code": "^8.0.0",
     "@hapi/inert": "^6.0.2",
     "@hapi/joi-legacy-test": "npm:@hapi/joi@^15.0.0",
-    "@hapi/lab": "^24.0.0",
+    "@hapi/lab": "^24.2.0",
     "@hapi/vision": "^6.0.1",
     "@hapi/wreck": "^17.0.0",
     "handlebars": "^4.7.4",


### PR DESCRIPTION
We're using the approach outlined [here](https://github.com/hapijs/lab/pull/1004#issuecomment-824109034) to ensure `'*'` listed in CI pulls the latest version of node.  Also updating to lab 24.2.0 which supports node v16's new globals.

Refs: https://github.com/nodejs/citgm/issues/852 https://github.com/hapijs/lab/pull/1004