### PR TITLE
Add optional payload authentication skip on credentials injection

### DIFF
--- a/API.md
+++ b/API.md
@@ -1893,6 +1893,10 @@ injections, with some additional options and response properties:
           and are validated directly as if they were received via an authentication scheme.
           Defaults to no artifacts.
 
+        - `payload` - (optional) disables payload authentication when set to false.
+          Only required when an authentication strategy requires payload authentication.
+          Defaults to `true`.
+
     - `app` - (optional) sets the initial value of `request.app`, defaults to `{}`.
 
     - `plugins` - (optional) sets the initial value of `request.plugins`, defaults to `{}`.

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -5,6 +5,7 @@ const Bounce = require('@hapi/bounce');
 const Hoek = require('@hapi/hoek');
 
 const Config = require('./config');
+const Request = require('./request');
 
 
 const internals = {
@@ -361,7 +362,7 @@ exports = module.exports = internals.Auth = class {
 
     static async payload(request) {
 
-        if (!request.auth.isAuthenticated) {
+        if (!request.auth.isAuthenticated || !request.auth[Request.symbols.authPayload]) {
             return;
         }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -66,6 +66,7 @@ exports = module.exports = internals.Request = class {
             isAuthenticated: false,
             isAuthorized: false,
             isInjected: options.auth ? true : false,
+            [internals.Request.symbols.authPayload]: options.auth && options.auth.payload !== undefined ? options.auth.payload : true,
             credentials: options.auth ? options.auth.credentials : null,                                    // Special keys: 'app', 'user', 'scope'
             artifacts: options.auth && options.auth.artifacts || null,                                      // Scheme-specific artifacts
             strategy: options.auth ? options.auth.strategy : null,
@@ -619,6 +620,9 @@ exports = module.exports = internals.Request = class {
 
 internals.Request.reserved = internals.reserved;
 
+internals.Request.symbols = {
+    authPayload: Symbol('auth.payload')
+};
 
 internals.Info = class {
 

--- a/test/auth.js
+++ b/test/auth.js
@@ -42,7 +42,7 @@ describe('authentication', () => {
             strategy: 'default',
             mode: 'required',
             error: null
-        });
+        }, { symbols: false });
     });
 
     it('disables authentication on a route', async () => {
@@ -1100,7 +1100,7 @@ describe('authentication', () => {
                 strategy: 'default',
                 mode: 'required',
                 error: null
-            });
+            }, { symbols: false });
         });
 
         it('matches scope (access array)', async () => {
@@ -1756,6 +1756,28 @@ describe('authentication', () => {
             });
 
             const res = await server.inject({ method: 'POST', url: '/', headers: { authorization: 'Custom optionalPayload' } });
+            expect(res.statusCode).to.equal(204);
+        });
+
+        it('skips required payload authentication when disabled on injection', async () => {
+
+            const server = Hapi.server();
+            server.auth.scheme('custom', internals.implementation);
+            server.auth.strategy('default', 'custom');
+            server.auth.default('default');
+            server.route({
+                method: 'POST',
+                path: '/',
+                options: {
+                    handler: (request) => null,
+                    auth: {
+                        mode: 'try',
+                        payload: true
+                    }
+                }
+            });
+
+            const res = await server.inject({ method: 'POST', url: '/', auth: { credentials: { payload: Boom.internal('payload error') }, payload: false, strategy: 'default' } });
             expect(res.statusCode).to.equal(204);
         });
 


### PR DESCRIPTION
Adds optional support to disable payload authentication when credentials are injected. Solves #4214