### PR TITLE
Make default error available in validation failAction

### DIFF
--- a/API.md
+++ b/API.md
@@ -3432,7 +3432,8 @@ Default value: `'error'` (return a Bad Request (400) error response).
 
 A [`failAction` value](#lifecycle-failAction) which determines how to handle failed validations.
 When set to a function, the `err` argument includes the type of validation error under
-`err.output.payload.validation.source`.
+`err.output.payload.validation.source`. The default error that would otherwise have been logged
+ or returned can be accessed under `err.data.defaultError`.
 
 #### <a name="route.options.validate.headers" /> `route.options.validate.headers`
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -146,7 +146,7 @@ internals.input = async function (source, request) {
     // Prepare error
 
     const defaultError = validationError.isBoom ? validationError : Boom.badRequest(`Invalid request ${source} input`);
-    const detailedError = Boom.boomify(validationError, { statusCode: 400, override: false });
+    const detailedError = Boom.boomify(validationError, { statusCode: 400, override: false, data: { defaultError } });
     detailedError.output.payload.validation = { source, keys: [] };
     if (validationError.details) {
         for (const details of validationError.details) {


### PR DESCRIPTION
Following from the conversation in #4040, I've added the default validation error to `err.data.defaultError` where `err` is the detailed error passed to `failAction()` for input validation.  Since the common use-case seems to be logging detailed validation errors without modifying the error response, I considered logging the detailed error by default.  But I determined that it contained user input which could be sensitive: I believe users should opt-in to this behavior with a custom `failAction()` rather than it become the default `'log'` behavior.  Here's how that would look with this update:

```js
server.route({
    method: 'get',
    path: '/',
    handler: () => 'ok',
    options: {
        validate: {
            query: {
                a: Joi.string().min(2)
            },
            failAction: function (request, h, err) {
                request.log(['validation', 'error', err.payload.validation.source], err);
                throw err.data.defaultError;
            }
        }
    }
});
```

Resolves #4040