### PR TITLE
WIP: add diagnostic channel for server creation

### DIFF
--- a/lib/channels.js
+++ b/lib/channels.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports = module.exports = {};
+
+try {
+    const DiagnosticsChannel = require('diagnostics_channel');
+
+    exports = module.exports = {
+        serverChannel: DiagnosticsChannel.channel('hapi:server')
+    };
+}
+catch {
+    // diagnostics_channel is not supported (e.g. node 12)
+}
+

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,7 @@ const Shot = require('@hapi/shot');
 const Somever = require('@hapi/somever');
 const Teamwork = require('@hapi/teamwork');
 
+const Channels = require('./channels');
 const Config = require('./config');
 const Core = require('./core');
 const Cors = require('./cors');
@@ -85,6 +86,10 @@ internals.Server = class {
         }
 
         core.registerServer(this);
+
+        if (Channels.serverChannel && Channels.serverChannel.hasSubscribers) {
+            Channels.serverChannel.publish(this);
+        }
     }
 
     _clone(name) {

--- a/test/server.js
+++ b/test/server.js
@@ -2941,6 +2941,34 @@ describe('Server', () => {
             expect(res3.result).to.equal('<h1>grabbed</h1>');
         });
     });
+
+    describe('Diagnostics channel', () => {
+
+        it('Fires server event on server creation', async () => {
+
+            // If diagnostics_channel is not supported (node 12), skip test
+            try {
+                require('diagnostics_channel');
+            }
+            catch {
+                return Promise.resolve();
+            }
+
+            const DiagnosticsChannel = require('diagnostics_channel');
+
+            const serverChannel = DiagnosticsChannel.channel('hapi:server');
+            return await new Promise((resolve) => {
+
+                serverChannel.subscribe((server) => {
+
+                    expect(server).to.exist();
+                    resolve();
+                });
+
+                new Hapi.Server();
+            });
+        });
+    });
 });
 
 


### PR DESCRIPTION
This is very basic implementation to add diagnostic channels to hapi.
This came out of Twitter thread https://twitter.com/AdriVanHoudt_/status/1430068665102241795.

The pros for this would be that it would be way easier and handier for apm vendors to instrument hapi, which in turn makes the experience for hapi users way better.
The current solution is to monkey patch all over the place.
See https://github.com/DataDog/dd-trace-js/tree/master/packages/datadog-plugin-hapi/src and https://github.com/googleapis/cloud-trace-nodejs/blob/main/src/plugins/plugin-hapi.ts for examples.

The downside is that this is not a thing on node 12 and the node api is experimental. https://nodejs.org/docs/latest-v16.x/api/diagnostics_channel.html

Feel free to give feedback on usefulness, naming and code structure.

cc @qard for feedback on whether this is what they had in mind and if they have suggestions on other events/channels that would help their apm use case.

Slight side note that I might not respond to this soon due to vacation but I will pick this back up as soon as I'm back ^^