### PR TITLE
Fix flaky test in test/request.js

### DIFF
--- a/test/request.js
+++ b/test/request.js
@@ -1395,6 +1395,7 @@ describe('Request', () => {
         it('handles hostname in HTTP request resource', async () => {
 
             const server = Hapi.server({ debug: false });
+            const team = new Teamwork.Team();
 
             let hostname;
             server.route({
@@ -1403,13 +1404,14 @@ describe('Request', () => {
                 handler: (request) => {
 
                     hostname = request.info.hostname;
+                    team.attend();
                     return null;
                 }
             });
 
             await server.start();
             const socket = Net.createConnection(server.info.port, '127.0.0.1', () => socket.write('GET http://host.com\r\n\r\n'));
-            await Hoek.wait(10);
+            await team.work;
             socket.destroy();
             await server.stop();
             expect(hostname).to.equal('host.com');


### PR DESCRIPTION
The PR #4352 unveiled a flaky test on OSX for node@16 which relied on `await Hoek.wait(10)`. The timer was supposed to be enough for the socket to send along the data and the server to receive the request but on some OS it's not the case. With this fix we're waiting until the server gets the request or ~~die trying~~ fail on the overall timeout for individual test (current 5000ms). This way the test should be more reliable no matter the OS it's run upon.
