### PR TITLE
fix(types): enhance reusability of pres

### DIFF
--- a/lib/types/utils.d.ts
+++ b/lib/types/utils.d.ts
@@ -65,10 +65,10 @@ export namespace Lifecycle {
     type Method<
         Refs extends ReqRef = ReqRefDefaults,
         R extends ReturnValue<any> = ReturnValue<Refs>
-    > = (
+    > = <RouteRef extends Refs>(
             this: MergeRefs<Refs>['Bind'],
-            request: Request<Refs>,
-            h: ResponseToolkit<Refs>,
+            request: Request<RouteRef>,
+            h: ResponseToolkit<RouteRef>,
             err?: Error | undefined
         ) => R;
 


### PR DESCRIPTION
Support for pre handlers whose type definition is only a subset of the actual route type definition.

When trying to reuse pre handlers in a typescript environment like the following
```typescript
const doSomething: Lifecycle.Method<any> = async ({ params }) => {
  console.log(params.preParam);
};

server.route<{ Params: { param: string, preParam: number } }>({
    method: 'GET',
    path: '/route',
    handler: async ({ params }) => console.log(params.param),
    options: {
        pre: [ doSomething ]
    }
});

server.route<{ Params: { otherParam: string, preParam: number } }>({
    method: 'GET',
    path: '/route',
    handler: async ({ params }) => console.log(params.otherParam),
    options: {
        pre: [ doSomething ]
    }
});
```

The type definition of the pre handler does not have any possible valid value, hence needing to drop type checking using the `any` keyword in order for typescript not to throw an error.

This happens because the definition of `Lifecycle.Method` expects the request type to equal to the type provided in the `Method` generic, but in this scenario there're 2 distinct request types.
> Note: Using unions of both request types is also invalid, I would need to dig deeper into why, but seems related to the usege of the `keyof` operator in another type definitions.

The changes in this PR update the `Method` type definition to require the request type to **extend** the type provided in the generic instead of checking for it to be equal.

This change allows to resolve the above scenario with type definitions like the following:
```typescript
const doSomething: Lifecycle.Method<{ Params: { preParam: number } }> = async ({ params }) => {
  console.log(params.preParam);
};
```
As all route definitions contain a `preParam: number` param, they're successfully extending the Method's generic, passing type checking