### PR TITLE
Fix handling of auth scheme/strategy realms

### DIFF
--- a/API.md
+++ b/API.md
@@ -964,7 +964,7 @@ Registers an authentication scheme where:
 
 - `name` - the scheme name.
 - `scheme` - the method implementing the scheme with signature `function(server, options)` where:
-    - `server` - a reference to the server object the scheme is added to.
+    - `server` - a reference to the server object the scheme is added to. Each auth strategy is given its own [`server.realm`](#server.realm) whose parent is the realm of the `server` in the call to [`server.auth.strategy()`](#server.auth.strategy()).
     - `options` - (optional) the scheme `options` argument passed to
       [`server.auth.strategy()`](#server.auth.strategy()) when instantiation a strategy.
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -18,7 +18,8 @@ exports = module.exports = internals.Auth = class {
     #schemes = {};
     #strategies = {};
 
-    api = {};
+
+    api = {};                   // Do not reassign api or settings, as they are referenced in public()
     settings = {
         default: null           // Strategy used as default if route has no auth settings
     };
@@ -26,6 +27,20 @@ exports = module.exports = internals.Auth = class {
     constructor(core) {
 
         this.#core = core;
+    }
+
+    public(server) {
+
+        return {
+            api: this.api,
+            settings: this.settings,
+            scheme: this.scheme.bind(this),
+            strategy: this._strategy.bind(this, server),
+            default: this.default.bind(this),
+            test: this.test.bind(this),
+            verify: this.verify.bind(this),
+            lookup: this.lookup.bind(this)
+        };
     }
 
     scheme(name, scheme) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -18,7 +18,6 @@ exports = module.exports = internals.Auth = class {
     #schemes = {};
     #strategies = {};
 
-
     api = {};                   // Do not reassign api or settings, as they are referenced in public()
     settings = {
         default: null           // Strategy used as default if route has no auth settings

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,8 +34,7 @@ internals.Server = class {
         // Public interface
 
         this.app = core.app;
-        this.auth = this._core.auth;
-        this.auth.strategy = this.auth._strategy.bind(this.auth, this);
+        this.auth = core.auth.public(this);
         this.decorations = core.decorations.public;
         this.cache = internals.cache(this);
         this.events = core.events;

--- a/test/auth.js
+++ b/test/auth.js
@@ -255,7 +255,6 @@ describe('authentication', () => {
                 }
             });
 
-
             const handler = (request) => request.auth.credentials;
             server.route({ method: 'GET', path: '/a', handler, options: { auth: 'a' } });
             server.route({ method: 'GET', path: '/root', handler, options: { auth: 'root' } });


### PR DESCRIPTION
We were seeing some hard-to-explain behavior in #4218 as it relates to the realm of the `server` inside of auth schemes.  In short, each time `server` is cloned, _all_ servers were being mutated such that `server.auth.strategy` was bound to the server of the most recent clone.

Cloning is the process by which hapi creates independent realms for a. each plugin and b. each auth strategy.  When `server` is cloned, the clone's `realm.parent` is assigned to `server.realm`.  Due to the mutation of a shared interface during each clone, the `server.realm` within an auth strategy had a strange/unpredictable chain of ancestor realms.  This work tidies that up by no longer mutating the shared `auth` on each clone, instead creating a new public auth interface for each one.

Resolves #4218.