### PR TITLE
failAction loses stacktrace context

### DIFF
--- a/lib/toolkit.js
+++ b/lib/toolkit.js
@@ -114,7 +114,7 @@ exports.Manager = class {
         this._toolkit.prototype[name] = method;
     }
 
-    failAction(request, failAction, err, options) {
+    async failAction(request, failAction, err, options) {
 
         const retain = options.retain ? err : undefined;
         if (failAction === 'ignore') {
@@ -130,7 +130,7 @@ exports.Manager = class {
             throw err;
         }
 
-        return this.execute(failAction, request, { realm: request.route.realm, args: [options.details ?? err] });
+        return await this.execute(failAction, request, { realm: request.route.realm, args: [options.details ?? err] });
     }
 };
 

--- a/lib/toolkit.js
+++ b/lib/toolkit.js
@@ -135,7 +135,7 @@ exports.Manager = class {
 };
 
 
-exports.timed = function (method, options) {
+exports.timed = async function (method, options) {
 
     if (!options.timeout) {
         return method;
@@ -151,7 +151,7 @@ exports.timed = function (method, options) {
         setTimeout(handler, options.timeout);
     });
 
-    return Promise.race([timer, method]);
+    return await Promise.race([timer, method]);
 };
 
 


### PR DESCRIPTION
Returning promise without await causes Node.js to lose stacktrace context making hapijs app harder to debug