### PR TITLE
Update invalid path test to match message

### DIFF
--- a/test/request.js
+++ b/test/request.js
@@ -346,7 +346,7 @@ describe('Request', () => {
 
             const res = await server.inject('invalid');
             expect(res.statusCode).to.equal(400);
-            expect(res.result.message).to.equal('Invalid URL: invalid');
+            expect(res.result.message).to.equal('Invalid URL');
         });
 
         it('returns boom response on ext error', async () => {


### PR DESCRIPTION
I noticed on running the tests that 'returns 400 on invalid path' (currently test 392) fails because of a text mismatch. I checked back to at least v20.0.3 and it failed in the same way. The text of the test hasn't changed since 2018.

I wasn't able to find out where the text is generated, unfortunately, but took a guess that the new text is okay. If someone can point me to where the error text comes from I'm happy to look again. :-)

Thanks
Paul