### PR TITLE
Fix request test to account for changes to ERR_INVALID_URL in node 16.2.0

### DIFF
--- a/test/request.js
+++ b/test/request.js
@@ -346,7 +346,7 @@ describe('Request', () => {
 
             const res = await server.inject('invalid');
             expect(res.statusCode).to.equal(400);
-            expect(res.result.message).to.equal('Invalid URL: invalid');
+            expect(res.result.message).to.startWith('Invalid URL');
         });
 
         it('returns boom response on ext error', async () => {


### PR DESCRIPTION
There [was a change](https://github.com/nodejs/node/pull/38614) to the `ERR_INVALID_URL` constructor to stop reflecting the input in the error message that was landed in node 16.2.0, this adjusts our assertion so that both the new and old message will pass.

An alternative would be to start passing the `code` property from the error into the response, which I don't really love but one could certainly make a case for.