### PR TITLE
Initialize server settings defaults

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -652,6 +652,7 @@ exports = module.exports = internals.Core = class {
 internals.setup = function (options = {}) {
 
     let settings = Hoek.clone(options, { shallow: ['cache', 'listener', 'routes.bind'] });
+    settings.app = settings.app || {};
     settings.routes = Config.enable(settings.routes);
     settings = Config.apply('server', settings);
 

--- a/test/core.js
+++ b/test/core.js
@@ -33,7 +33,13 @@ const expect = Code.expect;
 
 describe('Core', () => {
 
-    it('sets connections defaults', () => {
+    it('sets app settings defaults', () => {
+
+        const server = Hapi.server();
+        expect(server.settings.app).to.equal({});
+    });
+
+    it('sets app settings', () => {
 
         const server = Hapi.server({ app: { message: 'test defaults' } });
         expect(server.settings.app.message).to.equal('test defaults');


### PR DESCRIPTION
Initializes [server settings](https://hapi.dev/api/?v=20.1.4#-serveroptionsapp) default value as specified by the documentation. Solves #4285 