### PR TITLE
Change default host to be IPv6-friendly

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,11 +26,11 @@ All options are optionals.
 
 #### <a name="server.options.address" /> `server.options.address`
 
-Default value: `'0.0.0.0'` (all available network interfaces).
+Default value: `'::'` if IPv6 is available, otherwise `'0.0.0.0'` (i.e. all available network interfaces).
 
 Sets the hostname or IP address the server will listen on. If not configured, defaults to
 [`host`](#server.options.host) if present, otherwise to all available network interfaces. Set to
-`'127.0.0.1'` or `'localhost'` to restrict the server to only those coming from the same host.
+`'127.0.0.1'`, `'::1'`, or `'localhost'` to restrict the server to only those coming from the same host.
 
 #### <a name="server.options.app" /> `server.options.app`
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -336,7 +336,7 @@ exports = module.exports = internals.Core = class {
                 this.listener.listen(this.settings.port, finalize);
             }
             else {
-                const address = this.settings.address || this.settings.host || '0.0.0.0';
+                const address = this.settings.address || this.settings.host || null;
                 this.listener.listen(this.settings.port, address, finalize);
             }
         });

--- a/lib/core.js
+++ b/lib/core.js
@@ -336,6 +336,7 @@ exports = module.exports = internals.Core = class {
                 this.listener.listen(this.settings.port, finalize);
             }
             else {
+                // Default is the unspecified address, :: if IPv6 is available or otherwise the IPv4 address 0.0.0.0
                 const address = this.settings.address || this.settings.host || null;
                 this.listener.listen(this.settings.port, address, finalize);
             }

