### PR TITLE
feat: Allow passing query parser implementation in route config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -160,7 +160,8 @@ internals.routeBase = Validate.object({
         defaultContentType: Validate.string().default('application/json'),
         compression: Validate.object()
             .pattern(/.+/, Validate.object())
-            .default()
+            .default(),
+        querystring: Validate.function(),
     })
         .default(),
     plugins: Validate.object(),

--- a/lib/types/route.d.ts
+++ b/lib/types/route.d.ts
@@ -334,6 +334,12 @@ export interface RouteOptionsPayload {
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionspayloaduploads)
      */
     uploads?: string | undefined;
+
+    /**
+     * @default Querystring.parse().
+     * Query parser implementation fro application/x-www-form-urlencoded data
+     */
+    querystring?: (query: string) => { [key: string]: unknown };
 }
 
 /**


### PR DESCRIPTION
Allow passing query parser implementation for parsing x-www-form-urlencoded data in route payload config