### PR TITLE
Add http2 option to allow creating http2 servers directly

### DIFF
--- a/API.md
+++ b/API.md
@@ -160,6 +160,15 @@ If the `listener` needs to be manually started, set [`autoListen`](#server.optio
 
 If the `listener` uses TLS, set [`tls`](#server.options.tls) to `true`.
 
+#### <a name="server.options.http2" /> `server.options.http2`
+
+Default value: `false`.
+
+If `true`, hapi will use http2 instead of http/https.
+
+If a certificate is specified, the http2 server will be tls-enabled (h2),
+otherwise it will listen in cleartext mode (h2c).
+
 #### <a name="server.options.load" /> `server.options.load`
 
 Default value: `{ sampleInterval: 0 }`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -249,6 +249,7 @@ internals.server = Validate.object({
         .allow(false)
         .default(),
     host: Validate.string().hostname().allow(null),
+    http2: Validate.boolean().default(false),
     info: Validate.object({
         remote: Validate.boolean().default(false)
     })

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,6 +2,7 @@
 
 const Http = require('http');
 const Https = require('https');
+const Http2 = require('http2');
 const Os = require('os');
 const Path = require('path');
 
@@ -540,7 +541,7 @@ exports = module.exports = internals.Core = class {
 
     _createListener() {
 
-        const listener = this.settings.listener || (this.settings.tls ? Https.createServer(this.settings.tls) : Http.createServer());
+        const listener = this.settings.listener || this.settings.http2 && this.settings.tls && Http2.createSecureServer(this.settings.tls) || this.settings.http2 && Http2.createServer() || this.settings.tls && Https.createServer(this.settings.tls) || Http.createServer();
         listener.on('request', this._dispatch());
         listener.on('checkContinue', this._dispatch({ expectContinue: true }));
 

--- a/test/core.js
+++ b/test/core.js
@@ -4,6 +4,10 @@ const ChildProcess = require('child_process');
 const Fs = require('fs');
 const Http = require('http');
 const Https = require('https');
+const Http2 = require('http2');
+
+const Http2Server = Http2.createServer().constructor; // the Http2Server class is not exported
+const Http2SecureServer = Http2.createSecureServer().constructor; // the Http2SecureServer class is not exported
 const Net = require('net');
 const Os = require('os');
 const Path = require('path');
@@ -175,6 +179,23 @@ describe('Core', () => {
 
         const server = Hapi.server({ tls: tlsOptions });
         expect(server.listener instanceof Https.Server).to.equal(true);
+    });
+
+    it('creates an h2 server when passed tls+h2 options', () => {
+
+        const tlsOptions = {
+            key: '-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0UqyXDCqWDKpoNQQK/fdr0OkG4gW6DUafxdufH9GmkX/zoKz\ng/SFLrPipzSGINKWtyMvo7mPjXqqVgE10LDI3VFV8IR6fnART+AF8CW5HMBPGt/s\nfQW4W4puvBHkBxWSW1EvbecgNEIS9hTGvHXkFzm4xJ2e9DHp2xoVAjREC73B7JbF\nhc5ZGGchKw+CFmAiNysU0DmBgQcac0eg2pWoT+YGmTeQj6sRXO67n2xy/hA1DuN6\nA4WBK3wM3O4BnTG0dNbWUEbe7yAbV5gEyq57GhJIeYxRvveVDaX90LoAqM4cUH06\n6rciON0UbDHV2LP/JaH5jzBjUyCnKLLo5snlbwIDAQABAoIBAQDJm7YC3pJJUcxb\nc8x8PlHbUkJUjxzZ5MW4Zb71yLkfRYzsxrTcyQA+g+QzA4KtPY8XrZpnkgm51M8e\n+B16AcIMiBxMC6HgCF503i16LyyJiKrrDYfGy2rTK6AOJQHO3TXWJ3eT3BAGpxuS\n12K2Cq6EvQLCy79iJm7Ks+5G6EggMZPfCVdEhffRm2Epl4T7LpIAqWiUDcDfS05n\nNNfAGxxvALPn+D+kzcSF6hpmCVrFVTf9ouhvnr+0DpIIVPwSK/REAF3Ux5SQvFuL\njPmh3bGwfRtcC5d21QNrHdoBVSN2UBLmbHUpBUcOBI8FyivAWJhRfKnhTvXMFG8L\nwaXB51IZAoGBAP/E3uz6zCyN7l2j09wmbyNOi1AKvr1WSmuBJveITouwblnRSdvc\nsYm4YYE0Vb94AG4n7JIfZLKtTN0xvnCo8tYjrdwMJyGfEfMGCQQ9MpOBXAkVVZvP\ne2k4zHNNsfvSc38UNSt7K0HkVuH5BkRBQeskcsyMeu0qK4wQwdtiCoBDAoGBANF7\nFMppYxSW4ir7Jvkh0P8bP/Z7AtaSmkX7iMmUYT+gMFB5EKqFTQjNQgSJxS/uHVDE\nSC5co8WGHnRk7YH2Pp+Ty1fHfXNWyoOOzNEWvg6CFeMHW2o+/qZd4Z5Fep6qCLaa\nFvzWWC2S5YslEaaP8DQ74aAX4o+/TECrxi0z2lllAoGAdRB6qCSyRsI/k4Rkd6Lv\nw00z3lLMsoRIU6QtXaZ5rN335Awyrfr5F3vYxPZbOOOH7uM/GDJeOJmxUJxv+cia\nPQDflpPJZU4VPRJKFjKcb38JzO6C3Gm+po5kpXGuQQA19LgfDeO2DNaiHZOJFrx3\nm1R3Zr/1k491lwokcHETNVkCgYBPLjrZl6Q/8BhlLrG4kbOx+dbfj/euq5NsyHsX\n1uI7bo1Una5TBjfsD8nYdUr3pwWltcui2pl83Ak+7bdo3G8nWnIOJ/WfVzsNJzj7\n/6CvUzR6sBk5u739nJbfgFutBZBtlSkDQPHrqA7j3Ysibl3ZIJlULjMRKrnj6Ans\npCDwkQKBgQCM7gu3p7veYwCZaxqDMz5/GGFUB1My7sK0hcT7/oH61yw3O8pOekee\nuctI1R3NOudn1cs5TAy/aypgLDYTUGQTiBRILeMiZnOrvQQB9cEf7TFgDoRNCcDs\nV/ZWiegVB/WY7H0BkCekuq5bHwjgtJTpvHGqQ9YD7RhE8RSYOhdQ/Q==\n-----END RSA PRIVATE KEY-----\n',
+            cert: '-----BEGIN CERTIFICATE-----\nMIIDBjCCAe4CCQDvLNml6smHlTANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJV\nUzETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0\ncyBQdHkgTHRkMB4XDTE0MDEyNTIxMjIxOFoXDTE1MDEyNTIxMjIxOFowRTELMAkG\nA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0\nIFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nANFKslwwqlgyqaDUECv33a9DpBuIFug1Gn8Xbnx/RppF/86Cs4P0hS6z4qc0hiDS\nlrcjL6O5j416qlYBNdCwyN1RVfCEen5wEU/gBfAluRzATxrf7H0FuFuKbrwR5AcV\nkltRL23nIDRCEvYUxrx15Bc5uMSdnvQx6dsaFQI0RAu9weyWxYXOWRhnISsPghZg\nIjcrFNA5gYEHGnNHoNqVqE/mBpk3kI+rEVzuu59scv4QNQ7jegOFgSt8DNzuAZ0x\ntHTW1lBG3u8gG1eYBMquexoSSHmMUb73lQ2l/dC6AKjOHFB9Ouq3IjjdFGwx1diz\n/yWh+Y8wY1Mgpyiy6ObJ5W8CAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAoSc6Skb4\ng1e0ZqPKXBV2qbx7hlqIyYpubCl1rDiEdVzqYYZEwmst36fJRRrVaFuAM/1DYAmT\nWMhU+yTfA+vCS4tql9b9zUhPw/IDHpBDWyR01spoZFBF/hE1MGNpCSXXsAbmCiVf\naxrIgR2DNketbDxkQx671KwF1+1JOMo9ffXp+OhuRo5NaGIxhTsZ+f/MA4y084Aj\nDI39av50sTRTWWShlN+J7PtdQVA5SZD97oYbeUeL7gI18kAJww9eUdmT0nEjcwKs\nxsQT1fyKbo7AlZBY4KSlUMuGnn0VnAsB9b+LxtXlDfnjyM8bVQx1uAfRo0DO8p/5\n3J5DTjAU55deBQ==\n-----END CERTIFICATE-----\n'
+        };
+
+        const server = Hapi.server({ tls: tlsOptions, http2: true });
+        expect(server.listener instanceof Http2SecureServer).to.equal(true);
+    });
+
+    it('creates an h2c server when passed h2 options', () => {
+
+        const server = Hapi.server({ http2: true });
+        expect(server.listener instanceof Http2Server).to.equal(true);
     });
 
     it('uses a provided listener', async () => {


### PR DESCRIPTION
This makes it more convinient to use http2 in hapi