### PR TITLE
Add response lifecycle tracking and checks

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -55,10 +55,11 @@ exports = module.exports = internals.Response = class {
 
         this._events = null;
         this._payload = null;                       // Readable stream
-        this._error = null;                         // The boom object when created from an error (used for logging)
+        this._error = options.error || null;        // The boom object when created from an error (used for logging)
         this._contentType = null;                   // Used if no explicit content-type is set and type is known
         this._takeover = false;
         this._statusCode = false;                   // true when code() called
+        this._state = 'init';                       // One of 'init', 'prepared', 'marshalled', 'closed'
 
         this._processors = {
             marshal: options.marshal,
@@ -495,17 +496,24 @@ exports = module.exports = internals.Response = class {
 
     _prepare() {
 
-        this._passThrough();
-
-        if (!this._processors.prepare) {
-            return this;
-        }
+        Hoek.assert(this._state === 'init');
 
         try {
-            return this._processors.prepare(this);
+            this._passThrough();
+
+            if (!this._processors.prepare) {
+                return this;
+            }
+
+            try {
+                return this._processors.prepare(this);
+            }
+            catch (err) {
+                throw Boom.boomify(err);
+            }
         }
-        catch (err) {
-            throw Boom.boomify(err);
+        finally {
+            this._state = 'prepared';
         }
     }
 
@@ -558,67 +566,74 @@ exports = module.exports = internals.Response = class {
 
     async _marshal() {
 
-        let source = this.source;
+        Hoek.assert(this._state === 'prepared' || this._error);
 
-        // Processor marshal
+        try {
+            let source = this.source;
 
-        if (this._processors.marshal) {
-            try {
-                source = await this._processors.marshal(this);
-            }
-            catch (err) {
-                throw Boom.boomify(err);
-            }
-        }
+            // Processor marshal
 
-        // Stream source
-
-        if (Streams.isStream(source)) {
-            this._payload = source;
-            return;
-        }
-
-        // Plain source (non string or null)
-
-        const jsonify = this.variety === 'plain' && source !== null && typeof source !== 'string';
-
-        if (!jsonify &&
-            this.settings.stringify) {
-
-            throw Boom.badImplementation('Cannot set formatting options on non object response');
-        }
-
-        let payload = source;
-
-        if (jsonify) {
-            const options = this.settings.stringify || {};
-            const space = options.space || this.request.route.settings.json.space;
-            const replacer = options.replacer || this.request.route.settings.json.replacer;
-            const suffix = options.suffix || this.request.route.settings.json.suffix || '';
-            const escape = this.request.route.settings.json.escape || false;
-
-            try {
-                if (replacer || space) {
-                    payload = JSON.stringify(payload, replacer, space);
+            if (this._processors.marshal) {
+                try {
+                    source = await this._processors.marshal(this);
                 }
-                else {
-                    payload = JSON.stringify(payload);
+                catch (err) {
+                    throw Boom.boomify(err);
                 }
             }
-            catch (err) {
-                throw Boom.boomify(err);
+
+            // Stream source
+
+            if (Streams.isStream(source)) {
+                this._payload = source;
+                return;
             }
 
-            if (suffix) {
-                payload = payload + suffix;
+            // Plain source (non string or null)
+
+            const jsonify = this.variety === 'plain' && source !== null && typeof source !== 'string';
+
+            if (!jsonify &&
+                this.settings.stringify) {
+
+                throw Boom.badImplementation('Cannot set formatting options on non object response');
             }
 
-            if (escape) {
-                payload = Hoek.escapeJson(payload);
+            let payload = source;
+
+            if (jsonify) {
+                const options = this.settings.stringify || {};
+                const space = options.space || this.request.route.settings.json.space;
+                const replacer = options.replacer || this.request.route.settings.json.replacer;
+                const suffix = options.suffix || this.request.route.settings.json.suffix || '';
+                const escape = this.request.route.settings.json.escape || false;
+
+                try {
+                    if (replacer || space) {
+                        payload = JSON.stringify(payload, replacer, space);
+                    }
+                    else {
+                        payload = JSON.stringify(payload);
+                    }
+                }
+                catch (err) {
+                    throw Boom.boomify(err);
+                }
+
+                if (suffix) {
+                    payload = payload + suffix;
+                }
+
+                if (escape) {
+                    payload = Hoek.escapeJson(payload);
+                }
             }
+
+            this._payload = new internals.Response.Payload(payload, this.settings);
         }
-
-        this._payload = new internals.Response.Payload(payload, this.settings);
+        finally {
+            this._state = 'marshalled';
+        }
     }
 
     _tap() {
@@ -638,19 +653,28 @@ exports = module.exports = internals.Response = class {
 
     _close() {
 
-        if (this._processors.close) {
-            try {
-                this._processors.close(this);
-            }
-            catch (err) {
-                Bounce.rethrow(err, 'system');
-                this.request._log(['response', 'cleanup', 'error'], err);
-            }
+        if (this._state === 'closed') {
+            return;
         }
 
-        const stream = this._payload || this.source;
-        if (Streams.isStream(stream)) {
-            internals.Response.drain(stream);
+        try {
+            if (this._processors.close) {
+                try {
+                    this._processors.close(this);
+                }
+                catch (err) {
+                    Bounce.rethrow(err, 'system');
+                    this.request._log(['response', 'cleanup', 'error'], err);
+                }
+            }
+
+            const stream = this._payload || this.source;
+            if (Streams.isStream(stream)) {
+                internals.Response.drain(stream);
+            }
+        }
+        finally {
+            this._state = 'closed';
         }
     }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -59,7 +59,7 @@ exports = module.exports = internals.Response = class {
         this._contentType = null;                   // Used if no explicit content-type is set and type is known
         this._takeover = false;
         this._statusCode = false;                   // true when code() called
-        this._state = 'init';                       // One of 'init', 'prepared', 'marshalled', 'closed'
+        this._state = this._error ? 'prepare' : 'init'; // One of 'init', 'prepare', 'marshall', 'close'
 
         this._processors = {
             marshal: options.marshal,
@@ -498,22 +498,19 @@ exports = module.exports = internals.Response = class {
 
         Hoek.assert(this._state === 'init');
 
-        try {
-            this._passThrough();
+        this._state = 'prepare';
 
-            if (!this._processors.prepare) {
-                return this;
-            }
+        this._passThrough();
 
-            try {
-                return this._processors.prepare(this);
-            }
-            catch (err) {
-                throw Boom.boomify(err);
-            }
+        if (!this._processors.prepare) {
+            return this;
         }
-        finally {
-            this._state = 'prepared';
+
+        try {
+            return this._processors.prepare(this);
+        }
+        catch (err) {
+            throw Boom.boomify(err);
         }
     }
 
@@ -566,74 +563,71 @@ exports = module.exports = internals.Response = class {
 
     async _marshal() {
 
-        Hoek.assert(this._state === 'prepared' || this._error);
+        Hoek.assert(this._state === 'prepare');
 
-        try {
-            let source = this.source;
+        this._state = 'marshall';
 
-            // Processor marshal
+        // Processor marshal
 
-            if (this._processors.marshal) {
-                try {
-                    source = await this._processors.marshal(this);
-                }
-                catch (err) {
-                    throw Boom.boomify(err);
-                }
+        let source = this.source;
+
+        if (this._processors.marshal) {
+            try {
+                source = await this._processors.marshal(this);
             }
-
-            // Stream source
-
-            if (Streams.isStream(source)) {
-                this._payload = source;
-                return;
+            catch (err) {
+                throw Boom.boomify(err);
             }
-
-            // Plain source (non string or null)
-
-            const jsonify = this.variety === 'plain' && source !== null && typeof source !== 'string';
-
-            if (!jsonify &&
-                this.settings.stringify) {
-
-                throw Boom.badImplementation('Cannot set formatting options on non object response');
-            }
-
-            let payload = source;
-
-            if (jsonify) {
-                const options = this.settings.stringify || {};
-                const space = options.space || this.request.route.settings.json.space;
-                const replacer = options.replacer || this.request.route.settings.json.replacer;
-                const suffix = options.suffix || this.request.route.settings.json.suffix || '';
-                const escape = this.request.route.settings.json.escape || false;
-
-                try {
-                    if (replacer || space) {
-                        payload = JSON.stringify(payload, replacer, space);
-                    }
-                    else {
-                        payload = JSON.stringify(payload);
-                    }
-                }
-                catch (err) {
-                    throw Boom.boomify(err);
-                }
-
-                if (suffix) {
-                    payload = payload + suffix;
-                }
-
-                if (escape) {
-                    payload = Hoek.escapeJson(payload);
-                }
-            }
-
-            this._payload = new internals.Response.Payload(payload, this.settings);
         }
-        finally {
-            this._state = 'marshalled';
+
+        // Stream source
+
+        if (Streams.isStream(source)) {
+            this._payload = source;
+            return;
         }
+
+        // Plain source (non string or null)
+
+        const jsonify = this.variety === 'plain' && source !== null && typeof source !== 'string';
+
+        if (!jsonify &&
+            this.settings.stringify) {
+
+            throw Boom.badImplementation('Cannot set formatting options on non object response');
+        }
+
+        let payload = source;
+
+        if (jsonify) {
+            const options = this.settings.stringify || {};
+            const space = options.space || this.request.route.settings.json.space;
+            const replacer = options.replacer || this.request.route.settings.json.replacer;
+            const suffix = options.suffix || this.request.route.settings.json.suffix || '';
+            const escape = this.request.route.settings.json.escape || false;
+
+            try {
+                if (replacer || space) {
+                    payload = JSON.stringify(payload, replacer, space);
+                }
+                else {
+                    payload = JSON.stringify(payload);
+                }
+            }
+            catch (err) {
+                throw Boom.boomify(err);
+            }
+
+            if (suffix) {
+                payload = payload + suffix;
+            }
+
+            if (escape) {
+                payload = Hoek.escapeJson(payload);
+            }
+        }
+
+        this._payload = new internals.Response.Payload(payload, this.settings);
     }
 
     _tap() {
@@ -653,28 +647,25 @@ exports = module.exports = internals.Response = class {
 
     _close() {
 
-        if (this._state === 'closed') {
+        if (this._state === 'close') {
             return;
         }
 
-        try {
-            if (this._processors.close) {
-                try {
-                    this._processors.close(this);
-                }
-                catch (err) {
-                    Bounce.rethrow(err, 'system');
-                    this.request._log(['response', 'cleanup', 'error'], err);
-                }
-            }
+        this._state = 'close';
 
-            const stream = this._payload || this.source;
-            if (Streams.isStream(stream)) {
-                internals.Response.drain(stream);
+        if (this._processors.close) {
+            try {
+                this._processors.close(this);
+            }
+            catch (err) {
+                Bounce.rethrow(err, 'system');
+                this.request._log(['response', 'cleanup', 'error'], err);
             }
         }
-        finally {
-            this._state = 'closed';
+
+        const stream = this._payload || this.source;
+        if (Streams.isStream(stream)) {
+            internals.Response.drain(stream);
         }
     }
 

--- a/lib/toolkit.js
+++ b/lib/toolkit.js
@@ -101,7 +101,7 @@ exports.Manager = class {
 
         if (typeof response !== 'symbol') {
             response = request._core.Response.wrap(response, request);
-            if (!response.isBoom) {
+            if (!response.isBoom && response._state === 'init') {
                 response = await response._prepare();
             }
         }

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -38,7 +38,7 @@ exports.send = async function (request) {
 internals.marshal = async function (response) {
 
     for (const func of response.request._route._marshalCycle) {
-        if (response._state !== 'closed') {
+        if (response._state !== 'close') {
             await func(response);
         }
     }

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -38,7 +38,9 @@ exports.send = async function (request) {
 internals.marshal = async function (response) {
 
     for (const func of response.request._route._marshalCycle) {
-        await func(response);
+        if (response._state !== 'closed') {
+            await func(response);
+        }
     }
 };
 
@@ -72,8 +74,7 @@ internals.fail = async function (request, boom) {
 internals.error = function (request, boom) {
 
     const error = boom.output;
-    const response = new request._core.Response(error.payload, request);
-    response._error = boom;
+    const response = new request._core.Response(error.payload, request, { error: boom });
     response.code(error.statusCode);
     response.headers = Hoek.clone(error.headers);               // Prevent source from being modified
     return response;

--- a/test/response.js
+++ b/test/response.js
@@ -1290,6 +1290,37 @@ describe('Response', () => {
             const res = await server.inject('/');
             expect(res.statusCode).to.equal(500);
         });
+
+        it('is only called once for returned responses', async () => {
+
+            let calls = 0;
+            const pre = (request, h) => {
+
+                const prepare = (response) => {
+
+                    ++calls;
+                    return response;
+                };
+
+                return request.generateResponse(null, { prepare });
+            };
+
+            const server = Hapi.server();
+            server.route({
+                method: 'GET',
+                path: '/',
+                options: {
+                    pre: [
+                        { method: pre, assign: 'p' }
+                    ],
+                    handler: (request) => request.preResponses.p
+                }
+            });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(204);
+            expect(calls).to.equal(1);
+        });
     });
 
     describe('_tap()', () => {


### PR DESCRIPTION
This is in response to #4256.

I added asserts to verify the expected state so this kind of error are less likely to be introduced in future code. This also caught another error, where the `marshal()` method could sometimes be called _after_ `close()`.