### PR TITLE
Allow matching prereleases when validating plugin version requirements

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,7 @@
 
 const Os = require('os');
 
+const Somever = require('@hapi/somever');
 const Validate = require('@hapi/validate');
 
 
@@ -38,6 +39,7 @@ exports.enable = function (options) {
     return settings;
 };
 
+exports.versionMatch = (version, range) => Somever.match(version, range, { includePrerelease: true });
 
 internals.access = Validate.object({
     entity: Validate.valid('user', 'app', 'any'),

--- a/lib/core.js
+++ b/lib/core.js
@@ -14,7 +14,6 @@ const { Heavy } = require('@hapi/heavy');
 const Hoek = require('@hapi/hoek');
 const { Mimos } = require('@hapi/mimos');
 const Podium = require('@hapi/podium');
-const Somever = require('@hapi/somever');
 const Statehood = require('@hapi/statehood');
 
 const Auth = require('./auth');
@@ -386,7 +385,7 @@ exports = module.exports = internals.Core = class {
             for (const dep in deps) {
                 const version = deps[dep];
                 Hoek.assert(this.registrations[dep], 'Plugin', plugin, 'missing dependency', dep);
-                Hoek.assert(version === '*' || Somever.match(this.registrations[dep].version, version), 'Plugin', plugin, 'requires', dep, 'version', version, 'but found', this.registrations[dep].version);
+                Hoek.assert(version === '*' || Config.versionMatch(this.registrations[dep].version, version), 'Plugin', plugin, 'requires', dep, 'version', version, 'but found', this.registrations[dep].version);
             }
         }
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,7 +2,6 @@
 
 const Hoek = require('@hapi/hoek');
 const Shot = require('@hapi/shot');
-const Somever = require('@hapi/somever');
 const Teamwork = require('@hapi/teamwork');
 
 const Config = require('./config');
@@ -463,8 +462,8 @@ internals.Server = class {
                 // Validate requirements
 
                 const requirements = item.plugin.requirements;
-                Hoek.assert(!requirements.node || Somever.match(process.version, requirements.node), 'Plugin', name, 'requires node version', requirements.node, 'but found', process.version);
-                Hoek.assert(!requirements.hapi || Somever.match(this.version, requirements.hapi), 'Plugin', name, 'requires hapi version', requirements.hapi, 'but found', this.version);
+                Hoek.assert(!requirements.node || Config.versionMatch(process.version, requirements.node), 'Plugin', name, 'requires node version', requirements.node, 'but found', process.version);
+                Hoek.assert(!requirements.hapi || Config.versionMatch(this.version, requirements.hapi), 'Plugin', name, 'requires hapi version', requirements.hapi, 'but found', this.version);
 
                 // Protect against multiple registrations
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@hapi/mimos": "^7.0.0",
     "@hapi/podium": "^5.0.0",
     "@hapi/shot": "^6.0.0",
-    "@hapi/somever": "^4.0.0",
+    "@hapi/somever": "^4.1.0",
     "@hapi/statehood": "^8.0.0",
     "@hapi/subtext": "^8.0.0",
     "@hapi/teamwork": "^6.0.0",

--- a/test/core.js
+++ b/test/core.js
@@ -835,7 +835,7 @@ describe('Core', () => {
             await server.start();
 
             const socket = await internals.socket(server);
-            socket.write('GET / HTTP/1.0\nHost: test\n\n');
+            socket.write('GET / HTTP/1.0\r\nHost: test\r\n\r\n');
             await Hoek.wait(10);
 
             const count1 = await internals.countConnections(server);
@@ -853,7 +853,7 @@ describe('Core', () => {
             await server.start();
 
             const socket = await internals.socket(server);
-            socket.write('GET / HTTP/1.0\nHost: test\n\n');
+            socket.write('GET / HTTP/1.0\r\nHost: test\r\n\r\n');
             await Hoek.wait(10);
 
             const count1 = await internals.countConnections(server);
@@ -874,7 +874,7 @@ describe('Core', () => {
             await server.start();
 
             const socket = await internals.socket(server);
-            socket.write('GET / HTTP/1.1\nHost: test\nConnection: Keep-Alive\n\n\n');
+            socket.write('GET / HTTP/1.1\r\nHost: test\r\nConnection: Keep-Alive\r\n\r\n\r\n');
             await new Promise((resolve) => socket.on('data', resolve));
 
             const count = await internals.countConnections(server);
@@ -892,7 +892,7 @@ describe('Core', () => {
             await server.start();
 
             const socket = await internals.socket(server);
-            socket.write('GET / HTTP/1.0\nHost: test\n\n');
+            socket.write('GET / HTTP/1.0\r\nHost: test\r\n\r\n');
             await Hoek.wait(10);
 
             const count1 = await internals.countConnections(server);

--- a/test/request.js
+++ b/test/request.js
@@ -2260,7 +2260,7 @@ describe('Request', () => {
             });
 
             await new Promise((resolve) => client.on('connect', resolve));
-            client.write('GET / HTTP/1.1\nHost: test\nContent-Length: 0\n\n\ninvalid data');
+            client.write('GET / HTTP/1.1\r\nHost: test\r\nContent-Length: 0\r\n\r\n\r\ninvalid data');
 
             const [request] = await log;
             expect(request.response.statusCode).to.equal(400);
@@ -2290,7 +2290,7 @@ describe('Request', () => {
             });
 
             await new Promise((resolve) => client.on('connect', resolve));
-            client.write('GET / HTTP/1.1\nHost: test\nContent-Length: 0\n\n\ninvalid data');
+            client.write('GET / HTTP/1.1\r\nHost: test\nContent-Length: 0\r\n\r\n\r\ninvalid data');
 
             const clientResponse = await clientEnded;
             expect(clientResponse).to.contain('400 Bad Request');

--- a/test/server.js
+++ b/test/server.js
@@ -2790,6 +2790,24 @@ describe('Server', () => {
             await expect(server.register(test)).to.not.reject();
         });
 
+        it('validates node version, allowing prereleases', async (flags) => {
+
+            const test = {
+                name: 'test',
+                requirements: {
+                    node: '>=8.x.x'
+                },
+                register: function (srv, options) { }
+            };
+
+            const origVersion = process.version;
+            Object.defineProperty(process, 'version', { value: 'v100.0.0-beta' });
+            flags.onCleanup = () => Object.defineProperty(process, 'version', { value: origVersion });
+
+            const server = Hapi.server();
+            await expect(server.register(test)).to.not.reject();
+        });
+
         it('errors on invalid node version', async () => {
 
             const test = {
@@ -2818,6 +2836,21 @@ describe('Server', () => {
             await expect(server.register(test)).to.not.reject();
         });
 
+        it('validates hapi version, allowing prereleases', async () => {
+
+            const test = {
+                name: 'test',
+                requirements: {
+                    hapi: '>=17.x.x'
+                },
+                register: function (srv, options) { }
+            };
+
+            const server = Hapi.server();
+            server.version = '100.0.0-beta';
+            await expect(server.register(test)).to.not.reject();
+        });
+
         it('errors on invalid hapi version', async () => {
 
             const test = {
@@ -2830,6 +2863,37 @@ describe('Server', () => {
 
             const server = Hapi.server();
             await expect(server.register(test)).to.reject(`Plugin test requires hapi version 4.x.x but found ${Pkg.version}`);
+        });
+
+        it('validates plugin version, allowing prereleases', async () => {
+
+            const a = {
+                name: 'a',
+                version: '0.1.2',
+                dependencies: {
+                    b: '>=3.x.x',
+                    c: '>=2.x.x'
+                },
+                register: Hoek.ignore
+            };
+
+            const b = {
+                name: 'b',
+                version: '4.0.0-beta',
+                register: Hoek.ignore
+            };
+
+            const c = {
+                name: 'c',
+                version: '2.3.4',
+                register: Hoek.ignore
+            };
+
+            const server = Hapi.server();
+            await server.register(b);
+            await server.register(c);
+            await server.register(a);
+            await expect(server.initialize()).to.not.reject();
         });
 
         it('errors on invalid plugin version', async () => {


### PR DESCRIPTION
Historically hapi has disallowed matching of prerelease versions when validating plugin `requirements`.  This has caused some issues, e.g. when node's CITGM runs hapi's test suite on upcoming versions of node (https://github.com/hapijs/somever/issues/18), or when testing plugins against the beta of hapi v21 (https://github.com/hapijs/inert/pull/164#discussion_r907095052).  In https://github.com/hapijs/somever/issues/18 we resolved to change this behavior within hapi. This PR addresses the issue, following from adding the feature to somever in https://github.com/hapijs/somever/pull/22.

I also updated the tests so that we don't trigger errors in the updated version of llhttp in node v18.5.0 ([ref](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2022-07-07-version-1850-current-rafaelgss)).