### PR TITLE
Fix memory leaks from teamwork long standing notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@hapi/somever": "^3.0.0",
     "@hapi/statehood": "^7.0.3",
     "@hapi/subtext": "^7.0.3",
-    "@hapi/teamwork": "^5.1.0",
+    "@hapi/teamwork": "^5.1.1",
     "@hapi/topo": "^5.0.0",
     "@hapi/validate": "^1.1.1"
   },


### PR DESCRIPTION
This is related to https://github.com/hapijs/teamwork/issues/32. @kanongil spotted a memory leak on https://github.com/hapijs/hapi/issues/4343#issuecomment-1072244342. The leak stems from `hapi`'s `server.ext()` method that leverages long standing Teamwork instances when no method are passed for an extension point. Since `teamwork` didn't clear its internal notes ref once the meeting was over, objects passed to `team.attend()` were never garbage collected and it also kept adding notes to an ended meeting.

The fix was provided in `@hapi/teamwork@5.1.1` thus the PR only updates `hapi` dependency.
