### PR TITLE
Update sponsors.md, link to the maintained list

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,10 +1,12 @@
+We'd like to thank our sponsors as well as the legacy sponsors who have supported hapi throughout the years. Thanks so much for your support!
+
+> Below are hapi's top recurring sponsors, but there are many more to thank.  For the complete list, see [hapi.dev/policies/sponsors](https://hapi.dev/policies/sponsors/) or [hapijs/.github/SPONSORS.md](https://github.com/hapijs/.github/blob/master/SPONSORS.md).
+
+# Staff Sponsors
+- [Big Room Studios](https://www.bigroomstudios.com/)
+- [Dixeed](https://dixeed.com/)
+
 # Top Sponsors
-
-- Fabian Gündel / DataWrapper.de
+- Fabian Gündel / [DataWrapper.de](https://www.datawrapper.de/)
 - Devin Stewart
-
-# Backers
-
-- Aori Nevo
-- Zack McCartney
-
+- [Raider.IO](https://raider.io/)


### PR DESCRIPTION
The sponsor list list was out of date and out of sync with https://github.com/hapijs/.github/blob/master/SPONSORS.md, which is the official list appearing on the website.  I figured a reasonable compromise for now would be to list top sponsors here, which change less often, then link out to the extended list.