### PR TITLE
Drop node v12 support

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v21
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -67,7 +67,7 @@ exports = module.exports = internals.Auth = class {
         Hoek.assert(typeof strategy.authenticate === 'function', 'Invalid scheme:', name, 'invalid authenticate() method');
         Hoek.assert(!strategy.payload || typeof strategy.payload === 'function', 'Invalid scheme:', name, 'invalid payload() method');
         Hoek.assert(!strategy.response || typeof strategy.response === 'function', 'Invalid scheme:', name, 'invalid response() method');
-        strategy.options = strategy.options || {};
+        strategy.options = strategy.options ?? {};
         Hoek.assert(strategy.payload || !strategy.options.payload, 'Cannot require payload validation without a payload method');
 
         this.#strategies[name] = {
@@ -171,10 +171,10 @@ exports = module.exports = internals.Auth = class {
             options = Hoek.applyToDefaults(this.settings.default, options);
         }
 
-        path = path || 'default strategy';
-        Hoek.assert(options.strategies && options.strategies.length, 'Missing authentication strategy:', path);
+        path = path ?? 'default strategy';
+        Hoek.assert(options.strategies?.length, 'Missing authentication strategy:', path);
 
-        options.mode = options.mode || 'required';
+        options.mode = options.mode ?? 'required';
 
         if (options.entity !== undefined ||                                             // Backwards compatibility with <= 11.x.x
             options.scope !== undefined) {
@@ -304,9 +304,7 @@ exports = module.exports = internals.Auth = class {
     _access(request, route) {
 
         const config = this.lookup(route || request.route);
-        if (!config ||
-            !config.access) {
-
+        if (!config?.access) {
             return true;
         }
 
@@ -389,7 +387,7 @@ exports = module.exports = internals.Auth = class {
         }
 
         const config = auth.lookup(request.route);
-        const setting = config.payload || (strategy.methods.options.payload ? 'required' : false);
+        const setting = config.payload ?? (strategy.methods.options.payload ? 'required' : false);
         if (!setting) {
             return;
         }
@@ -451,13 +449,13 @@ internals.setupScope = function (access) {
         const prefix = value[0];
         const type = prefix === '+' ? 'required' : (prefix === '!' ? 'forbidden' : 'selection');
         const clean = type === 'selection' ? value : value.slice(1);
-        scope[type] = scope[type] || [];
+        scope[type] = scope[type] ?? [];
         scope[type].push(clean);
 
-        if ((!scope._hasParameters || !scope._hasParameters[type]) &&
+        if ((!scope._hasParameters?.[type]) &&
             /{([^}]+)}/.test(clean)) {
 
-            scope._hasParameters = scope._hasParameters || {};
+            scope._hasParameters = scope._hasParameters ?? {};
             scope._hasParameters[type] = true;
         }
     }
@@ -468,7 +466,7 @@ internals.setupScope = function (access) {
 
 internals.validate = function (err, result, name, config, request, errors) {                 // err can be Boom, Error, or a valid response object
 
-    result = result || {};
+    result = result ?? {};
     request.auth.isAuthenticated = !err;
 
     if (err) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -148,8 +148,8 @@ exports = module.exports = internals.Core = class {
 
         const method = (event) => {
 
-            const data = event.error || event.data;
-            console.error('Debug:', event.tags.join(', '), data ? '\n    ' + (data.stack || (typeof data === 'object' ? Hoek.stringify(data) : data)) : '');
+            const data = event.error ?? event.data;
+            console.error('Debug:', event.tags.join(', '), data ? '\n    ' + (data.stack ?? (typeof data === 'object' ? Hoek.stringify(data) : data)) : '');
         };
 
         if (debug.log) {
@@ -188,7 +188,7 @@ exports = module.exports = internals.Core = class {
             port,
             protocol,
             id: Os.hostname() + ':' + process.pid + ':' + now.toString(36),
-            uri: this.settings.uri || (protocol + ':' + (this.type === 'tcp' ? '//' + host + (port ? ':' + port : '') : port))
+            uri: this.settings.uri ?? (protocol + ':' + (this.type === 'tcp' ? '//' + host + (port ? ':' + port : '') : port))
         };
 
         return info;
@@ -223,7 +223,7 @@ exports = module.exports = internals.Core = class {
                 config = { provider: { constructor: config } };
             }
 
-            const name = config.name || '_default';
+            const name = config.name ?? '_default';
             Hoek.assert(!this.caches.has(name), 'Cannot configure the same cache more than once: ', name === '_default' ? 'default cache' : name);
 
             let client = null;
@@ -234,13 +234,13 @@ exports = module.exports = internals.Core = class {
                     provider = { constructor: provider };
                 }
 
-                client = new Catbox.Client(provider.constructor, provider.options || { partition: 'hapi-cache' });
+                client = new Catbox.Client(provider.constructor, provider.options ?? { partition: 'hapi-cache' });
             }
             else {
                 client = new Catbox.Client(config.engine);
             }
 
-            this.caches.set(name, { client, segments: {}, shared: config.shared || false });
+            this.caches.set(name, { client, segments: {}, shared: config.shared ?? false });
             added.push(client);
         }
 
@@ -392,7 +392,7 @@ exports = module.exports = internals.Core = class {
 
     async _stop(options = {}) {
 
-        options.timeout = options.timeout || 5000;          // Default timeout to 5 seconds
+        options.timeout = options.timeout ?? 5000;          // Default timeout to 5 seconds
 
         if (['stopped', 'initialized', 'started', 'invalid'].indexOf(this.phase) === -1) {
             throw new Error('Cannot stop server while in ' + this.phase + ' phase');
@@ -486,7 +486,7 @@ exports = module.exports = internals.Core = class {
         // Execute extensions
 
         for (const ext of exts.nodes) {
-            const bind = ext.bind || ext.realm.settings.bind;
+            const bind = ext.bind ?? ext.realm.settings.bind;
             const operation = ext.func.call(bind, ext.server, bind);
             await Toolkit.timed(operation, { timeout: ext.timeout, name: type });
         }
@@ -540,7 +540,7 @@ exports = module.exports = internals.Core = class {
 
     _createListener() {
 
-        const listener = this.settings.listener || (this.settings.tls ? Https.createServer(this.settings.tls) : Http.createServer());
+        const listener = this.settings.listener ?? (this.settings.tls ? Https.createServer(this.settings.tls) : Http.createServer());
         listener.on('request', this._dispatch());
         listener.on('checkContinue', this._dispatch({ expectContinue: true }));
 
@@ -577,7 +577,7 @@ exports = module.exports = internals.Core = class {
                 const address = this.listener.address();
                 this.info.address = address.address;
                 this.info.port = address.port;
-                this.info.uri = this.settings.uri || this.info.protocol + '://' + this.info.host + ':' + this.info.port;
+                this.info.uri = this.settings.uri ?? this.info.protocol + '://' + this.info.host + ':' + this.info.port;
             }
 
             if (this.settings.operations.cleanStop) {
@@ -604,11 +604,11 @@ exports = module.exports = internals.Core = class {
 
         options = Config.apply('cachePolicy', options);
 
-        const plugin = realm && realm.plugin;
-        const segment = options.segment || _segment || (plugin ? `!${plugin}` : '');
+        const plugin = realm?.plugin;
+        const segment = options.segment ?? _segment ?? (plugin ? `!${plugin}` : '');
         Hoek.assert(segment, 'Missing cache segment name');
 
-        const cacheName = options.cache || '_default';
+        const cacheName = options.cache ?? '_default';
         const cache = this.caches.get(cacheName);
         Hoek.assert(cache, 'Unknown cache', cacheName);
         Hoek.assert(!cache.segments[segment] || cache.shared || options.shared, 'Cannot provision the same cache segment more than once');
@@ -652,7 +652,7 @@ exports = module.exports = internals.Core = class {
 internals.setup = function (options = {}) {
 
     let settings = Hoek.clone(options, { shallow: ['cache', 'listener', 'routes.bind'] });
-    settings.app = settings.app || {};
+    settings.app = settings.app ?? {};
     settings.routes = Config.enable(settings.routes);
     settings = Config.apply('server', settings);
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -93,7 +93,7 @@ exports.defaults = function (method, handler, core) {
         }
     }
 
-    return defaults || {};
+    return defaults ?? {};
 };
 
 
@@ -152,7 +152,7 @@ exports.prerequisitesConfig = function (config) {
             const item = {
                 method: pre.method,
                 assign: pre.assign,
-                failAction: pre.failAction || 'error'
+                failAction: pre.failAction ?? 'error'
             };
 
             set.push(item);

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -23,7 +23,7 @@ exports.cache = function (response) {
         response.settings.ttl) {
 
         const ttl = response.settings.ttl !== null ? response.settings.ttl : request._route._cache.ttl();
-        const privacy = request.auth.isAuthenticated || response.headers['set-cookie'] ? 'private' : settings.privacy || 'default';
+        const privacy = request.auth.isAuthenticated || response.headers['set-cookie'] ? 'private' : settings.privacy ?? 'default';
         response._header('cache-control', 'max-age=' + Math.floor(ttl / 1000) + ', must-revalidate' + (privacy !== 'default' ? ', ' + privacy : ''));
     }
     else if (settings) {

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -33,7 +33,7 @@ exports = module.exports = internals.Methods = class {
         const items = [].concat(name);
         for (let item of items) {
             item = Config.apply('methodObject', item);
-            this._add(item.name, item.method, item.options || {}, realm);
+            this._add(item.name, item.method, item.options ?? {}, realm);
         }
     }
 
@@ -47,9 +47,9 @@ exports = module.exports = internals.Methods = class {
         options = Config.apply('method', options, name);
 
         const settings = Hoek.clone(options, { shallow: ['bind'] });
-        settings.generateKey = settings.generateKey || internals.generateKey;
+        settings.generateKey = settings.generateKey ?? internals.generateKey;
 
-        const bind = settings.bind || realm.settings.bind || null;
+        const bind = settings.bind ?? realm.settings.bind ?? null;
         const bound = !bind ? method : (...args) => method.apply(bind, args);
 
         // Not cached

--- a/lib/request.js
+++ b/lib/request.js
@@ -657,7 +657,7 @@ internals.Info = class {
     get remoteAddress() {
 
         if (!this._remoteAddress) {
-            this._remoteAddress = this._request.raw.req.connection.remoteAddress;
+            this._remoteAddress = this._request.raw.req.socket.remoteAddress;
         }
 
         return this._remoteAddress;
@@ -666,7 +666,7 @@ internals.Info = class {
     get remotePort() {
 
         if (this._remotePort === null) {
-            this._remotePort = this._request.raw.req.connection.remotePort || '';
+            this._remotePort = this._request.raw.req.socket.remotePort || '';
         }
 
         return this._remotePort;
@@ -705,7 +705,7 @@ internals.event = function ({ request }, event, err) {
     request._isPayloadPending = false;
 
     if (event === 'close' &&
-        request.raw.res.finished) {
+        request.raw.res.writableEnded) {
 
         return;
     }

--- a/lib/request.js
+++ b/lib/request.js
@@ -66,10 +66,10 @@ exports = module.exports = internals.Request = class {
             isAuthenticated: false,
             isAuthorized: false,
             isInjected: options.auth ? true : false,
-            [internals.Request.symbols.authPayload]: options.auth && options.auth.payload !== undefined ? options.auth.payload : true,
-            credentials: options.auth ? options.auth.credentials : null,                                    // Special keys: 'app', 'user', 'scope'
-            artifacts: options.auth && options.auth.artifacts || null,                                      // Scheme-specific artifacts
-            strategy: options.auth ? options.auth.strategy : null,
+            [internals.Request.symbols.authPayload]: options.auth?.payload ?? true,
+            credentials: options.auth?.credentials ?? null,                                    // Special keys: 'app', 'user', 'scope'
+            artifacts: options.auth?.artifacts ?? null,                                      // Scheme-specific artifacts
+            strategy: options.auth?.strategy ?? null,
             mode: null,
             error: null
         };
@@ -326,8 +326,8 @@ exports = module.exports = internals.Request = class {
             this.route = this._route.public;
         }
 
-        this.params = match.params || {};
-        this.paramsArray = match.paramsArray || [];
+        this.params = match.params ?? {};
+        this.paramsArray = match.paramsArray ?? [];
 
         if (this.route.settings.cors) {
             this.info.cors = {
@@ -394,7 +394,7 @@ exports = module.exports = internals.Request = class {
 
         for (const ext of event.nodes) {
             const realm = ext.realm;
-            const bind = ext.bind || realm.settings.bind;
+            const bind = ext.bind ?? realm.settings.bind;
             const response = await this._core.toolkit.execute(ext.func, this, { bind, realm, timeout: ext.timeout, name: event.type, ignoreResponse: options.ignoreResponse });
 
             if (options.ignoreResponse) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -55,7 +55,7 @@ exports = module.exports = internals.Response = class {
 
         this._events = null;
         this._payload = null;                       // Readable stream
-        this._error = options.error || null;        // The boom object when created from an error (used for logging)
+        this._error = options.error ?? null;        // The boom object when created from an error (used for logging)
         this._contentType = null;                   // Used if no explicit content-type is set and type is known
         this._takeover = false;
         this._statusCode = false;                   // true when code() called
@@ -89,7 +89,7 @@ exports = module.exports = internals.Response = class {
 
         // Method must not set any headers or other properties as source can change later
 
-        this.variety = variety || 'plain';
+        this.variety = variety ?? 'plain';
 
         if (source === null ||
             source === undefined) {
@@ -151,7 +151,7 @@ exports = module.exports = internals.Response = class {
 
     _header(key, value, options = {}) {
 
-        const append = options.append || false;
+        const append = options.append ?? false;
         const separator = options.separator || ',';
         const override = options.override !== false;
         const duplicate = options.duplicate !== false;
@@ -345,28 +345,28 @@ exports = module.exports = internals.Response = class {
 
     replacer(method) {
 
-        this.settings.stringify = this.settings.stringify || {};
+        this.settings.stringify = this.settings.stringify ?? {};
         this.settings.stringify.replacer = method;
         return this;
     }
 
     spaces(count) {
 
-        this.settings.stringify = this.settings.stringify || {};
+        this.settings.stringify = this.settings.stringify ?? {};
         this.settings.stringify.space = count;
         return this;
     }
 
     suffix(suffix) {
 
-        this.settings.stringify = this.settings.stringify || {};
+        this.settings.stringify = this.settings.stringify ?? {};
         this.settings.stringify.suffix = suffix;
         return this;
     }
 
     escape(escape) {
 
-        this.settings.stringify = this.settings.stringify || {};
+        this.settings.stringify = this.settings.stringify ?? {};
         this.settings.stringify.escape = escape;
         return this;
     }
@@ -466,7 +466,7 @@ exports = module.exports = internals.Response = class {
 
     charset(charset) {
 
-        this.settings.charset = charset || null;
+        this.settings.charset = charset ?? null;
         return this;
     }
 
@@ -558,7 +558,7 @@ exports = module.exports = internals.Response = class {
             }
         }
 
-        this.statusCode = this.statusCode || 200;
+        this.statusCode = this.statusCode ?? 200;
     }
 
     async _marshal() {
@@ -600,11 +600,11 @@ exports = module.exports = internals.Response = class {
         let payload = source;
 
         if (jsonify) {
-            const options = this.settings.stringify || {};
-            const space = options.space || this.request.route.settings.json.space;
-            const replacer = options.replacer || this.request.route.settings.json.replacer;
-            const suffix = options.suffix || this.request.route.settings.json.suffix || '';
-            const escape = this.request.route.settings.json.escape || false;
+            const options = this.settings.stringify ?? {};
+            const space = options.space ?? this.request.route.settings.json.space;
+            const replacer = options.replacer ?? this.request.route.settings.json.replacer;
+            const suffix = options.suffix ?? this.request.route.settings.json.suffix ?? '';
+            const escape = this.request.route.settings.json.escape;
 
             try {
                 if (replacer || space) {

--- a/lib/route.js
+++ b/lib/route.js
@@ -40,7 +40,7 @@ exports = module.exports = internals.Route = class {
         const path = realm.modifiers.route.prefix ? realm.modifiers.route.prefix + (route.path !== '/' ? route.path : '') : route.path;
         Hoek.assert(path === '/' || path[path.length - 1] !== '/' || !core.settings.router.stripTrailingSlash, 'Path cannot end with a trailing slash when configured to strip:', route.method, route.path);
 
-        const vhost = realm.modifiers.route.vhost || route.vhost;
+        const vhost = realm.modifiers.route.vhost ?? route.vhost;
 
         // Set identifying members (assert)
 
@@ -49,7 +49,7 @@ exports = module.exports = internals.Route = class {
 
         // Prepare configuration
 
-        let config = route.options || route.config || {};
+        let config = route.options ?? route.config ?? {};
         if (typeof config === 'function') {
             config = config.call(realm.settings.bind, server);
         }
@@ -59,12 +59,12 @@ exports = module.exports = internals.Route = class {
         // Verify route level config (as opposed to the merged settings)
 
         this._assert(method !== 'get' || !config.payload, 'Cannot set payload settings on HEAD or GET request');
-        this._assert(method !== 'get' || !config.validate || !config.validate.payload, 'Cannot validate HEAD or GET request payload');
+        this._assert(method !== 'get' || !config.validate?.payload, 'Cannot validate HEAD or GET request payload');
 
         // Rules
 
         this._assert(!route.rules || !config.rules, 'Route rules can only appear once');                    // XOR
-        const rules = route.rules || config.rules;
+        const rules = route.rules ?? config.rules;
         const rulesConfig = internals.rules(rules, { method, path, vhost }, server);
         delete config.rules;
 
@@ -73,7 +73,7 @@ exports = module.exports = internals.Route = class {
         this._assert(route.handler || config.handler, 'Missing or undefined handler');
         this._assert(!!route.handler ^ !!config.handler, 'Handler must only appear once');                  // XOR
 
-        const handler = Config.apply('handler', route.handler || config.handler);
+        const handler = Config.apply('handler', route.handler ?? config.handler);
         delete config.handler;
 
         const handlerDefaults = Handler.defaults(method, handler, core);
@@ -90,8 +90,8 @@ exports = module.exports = internals.Route = class {
         this.realm = realm;
 
         this.settings.vhost = vhost;
-        this.settings.plugins = this.settings.plugins || {};            // Route-specific plugins settings, namespaced using plugin name
-        this.settings.app = this.settings.app || {};                    // Route-specific application settings
+        this.settings.plugins = this.settings.plugins ?? {};            // Route-specific plugins settings, namespaced using plugin name
+        this.settings.app = this.settings.app ?? {};                    // Route-specific application settings
 
         // Path parsing
 
@@ -197,7 +197,7 @@ exports = module.exports = internals.Route = class {
             this.settings.response._validate = true;
 
             const rule = this.settings.response.schema;
-            this.settings.response.status = this.settings.response.status || {};
+            this.settings.response.status = this.settings.response.status ?? {};
             const statuses = Object.keys(this.settings.response.status);
 
             if (rule === true &&
@@ -389,8 +389,8 @@ internals.state = async function (request) {
         var parseError = err;
     }
 
-    const { states, failed = [] } = result || parseError;
-    request.state = states || {};
+    const { states, failed = [] } = result ?? parseError;
+    request.state = states ?? {};
 
     // Clear cookies
 
@@ -429,7 +429,7 @@ internals.payload = async function (request) {
     try {
         const { payload, mime } = await Subtext.parse(request.raw.req, request._tap(), request.route.settings.payload);
 
-        request._isPayloadPending = !!(payload && payload._readableState);
+        request._isPayloadPending = !!payload?._readableState;
         request.mime = mime;
         request.payload = payload;
     }

--- a/lib/security.js
+++ b/lib/security.js
@@ -18,7 +18,7 @@ exports.route = function (settings) {
             security._hsts = 'max-age=' + security.hsts;
         }
         else {
-            security._hsts = 'max-age=' + (security.hsts.maxAge || 15768000);
+            security._hsts = 'max-age=' + (security.hsts.maxAge ?? 15768000);
             if (security.hsts.includeSubdomains || security.hsts.includeSubDomains) {
                 security._hsts = security._hsts + '; includeSubDomains';
             }

--- a/lib/server.js
+++ b/lib/server.js
@@ -101,7 +101,7 @@ internals.Server = class {
 
         Hoek.assert(server instanceof internals.Server, 'Can only control Server objects');
 
-        this._core.controlled = this._core.controlled || [];
+        this._core.controlled = this._core.controlled ?? [];
         this._core.controlled.push(server);
     }
 
@@ -146,7 +146,7 @@ internals.Server = class {
             Hoek.assert(!this._core.Request.reserved.includes(property), 'Cannot override built-in request interface decoration:', propertyName);
 
             if (options.apply) {
-                this._core.decorations.requestApply = this._core.decorations.requestApply || new Map();
+                this._core.decorations.requestApply = this._core.decorations.requestApply ?? new Map();
                 this._core.decorations.requestApply.set(property, method);
             }
             else {
@@ -238,7 +238,7 @@ internals.Server = class {
             });
         }
 
-        this._core.plugins[plugin] = this._core.plugins[plugin] || {};
+        this._core.plugins[plugin] = this._core.plugins[plugin] ?? {};
 
         if (typeof key === 'string') {
             this._core.plugins[plugin][key] = value;
@@ -323,7 +323,7 @@ internals.Server = class {
             delete settings.plugins;
             delete settings.allowInternals;
 
-            settings.authority = settings.authority || this._core.info.host + ':' + this._core.info.port;
+            settings.authority = settings.authority ?? this._core.info.host + ':' + this._core.info.port;
         }
 
         Hoek.assert(!options.credentials, 'options.credentials no longer supported (use options.auth)');
@@ -414,10 +414,10 @@ internals.Server = class {
             this.realm.modifiers.route.vhost) {
 
             options = Hoek.clone(options);
-            options.routes = options.routes || {};
+            options.routes = options.routes ?? {};
 
-            options.routes.prefix = (this.realm.modifiers.route.prefix || '') + (options.routes.prefix || '') || undefined;
-            options.routes.vhost = this.realm.modifiers.route.vhost || options.routes.vhost;
+            options.routes.prefix = (this.realm.modifiers.route.prefix ?? '') + (options.routes.prefix ?? '') || undefined;
+            options.routes.vhost = this.realm.modifiers.route.vhost ?? options.routes.vhost;
         }
 
         options = Config.apply('register', options);
@@ -453,12 +453,12 @@ internals.Server = class {
 
                 item = Config.apply('plugin', item);
 
-                const name = item.plugin.name || item.plugin.pkg.name;
+                const name = item.plugin.name ?? item.plugin.pkg.name;
                 const clone = this._clone(name);
 
-                clone.realm.modifiers.route.prefix = item.routes.prefix || options.routes.prefix;
-                clone.realm.modifiers.route.vhost = item.routes.vhost || options.routes.vhost;
-                clone.realm.pluginOptions = item.options || {};
+                clone.realm.modifiers.route.prefix = item.routes.prefix ?? options.routes.prefix;
+                clone.realm.modifiers.route.vhost = item.routes.vhost ?? options.routes.vhost;
+                clone.realm.pluginOptions = item.options ?? {};
 
                 // Validate requirements
 
@@ -480,7 +480,7 @@ internals.Server = class {
                 }
                 else {
                     this._core.registrations[name] = {
-                        version: item.plugin.version || item.plugin.pkg.version,
+                        version: item.plugin.version ?? item.plugin.pkg.version,
                         name,
                         options: item.options
                     };
@@ -492,7 +492,7 @@ internals.Server = class {
 
                 // Register
 
-                await item.plugin.register(clone, item.options || {});
+                await item.plugin.register(clone, item.options ?? {});
             }
         }
         finally {
@@ -522,7 +522,7 @@ internals.Server = class {
     _addRoute(config, server) {
 
         const route = new Route(config, server);                        // Do no use config beyond this point, use route members
-        const vhosts = [].concat(route.settings.vhost || '*');
+        const vhosts = [].concat(route.settings.vhost ?? '*');
 
         for (const vhost of vhosts) {
             const record = this._core.router.add({ method: route.method, path: route.path, vhost, analysis: route._analysis, id: route.settings.id }, route);

--- a/lib/toolkit.js
+++ b/lib/toolkit.js
@@ -42,7 +42,7 @@ exports.Manager = class {
     async execute(method, request, options) {
 
         const h = new this._toolkit(request, options);
-        const bind = options.bind || null;
+        const bind = options.bind ?? null;
 
         try {
             let operation;
@@ -130,7 +130,7 @@ exports.Manager = class {
             throw err;
         }
 
-        return this.execute(failAction, request, { realm: request.route.realm, args: [options.details || err] });
+        return this.execute(failAction, request, { realm: request.route.realm, args: [options.details ?? err] });
     }
 };
 
@@ -225,7 +225,7 @@ internals.toolkit = function () {
         authenticated(data) {
 
             Hoek.assert(this._auth, 'Method not supported outside of authentication');
-            Hoek.assert(data && data.credentials, 'Authentication data missing credentials information');
+            Hoek.assert(data?.credentials, 'Authentication data missing credentials information');
 
             return new internals.Auth(null, data);
         }

--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -283,7 +283,7 @@ internals.end = function (env, event, err) {
 
     env.team = null;
 
-    if (request.raw.res.finished) {
+    if (request.raw.res.writableEnded) {
         if (!event) {
             request.info.responded = Date.now();
         }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -19,7 +19,7 @@ exports.validator = function (validator) {
 
 exports.compile = function (rule, validator, realm, core) {
 
-    validator = validator || internals.validator(realm, core);
+    validator = validator ?? internals.validator(realm, core);
 
     // false - nothing allowed
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@hapi/hoek": "^9.0.4",
     "@hapi/mimos": "^6.0.0",
     "@hapi/podium": "^4.1.1",
-    "@hapi/shot": "^5.0.5",
+    "@hapi/shot": "6.0.0-beta.1",
     "@hapi/somever": "^3.0.0",
     "@hapi/statehood": "^7.0.3",
     "@hapi/subtext": "^7.0.3",
@@ -43,11 +43,11 @@
     "@hapi/validate": "^1.1.1"
   },
   "devDependencies": {
-    "@hapi/code": "^8.0.0",
+    "@hapi/code": "9.0.0-beta.0",
     "@hapi/eslint-plugin": "*",
     "@hapi/inert": "^6.0.2",
     "@hapi/joi-legacy-test": "npm:@hapi/joi@^15.0.0",
-    "@hapi/lab": "^24.4.0",
+    "@hapi/lab": "25.0.0-beta.0",
     "@hapi/vision": "^6.0.1",
     "@hapi/wreck": "^17.0.0",
     "handlebars": "^4.7.4",


### PR DESCRIPTION
Dropping node v12 support.  There's a good discussion in #4279 that outlines other steps we may want to take as we end support for node v12.  Here's my approach here:
 - I adopted nullish coalescing and optional chaining.
 - Recognizing that it might break code that relies on the old behavior, I did adopt `??` in the place of `||` when evaluating non-boolean expressions.  I am open to other thoughts, but I am of the mind that it usually gives a better, more precise behavior than `||`.  In some cases I kept `||` when I thought it made sense, e.g to fall through empty header values of `''`.
 - I did not address the usage of private methods since hapi treats private methods as private to hapi and not just the class in question.  One great example is `request._log()` which is called all over the place.  I feel that we should adopt private methods in a given class only if we're willing to remove usage of `_`-prefixed methods from that class that may be used by other classes.
 - I addressed usage of any deprecated APIs I could find: `res.writeableEnd` rather than `res.finished`, `req.socket` rather than `req.connection`.
 - I did not implement anything with `AbortSignal` since I didn't want to make any substantive API changes, though I am in support of it.

This PR will not pass CI until https://github.com/hapijs/shot/pull/144 and https://github.com/hapijs/lab/pull/1036 are published.  I intend to publish beta versions of these (and other) modules in the near future.

Resolves #4279