### PR TITLE
Soft deprecate returning a new object from generateResponse()

### DIFF
--- a/API.md
+++ b/API.md
@@ -4819,7 +4819,7 @@ Returns a [`response`](#response-object) which you can pass into the [reply inte
     - `variety` - a sting name of the response type (e.g. `'file'`).
     - `prepare` - a function with the signature `async function(response)` used to prepare the response after it is returned by a [lifecycle method](#lifecycle-methods) such as setting a file descriptor, where:
         - `response` - the response object being prepared.
-        - must return the prepared response object (new object or `response`).
+        - must return the prepared response object (`response`).
         - may throw an error which is used as the prepared response.
     - `marshal` - a function with the signature `async function(response)` used to prepare the response for transmission to the client before it is sent, where:
         - `response` - the response object being marshaled.


### PR DESCRIPTION
This is a doc only fix for issue in #4299 so no one should try to use the broken "new object" return feature.

This makes the API weird (always return the passed object), but that should be fixed in an upcoming breaking release.

I opted not to also allow empty return values. This way once the breaking release has been published, plugins must explicitly choose to support old versions by returning `response`. If it returns `undefined` it will break on all version of v20.