### PR TITLE
Fix mimos import in lib/types/server/server.d.ts

### DIFF
--- a/lib/types/server/server.d.ts
+++ b/lib/types/server/server.d.ts
@@ -2,7 +2,7 @@ import * as http from 'http';
 import * as zlib from 'zlib';
 
 import { Root } from 'joi';
-import { Mimos } from '@hapi/mimos';
+import Mimos = require('@hapi/mimos');
 
 import {
     Dependencies,


### PR DESCRIPTION
@hapi/mimos still uses TS-only `export = Mimos` syntax, so server.d.ts needs to use TS-only `import Mimos = require('@hapi/mimos')` syntax.

A full fix would change the exports of @hapi/mimos, but this PR is a lot smaller.

Fixes #4418