### PR TITLE
Revised request / inject abort handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -1946,6 +1946,9 @@ Return value: a response object with the following properties:
 
 - `request` - the [request object](#request).
 
+Throws a Boom error if the request processing fails. The partial response object is exposed on
+the `data` property.
+
 ```js
 const Hapi = require('@hapi/hapi');
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -363,9 +363,7 @@ exports = module.exports = internals.Request = class {
     async _lifecycle() {
 
         for (const func of this._route._cycle) {
-            if (this._isReplied ||
-                !this._eventContext.request) {
-
+            if (this._isReplied) {
                 return;
             }
 
@@ -433,13 +431,13 @@ exports = module.exports = internals.Request = class {
             clearTimeout(this._serverTimeoutId);
         }
 
+        if (exit) {                                                     // Can be a valid response or error (if returned from an ext, already handled because this.response is also set)
+            this._setResponse(this._core.Response.wrap(exit, this));    // Wrap to ensure any object thrown is always a valid Boom or Response object
+        }
+
         if (!this._eventContext.request) {
             this._finalize();
             return;
-        }
-
-        if (exit) {                                                     // Can be a valid response or error (if returned from an ext, already handled because this.response is also set)
-            this._setResponse(this._core.Response.wrap(exit, this));    // Wrap to ensure any object thrown is always a valid Boom or Response object
         }
 
         if (typeof this.response === 'symbol') {                        // close or abandon
@@ -725,7 +723,12 @@ internals.event = function ({ request }, event, err) {
     request._eventContext.request = null;
 
     if (event === 'abort') {
-        request._setResponse(new Boom.Boom('Request aborted', { statusCode: request.route.settings.response.disconnectStatusCode }));
+
+        // Calling _reply() means that the abort is applied immediately, unless the response has already
+        // called _reply(), in which case this call is ignored and the transmit logic is responsible for
+        // handling the abort.
+
+        request._reply(new Boom.Boom('Request aborted', { statusCode: request.route.settings.response.disconnectStatusCode, data: request.response }));
 
         if (request._events) {
             request._events.emit('disconnect');

--- a/lib/server.js
+++ b/lib/server.js
@@ -349,16 +349,12 @@ internals.Server = class {
 
             res.request = custom.request;
 
+            if (custom.error) {
+                throw custom.error;
+            }
+
             if (custom.result !== undefined) {
                 res.result = custom.result;
-            }
-
-            if (custom.statusCode !== undefined) {
-                res.statusCode = custom.statusCode;
-            }
-
-            if (custom.statusMessage !== undefined) {
-                res.statusMessage = custom.statusMessage;
             }
         }
 

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -38,9 +38,7 @@ exports.send = async function (request) {
 internals.marshal = async function (response) {
 
     for (const func of response.request._route._marshalCycle) {
-        if (response._state !== 'close') {
-            await func(response);
-        }
+        await func(response);
     }
 };
 
@@ -246,9 +244,10 @@ internals.pipe = function (request, stream) {
     const env = { stream, request, team };
 
     if (request._closed) {
-        // No more events will be fired, so we proactively close-up shop
-        request.raw.res.end(); // Ensure res is finished so internals.end() doesn't think we're responding
-        internals.end(env, 'close');
+
+        // The request has already been aborted - no need to wait or attempt to write.
+
+        internals.end(env, 'aborted');
         return team.work;
     }
 
@@ -298,14 +297,19 @@ internals.end = function (env, event, err) {
         request._core.Response.drain(stream);
     }
 
-    err = err || new Boom.Boom(`Request ${event}`, { statusCode: request.route.settings.response.disconnectStatusCode });
-    const error = internals.error(request, Boom.boomify(err));
+    // Update reported response to reflect the error condition
+
+    const origResponse = request.response;
+    const error = err ? Boom.boomify(err) :
+        new Boom.Boom(`Request ${event}`, { statusCode: request.route.settings.response.disconnectStatusCode, data: origResponse });
+
     request._setResponse(error);
 
+    // Make inject throw a disconnect error
+
     if (request.raw.res[Config.symbol]) {
-        request.raw.res[Config.symbol].statusCode = error.statusCode;
-        request.raw.res[Config.symbol].statusMessage = error.source.error;
-        request.raw.res[Config.symbol].result = error.source;       // Force injected response to error
+        request.raw.res[Config.symbol].error = event ? error :
+            new Boom.Boom(`Response error`, { statusCode: request.route.settings.response.disconnectStatusCode, data: origResponse });
     }
 
     if (event) {


### PR DESCRIPTION
This is a targeted PR to fix the crash issue in #4294. Unfortunately it grew quite complex due to inconsistencies around how aborts & transmission errors are reported.

The issue in #4294 was mostly covered by this existing test: https://github.com/hapijs/hapi/blob/18495f785d602ee23bb01c6dccebb5297e731d7b/test/transmit.js#L528

The only thing missing is to trigger the `internals.chain()` loop in transmit.js, which I have done by adding a `accept-encoding: gzip` header to the request.

Most of the PR comes from revising `server.inject()` to handle an inconsistency, where it converts transmission errors to appear as actual server responses. This is contrary to regular http clients, which will emit / throw an `error`. I'm not sure whether this can be considered a bug fix, but its plausible given that it is supposed to work similar to a regular http client, and the docs does not cover how transmission errors are signalled.

FYI, I felt I had to do something, since currently 499 request abortion errors have two different response signatures depending on which stage of the requests it arrives at. One is a simple Boom error, while the other is a regular response. Ie. the `statusCode` is either found at the logged `response.statusCode` or `response.output.statusCode`.