--- a/lib/request.js
+++ b/lib/request.js
@@ -656,7 +656,15 @@ internals.Info = class {
     get remoteAddress() {
 
         if (!this._remoteAddress) {
-            this._remoteAddress = this._request.raw.req.socket.remoteAddress;
+            const ipv6Prefix = '::ffff:';
+            const socketAddress = this._request.raw.req.socket.remoteAddress;
+            if (socketAddress.startsWith(ipv6Prefix) && socketAddress.includes('.', ipv6Prefix.length)) {
+                // Normalize IPv4-mapped IPv6 address, e.g. ::ffff:127.0.0.1 -> 127.0.0.1
+                this._remoteAddress = socketAddress.slice(ipv6Prefix.length);
+            }
+            else {
+                this._remoteAddress = socketAddress;
+            }
         }
 
         return this._remoteAddress;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@hapi/code": "9.0.0-beta.0",
-    "@hapi/eslint-plugin": "*",
+    "@hapi/eslint-plugin": "^5.0.0",
     "@hapi/inert": "^6.0.2",
     "@hapi/joi-legacy-test": "npm:@hapi/joi@^15.0.0",
     "@hapi/lab": "25.0.0-beta.0",

--- a/test/common.js
+++ b/test/common.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const ChildProcess = require('child_process');
-const Dns = require('dns');
+const Http = require('http');
+const Net = require('net');
 
 const internals = {};
 
@@ -17,11 +18,15 @@ internals.hasLsof = () => {
     return true;
 };
 
+internals.hasIPv6 = () => {
+
+    const server = Http.createServer().listen();
+    const { address } = server.address();
+    server.close();
+
+    return Net.isIPv6(address);
+};
+
 exports.hasLsof = internals.hasLsof();
 
-exports.setDefaultDnsOrder = () => {
-    // Resolve localhost to ipv4 address on node v17
-    if (Dns.setDefaultResultOrder) {
-        Dns.setDefaultResultOrder('ipv4first');
-    }
-};
+exports.hasIPv6 = internals.hasIPv6();

--- a/test/core.js
+++ b/test/core.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ChildProcess = require('child_process');
+const Events = require('events');
 const Fs = require('fs');
 const Http = require('http');
 const Https = require('https');
@@ -27,13 +28,11 @@ const Common = require('./common');
 const internals = {};
 
 
-const { describe, it, before } = exports.lab = Lab.script();
+const { describe, it } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('Core', () => {
-
-    before(Common.setDefaultDnsOrder);
 
     it('sets app settings defaults', () => {
 
@@ -99,38 +98,58 @@ describe('Core', () => {
         }).to.throw('Cannot specify port when autoListen is false');
     });
 
-    it('defaults address to 0.0.0.0 or :: when no host is provided', async () => {
+    it('defaults address to 0.0.0.0 or :: when no host is provided', async (flags) => {
 
         const server = Hapi.server();
         await server.start();
+        flags.onCleanup = () => server.stop();
 
-        let expectedBoundAddress = '0.0.0.0';
-        if (Net.isIPv6(server.listener.address().address)) {
-            expectedBoundAddress = '::';
-        }
+        const expectedBoundAddress = Common.hasIPv6 ? '::' : '0.0.0.0';
 
         expect(server.info.address).to.equal(expectedBoundAddress);
-        await server.stop();
     });
 
-    it('uses address when present instead of host', async () => {
+    it('is accessible on localhost when using default host', async (flags) => {
+        // With hapi v20 this would fail on ipv6 machines on node v18+ due to DNS resolution changes in node (see nodejs/node#40537).
+        // To address this in hapi v21 we bind to :: if available, otherwise the former default of 0.0.0.0.
+
+        const server = Hapi.server();
+        server.route({ method: 'get', path: '/', handler: () => 'ok' });
+
+        await server.start();
+        flags.onCleanup = () => server.stop();
+
+        const req = Http.get(`http://localhost:${server.info.port}`);
+        const [res] = await Events.once(req, 'response');
+
+        let result = '';
+        for await (const chunk of res) {
+            result += chunk.toString();
+        }
+
+        expect(result).to.equal('ok');
+    });
+
+    it('uses address when present instead of host', async (flags) => {
 
         const server = Hapi.server({ host: 'no.such.domain.hapi', address: 'localhost' });
         await server.start();
+        flags.onCleanup = () => server.stop();
+
         expect(server.info.host).to.equal('no.such.domain.hapi');
-        expect(server.info.address).to.equal('127.0.0.1');
-        await server.stop();
+        expect(server.info.address).to.match(/^127\.0\.0\.1|::1$/); // ::1 on node v18 with ipv6 support
     });
 
-    it('uses uri when present instead of host and port', async () => {
+    it('uses uri when present instead of host and port', async (flags) => {
 
         const server = Hapi.server({ host: 'no.such.domain.hapi', address: 'localhost', uri: 'http://uri.example.com:8080' });
         expect(server.info.uri).to.equal('http://uri.example.com:8080');
         await server.start();
+        flags.onCleanup = () => server.stop();
+
         expect(server.info.host).to.equal('no.such.domain.hapi');
-        expect(server.info.address).to.equal('127.0.0.1');
+        expect(server.info.address).to.match(/^127\.0\.0\.1|::1$/); // ::1 on node v18 with ipv6 support
         expect(server.info.uri).to.equal('http://uri.example.com:8080');
-        await server.stop();
     });
 
     it('throws on uri ending with /', () => {

--- a/test/payload.js
+++ b/test/payload.js
@@ -11,18 +11,14 @@ const Hoek = require('@hapi/hoek');
 const Lab = require('@hapi/lab');
 const Wreck = require('@hapi/wreck');
 
-const Common = require('./common');
-
 const internals = {};
 
 
-const { describe, it, before } = exports.lab = Lab.script();
+const { describe, it } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('Payload', () => {
-
-    before(Common.setDefaultDnsOrder);
 
     it('sets payload', async () => {
 

--- a/test/request.js
+++ b/test/request.js
@@ -20,13 +20,11 @@ const Common = require('./common');
 const internals = {};
 
 
-const { describe, it, before } = exports.lab = Lab.script();
+const { describe, it } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('Request.Generator', () => {
-
-    before(Common.setDefaultDnsOrder);
 
     it('decorates request multiple times', async () => {
 
@@ -131,17 +129,19 @@ describe('Request', () => {
 
         const handler = (request) => {
 
-            let expectedClientAddress = '127.0.0.1';
-            if (Net.isIPv6(server.listener.address().address)) {
-                expectedClientAddress = '::ffff:127.0.0.1';
-            }
-
-            expect(request.info.remoteAddress).to.equal(expectedClientAddress);
-            expect(request.info.remotePort).to.be.above(0);
-
             // Call twice to reuse cached values
 
-            expect(request.info.remoteAddress).to.equal(expectedClientAddress);
+            if (Common.hasIPv6) {
+                // ::ffff:127.0.0.1 on node v14 and v16, ::1 on node v18.
+                expect(request.info.remoteAddress).to.match(/^::ffff:127\.0\.0\.1|::1$/);
+                expect(request.info.remoteAddress).to.match(/^::ffff:127\.0\.0\.1|::1$/);
+            }
+            else {
+                expect(request.info.remoteAddress).to.equal('127.0.0.1');
+                expect(request.info.remoteAddress).to.equal('127.0.0.1');
+            }
+
+            expect(request.info.remotePort).to.be.above(0);
             expect(request.info.remotePort).to.be.above(0);
 
             return 'ok';

--- a/test/server.js
+++ b/test/server.js
@@ -14,20 +14,17 @@ const Lab = require('@hapi/lab');
 const Vision = require('@hapi/vision');
 const Wreck = require('@hapi/wreck');
 
-const Common = require('./common');
 const Pkg = require('../package.json');
 
 
 const internals = {};
 
 
-const { describe, it, before } = exports.lab = Lab.script();
+const { describe, it } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('Server', () => {
-
-    before(Common.setDefaultDnsOrder);
 
     describe('auth', () => {
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -24,13 +24,11 @@ const Common = require('./common');
 const internals = {};
 
 
-const { describe, it, before } = exports.lab = Lab.script();
+const { describe, it } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
 describe('transmission', () => {
-
-    before(Common.setDefaultDnsOrder);
 
     describe('send()', () => {
 


### PR DESCRIPTION
This changes hapi's default host of `0.0.0.0` to use node's IPv6-friendly default host of `::` or `0.0.0.0`, depending on whether the machine supports IPv6.

Under node v18 the drawbacks of the current default are emphasized, since DNS resolution in node has changed (https://github.com/nodejs/node/pull/39987) allowing `localhost` to resolve to the IPv6 address `::1`— since `0.0.0.0` was pinned to IPv4, a request to `localhost` from node would not be able to connect to a default hapi server.