### PR TITLE
Fix valid values of 'xss' property in types and documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -3364,8 +3364,8 @@ following options:
 
 - `xss` - controls the 'X-XSS-Protection' header, where:
 
-    - `'disable'` - the header will be set to `'0'`.  This is the default value.
-    - `'enable'` - the header will be set to `'1; mode=block'`.
+    - `'disabled'` - the header will be set to `'0'`.  This is the default value.
+    - `'enabled'` - the header will be set to `'1; mode=block'`.
     - `false` - the header will be omitted.
 
     Note: when enabled, this setting can create a security vulnerabilities in versions of Internet Explorer

--- a/lib/types/route.d.ts
+++ b/lib/types/route.d.ts
@@ -494,8 +494,8 @@ export type ReferrerPolicy = '' | 'no-referrer' | 'no-referrer-when-downgrade' |
  * * * * source - when rule is 'allow-from' this is used to form the rest of the header, otherwise this field is ignored. If rule is 'allow-from' but source is unset, the rule will be automatically
  * changed to 'sameorigin'.
  * * xss - controls the 'X-XSS-Protection' header, where:
- * * * 'disable' - the header will be set to '0'. This is the default value.
- * * * 'enable' - the header will be set to '1; mode=block'.
+ * * * 'disabled' - the header will be set to '0'. This is the default value.
+ * * * 'enabled' - the header will be set to '1; mode=block'.
  * * * false - the header will be omitted
  * * noOpen - boolean controlling the 'X-Download-Options' header for Internet Explorer, preventing downloads from executing in your context. Defaults to true setting the header to 'noopen'.
  * * noSniff - boolean controlling the 'X-Content-Type-Options' header. Defaults to true setting the header to its only and default option, 'nosniff'.
@@ -535,11 +535,11 @@ export interface RouteOptionsSecureObject {
     } | undefined;
     /**
      * controls the 'X-XSS-Protection' header, where:
-     * * 'disable' - the header will be set to '0'. This is the default value.
-     * * 'enable' - the header will be set to '1; mode=block'.
+     * * 'disabled' - the header will be set to '0'. This is the default value.
+     * * 'enabled' - the header will be set to '1; mode=block'.
      * * false - the header will be omitted
      */
-    xss?: 'disable' | 'enable' | false | undefined;
+    xss?: 'disabled' | 'enabled' | false | undefined;
     /**
      * boolean controlling the 'X-Download-Options' header for Internet Explorer, preventing downloads from executing in your context. Defaults to true setting the header to 'noopen'.
      */


### PR DESCRIPTION
Fixes valid values of 'xss' security option in TS types and in the documentation. 

Context: The change https://github.com/hapijs/hapi/pull/4352 introduces string values `'enabled'` and `'disabled'` for the `xss` property. However, it adds `'enable'` and `'disable'` (mind the missing `d`) to the API documentation. Then, this change https://github.com/hapijs/hapi/pull/4401 adds those wrong values from the documentation to the Typescript types. Now if you use `xss: 'enable'` on a TS project, the code compiles but on runtime Hapi rightfully complains: `"routes.security.xss" must be one of [enabled, disabled, false]`. If you set it to `enabled` though the code no longer compiles due to the TS type declaration. This change fixes that and aligns the types with the values used at runtime.