### PR TITLE
Fix tests for node v17

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        node: ['*', '14', '12']
+        node: ['*', '16', '14', '12']
 
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} node@${{ matrix.node }}

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        node: ['*', '16', '14', '12']
+        node: ['17', '*', '14', '12']
 
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} node@${{ matrix.node }}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@hapi/eslint-plugin": "*",
     "@hapi/inert": "^6.0.2",
     "@hapi/joi-legacy-test": "npm:@hapi/joi@^15.0.0",
-    "@hapi/lab": "^24.2.0",
+    "@hapi/lab": "^24.4.0",
     "@hapi/vision": "^6.0.1",
     "@hapi/wreck": "^17.0.0",
     "handlebars": "^4.7.4",

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ChildProcess = require('child_process');
+const Dns = require('dns');
 
 const internals = {};
 
@@ -17,3 +18,10 @@ internals.hasLsof = () => {
 };
 
 exports.hasLsof = internals.hasLsof();
+
+exports.setDefaultDnsOrder = () => {
+    // Resolve localhost to ipv4 address on node v17
+    if (Dns.setDefaultResultOrder) {
+        Dns.setDefaultResultOrder('ipv4first');
+    }
+};

--- a/test/core.js
+++ b/test/core.js
@@ -27,11 +27,13 @@ const Common = require('./common');
 const internals = {};
 
 
-const { describe, it } = exports.lab = Lab.script();
+const { describe, it, before } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('Core', () => {
+
+    before(Common.setDefaultDnsOrder);
 
     it('sets app settings defaults', () => {
 

--- a/test/payload.js
+++ b/test/payload.js
@@ -11,15 +11,18 @@ const Hoek = require('@hapi/hoek');
 const Lab = require('@hapi/lab');
 const Wreck = require('@hapi/wreck');
 
+const Common = require('./common');
 
 const internals = {};
 
 
-const { describe, it } = exports.lab = Lab.script();
+const { describe, it, before } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('Payload', () => {
+
+    before(Common.setDefaultDnsOrder);
 
     it('sets payload', async () => {
 

--- a/test/request.js
+++ b/test/request.js
@@ -15,15 +15,18 @@ const Lab = require('@hapi/lab');
 const Teamwork = require('@hapi/teamwork');
 const Wreck = require('@hapi/wreck');
 
+const Common = require('./common');
 
 const internals = {};
 
 
-const { describe, it } = exports.lab = Lab.script();
+const { describe, it, before } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('Request.Generator', () => {
+
+    before(Common.setDefaultDnsOrder);
 
     it('decorates request multiple times', async () => {
 

--- a/test/server.js
+++ b/test/server.js
@@ -14,17 +14,20 @@ const Lab = require('@hapi/lab');
 const Vision = require('@hapi/vision');
 const Wreck = require('@hapi/wreck');
 
+const Common = require('./common');
 const Pkg = require('../package.json');
 
 
 const internals = {};
 
 
-const { describe, it } = exports.lab = Lab.script();
+const { describe, it, before } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('Server', () => {
+
+    before(Common.setDefaultDnsOrder);
 
     describe('auth', () => {
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -1196,8 +1196,7 @@ describe('transmission', () => {
             await log;
         });
 
-        // NOTE do not merge with this skip. Can be removed once fix in node v17.1.0 is released.
-        it.skip('stops processing the stream when the connection closes', async () => {
+        it('stops processing the stream when the connection closes', async () => {
 
             let stream;
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -25,11 +25,13 @@ const Common = require('./common');
 const internals = {};
 
 
-const { describe, it } = exports.lab = Lab.script();
+const { describe, it, before } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('transmission', () => {
+
+    before(Common.setDefaultDnsOrder);
 
     describe('send()', () => {
 
@@ -1194,7 +1196,8 @@ describe('transmission', () => {
             await log;
         });
 
-        it('stops processing the stream when the connection closes', async () => {
+        // NOTE do not merge with this skip. Can be removed once fix in node v17.1.0 is released.
+        it.skip('stops processing the stream when the connection closes', async () => {
 
             let stream;
 


### PR DESCRIPTION
While we will not officially support node v17 since it is not an LTS version of node, in practice we would like to test hapi against it and ensure everything will be in good shape when node v18 eventually arrives.

The hapi test suite was affected by the change in DNS ordering in https://github.com/nodejs/node/pull/39987, since default hapi servers would need to be connected to using `::1` over ipv6 rather than `127.0.0.1` over ipv4.  In the next major version of hapi we should consider how we might make our `address` default (currently `0.0.0.0`) more ipv6-aware.

We are also currently affected by a bug https://github.com/nodejs/node/issues/40528 slated to be resolved in node v17.1.0.  The one `skip()` in the test suite relates to this: we skip the test for now to avoid a hang caused by the bug.

~~Note that the test suite is going to be all red right now due to https://github.com/nodejs/node/issues/40528.  Once that is resolved I will re-run the tests and turn this into a non-draft PR if everything is passing.~~