### PR TITLE
Ignore return value from generateResponse() prepare method

### DIFF
--- a/lib/toolkit.js
+++ b/lib/toolkit.js
@@ -102,7 +102,7 @@ exports.Manager = class {
         if (typeof response !== 'symbol') {
             response = request._core.Response.wrap(response, request);
             if (!response.isBoom && response._state === 'init') {
-                response = await response._prepare();
+                await response._prepare();
             }
         }
 


### PR DESCRIPTION
The functionality of switching the response from `prepare()`'s return value is removed.  As outlined in #4299, this was undocumented and not a very safe behavior.