### PR TITLE
Replace deprecated `.abort()` with `.destroy()`

### DIFF
--- a/test/core.js
+++ b/test/core.js
@@ -648,7 +648,7 @@ describe('Core', () => {
             expect(server._core.sockets.size).to.equal(1);
             expect(count).to.equal(1);
 
-            promise.req.abort();
+            promise.req.destroy();
             await expect(promise).to.reject();
 
             await Hoek.wait(50);
@@ -688,7 +688,7 @@ describe('Core', () => {
             expect(server._core.sockets.size).to.equal(1);
             expect(count).to.equal(1);
 
-            promise.req.abort();
+            promise.req.destroy();
             await expect(promise).to.reject();
 
             await Hoek.wait(50);

--- a/test/payload.js
+++ b/test/payload.js
@@ -146,7 +146,7 @@ describe('Payload', () => {
         const req = Http.request(options, (res) => { });
         req.on('error', Hoek.ignore);
         req.write('Hello\n');
-        setTimeout(() => req.abort(), 50);
+        setTimeout(() => req.destroy(), 50);
 
         const [event] = await log;
         expect(event.error.message).to.equal('Parse Error');

--- a/test/request.js
+++ b/test/request.js
@@ -405,7 +405,7 @@ describe('Request', () => {
                 options: {
                     handler: async (request, h) => {
 
-                        req.abort();
+                        req.destroy();
 
                         while (request.active() && !testComplete) {
                             await Hoek.wait(10);
@@ -703,7 +703,7 @@ describe('Request', () => {
 
             const handler = async (request) => {
 
-                clientRequest.abort();
+                clientRequest.destroy();
                 await Hoek.wait(10);
                 team.attend();
                 throw new Error('fail');
@@ -735,7 +735,7 @@ describe('Request', () => {
 
             const preHandler = async (request, h) => {
 
-                clientRequest.abort();
+                clientRequest.destroy();
                 await Hoek.wait(10);
                 team.attend();
                 return h.continue;
@@ -762,7 +762,7 @@ describe('Request', () => {
 
             const handler = async (request) => {
 
-                clientRequest.abort();
+                clientRequest.destroy();
                 await Hoek.wait(10);
                 throw new Error('boom');
             };
@@ -1004,7 +1004,7 @@ describe('Request', () => {
                         status: {
                             200: async (_, { context }) => {
 
-                                req.abort();
+                                req.destroy();
 
                                 const raw = context.app.request;
                                 await Events.once(raw.req, 'aborted');
@@ -2234,7 +2234,7 @@ describe('Request', () => {
             req.flushHeaders();
 
             await ready;
-            req.abort();
+            req.destroy();
             const [request] = await log;
 
             expect(request.response.output.statusCode).to.equal(499);

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -1292,7 +1292,7 @@ describe('transmission', () => {
             const team = new Teamwork.Team();
             const handler = async (request) => {
 
-                clientRequest.abort();
+                clientRequest.destroy();
 
                 const stream = new Stream.Readable({
                     read(size) {


### PR DESCRIPTION
One test depends on the specific behavior of `.abort()`, so I haven't changed it:

https://github.com/hapijs/hapi/blob/9c17cc0dc99570939a449b623fbd58aca3ecac92/test/response.js#L1213