### PR TITLE
Explicitly add dependency @hapi/iron

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@hapi/catbox-memory": "^6.0.1",
     "@hapi/heavy": "^8.0.1",
     "@hapi/hoek": "^11.0.2",
+    "@hapi/iron": "^7.0.1",
     "@hapi/mimos": "^7.0.1",
     "@hapi/podium": "^5.0.1",
     "@hapi/shot": "^6.0.1",


### PR DESCRIPTION
Fixes typescript compilation for downstream projects where npm can't flatten this nested dependency into top. The only reason this appears to work here is because it is transitively included by statehood.

Required here:

https://github.com/hapijs/hapi/blob/c6d881ff10e3e102c2af99f117901740ee048d7d/lib/types/server/state.d.ts#L2