### PR TITLE
Fix req end during response transmission

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -257,7 +257,6 @@ internals.pipe = function (request, stream) {
     const end = internals.end.bind(null, env, null);
 
     request.raw.req.on('aborted', aborted);
-    request.raw.req.on('close', close);
 
     request.raw.res.on('close', close);
     request.raw.res.on('error', end);

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -7,11 +7,13 @@ const Net = require('net');
 const Path = require('path');
 const Stream = require('stream');
 const Zlib = require('zlib');
+const Events = require('events');
 
 const Boom = require('@hapi/boom');
 const Code = require('@hapi/code');
 const Hapi = require('..');
 const Hoek = require('@hapi/hoek');
+const Bounce = require('@hapi/bounce');
 const Inert = require('@hapi/inert');
 const Lab = require('@hapi/lab');
 const LegacyReadableStream = require('legacy-readable-stream');
@@ -1920,6 +1922,63 @@ describe('transmission', () => {
             server.route({ method: 'GET', path: '/', handler });
             const res = await server.inject('/');
             expect(res.statusCode).to.equal(500);
+        });
+
+        it('permits ending reading request stream while transmitting response.', async (flags) => {
+
+            const server = Hapi.server();
+
+            server.route({
+                method: 'post',
+                path: '/',
+                options: {
+                    payload: {
+                        output: 'stream'
+                    }
+                },
+                handler: (request, h) => {
+
+                    const stream = new Stream.PassThrough();
+
+                    // Start transmitting stream response...
+                    stream.push('hello ');
+
+                    Bounce.background(async () => {
+
+                        await Events.once(request.raw.res, 'pipe');
+
+                        // ...but also only read and end the request once the response is transmitting...
+                        request.raw.req.on('data', Hoek.ignore);
+                        await Events.once(request.raw.req, 'end');
+
+                        // ...and finally end the intended response once the request stream has ended.
+                        stream.end('world');
+                    });
+
+                    return h.response(stream);
+                }
+            });
+
+            flags.onCleanup = () => server.stop();
+            await server.start();
+
+            const req = Http.request({
+                hostname: 'localhost',
+                port: server.info.port,
+                method: 'post'
+            });
+
+            req.end('{}');
+
+            const [res] = await Events.once(req, 'response');
+
+            let result = '';
+            for await (const chunk of res) {
+                result += chunk.toString();
+            }
+
+            // If not permitted then result will be "hello " without "world"
+            expect(result).to.equal('hello world');
         });
     });
 


### PR DESCRIPTION
Addresses #4262.  On node v16 hapi would cut short any response that was transmitting while the request stream ended.  This is not especially common, partly because the request stream is often used prior to transmitting the response, and partly because this case does not apply when the request stream is not read at all i.e. for GET requests.

I believe this change is sound and backwards compatible because on node versions prior to v16, both req and res `'close'` events have identical meaning: the underlying connection shared by req and res has closed.  For this reason, there is no need to add listeners to both req and res on node <v16.

Starting with node v16 the `'close'` event for req no longer relates to the underlying connection, best documented at https://github.com/nodejs/node/issues/38924 and https://github.com/nodejs/node/pull/33035.  This means that it is possible for req to `'close'` prior to res, notably while transmitting res.  The change in this PR is intended to take that into account.  The test added here was failing on node v16 prior to this change.

See also #4263, which fixes a test that would have failed with the changes made in this PR.