### PR TITLE
Enforce that response streams are always Stream.Readable

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -676,18 +676,7 @@ exports = module.exports = internals.Response = class {
 
     static drain(stream) {
 
-        if (stream.destroy) {
-            stream.destroy();
-            return;
-        }
-
-        // Fallback for old-style streams
-
-        stream.unpipe();
-
-        if (stream.close) {
-            stream.close();
-        }
+        stream.destroy();
     }
 };
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -16,7 +16,7 @@ exports.isStream = function (stream) {
 
     if (!isReadableStream &&
         typeof stream?.pipe === 'function') {
-        throw Boom.badImplementation('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
+        throw Boom.badImplementation('Cannot reply with a stream-like object that is not an instance of Stream.Readable');
     }
 
     if (!isReadableStream) {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,8 +1,9 @@
 'use strict';
 
+const Stream = require('stream');
+
 const Boom = require('@hapi/boom');
 const Teamwork = require('@hapi/teamwork');
-
 
 const internals = {
     team: Symbol('team')
@@ -11,18 +12,18 @@ const internals = {
 
 exports.isStream = function (stream) {
 
-    if (!stream ||
-        typeof stream !== 'object' ||
-        typeof stream.pipe !== 'function') {
+    const isReadableStream = stream instanceof Stream.Readable;
 
+    if (!isReadableStream &&
+        typeof stream?.pipe === 'function') {
+        throw Boom.badImplementation('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
+    }
+
+    if (!isReadableStream) {
         return false;
     }
 
-    if (typeof stream._read !== 'function') {
-        throw Boom.badImplementation('Stream must have a readable interface');
-    }
-
-    if (stream._readableState.objectMode) {
+    if (stream.readableObjectMode) {
         throw Boom.badImplementation('Cannot reply with stream in object mode');
     }
 

--- a/test/response.js
+++ b/test/response.js
@@ -7,6 +7,7 @@ const Stream = require('stream');
 
 const Code = require('@hapi/code');
 const Handlebars = require('handlebars');
+const LegacyReadableStream = require('legacy-readable-stream');
 const Hapi = require('..');
 const Inert = require('@hapi/inert');
 const Lab = require('@hapi/lab');
@@ -1194,14 +1195,14 @@ describe('Response', () => {
             expect(res1.statusCode).to.equal(500);
 
             const [, event1] = await log1;
-            expect(event1.error).to.be.an.error('Stream must have a readable interface');
+            expect(event1.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
 
             const log2 = server.events.once({ name: 'request', channels: 'error' });
             const res2 = await server.inject('/writable');
             expect(res2.statusCode).to.equal(500);
 
             const [, event2] = await log2;
-            expect(event2.error).to.be.an.error('Stream must have a readable interface');
+            expect(event2.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
         });
 
         it('errors on an http client stream response', async () => {
@@ -1223,7 +1224,38 @@ describe('Response', () => {
             expect(res.statusCode).to.equal(500);
 
             const [, event] = await log;
-            expect(event.error).to.be.an.error('Stream must have a readable interface');
+            expect(event.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
+        });
+
+        it('errors on a legacy readable stream response', async () => {
+
+            const streamHandler = () => {
+
+                const stream = new LegacyReadableStream.Readable();
+                stream._read = function (size) {
+
+                    const chunk = new Array(size).join('x');
+
+                    setTimeout(() => {
+
+                        this.push(chunk);
+                    }, 10);
+                };
+
+                return stream;
+            };
+
+            const server = Hapi.server({ debug: false });
+            server.route({ method: 'GET', path: '/stream', handler: streamHandler });
+
+            const log = server.events.once({ name: 'request', channels: 'error' });
+
+            await server.initialize();
+            const res = await server.inject('/stream');
+            expect(res.statusCode).to.equal(500);
+
+            const [, event] = await log;
+            expect(event.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
         });
 
         it('errors on objectMode stream response', async () => {

--- a/test/response.js
+++ b/test/response.js
@@ -1195,14 +1195,14 @@ describe('Response', () => {
             expect(res1.statusCode).to.equal(500);
 
             const [, event1] = await log1;
-            expect(event1.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
+            expect(event1.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable');
 
             const log2 = server.events.once({ name: 'request', channels: 'error' });
             const res2 = await server.inject('/writable');
             expect(res2.statusCode).to.equal(500);
 
             const [, event2] = await log2;
-            expect(event2.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
+            expect(event2.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable');
         });
 
         it('errors on an http client stream response', async () => {
@@ -1224,7 +1224,7 @@ describe('Response', () => {
             expect(res.statusCode).to.equal(500);
 
             const [, event] = await log;
-            expect(event.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
+            expect(event.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable');
         });
 
         it('errors on a legacy readable stream response', async () => {
@@ -1255,7 +1255,7 @@ describe('Response', () => {
             expect(res.statusCode).to.equal(500);
 
             const [, event] = await log;
-            expect(event.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable.');
+            expect(event.error).to.be.an.error('Cannot reply with a stream-like object that is not an instance of Stream.Readable');
         });
 
         it('errors on objectMode stream response', async () => {


### PR DESCRIPTION
Dropping support for old/non-standard response streams.  If you want to use one of these, you can try repairing it into a `Stream.Readable` by piping it through a `Stream.PassThrough`.  I ended-up keeping the old stream duck-typing logic around for the purpose of helping users catch any issues when moving from v20 to v21, rather than treating legacy streams as an object response.

Resolves #4293