### PR TITLE
Correct the ResponseObject type

### DIFF
--- a/lib/types/request.d.ts
+++ b/lib/types/request.d.ts
@@ -6,8 +6,7 @@ import { Boom } from '@hapi/boom';
 import { Podium } from '@hapi/podium';
 
 import { PluginsStates, ServerRealm } from './plugin';
-import { ResponseObject } from '@hapi/shot';
-import { ResponseValue } from './response';
+import { ResponseValue, ResponseObject } from "./response";
 import { RouteRules, RouteSettings } from './route';
 import { Server, ServerAuthSchemeObjectApi } from './server';
 import { HTTP_METHODS_PARTIAL, HTTP_METHODS_PARTIAL_LOWERCASE, PeekListener } from './utils';


### PR DESCRIPTION
I am one of the previous maintainers of `@types/hapi__hapi` - after migrating away from it I noticed that a lot of properties inside the response were unavailable, and it seems to come down to the `ResponseObject` from `shot` being used instead of the actual `ResponseObject` from `hapi`.

As an example, this used to work, but doesn't with the current types:

```ts
server.ext('onPreResponse', (request: Request, h: ResponseToolkit): Lifecycle.ReturnValue => {
    const { response } = request;

    if (!response || response instanceof Error) {
        return h.continue;
    }

    response.events.on('peek', chunk => {
        console.dir(chunk);
    });

    return h.continue;
});
``` 

Maybe it would also be good to migrate over all of the tests from DefinitelyTyped? I can try to attempt that if no-one else does, but I am very limited on time currently. 