### PR TITLE
Remove support for pre v16 joi

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -126,7 +126,7 @@ internals.input = async function (source, request) {
         const schema = request.route.settings.validate[source];
         const bind = request.route.settings.bind;
 
-        var value = await (typeof schema !== 'function' ? internals.validate(request[source], schema, localOptions) : schema.call(bind, request[source], localOptions));
+        var value = await (typeof schema !== 'function' ? schema.validateAsync(request[source], localOptions) : schema.call(bind, request[source], localOptions));
         return;
     }
     catch (err) {
@@ -217,7 +217,7 @@ exports.response = async function (request) {
         let value;
 
         if (typeof schema !== 'function') {
-            value = await internals.validate(source, schema, localOptions);
+            value = await schema.validateAsync(source, localOptions);
         }
         else {
             value = await schema(source, localOptions);
@@ -237,14 +237,4 @@ exports.response = async function (request) {
     catch (err) {
         return request._core.toolkit.failAction(request, request.route.settings.response.failAction, err, { tags: ['validation', 'response', 'error'] });
     }
-};
-
-
-internals.validate = function (value, schema, options) {
-
-    if (typeof schema.validateAsync === 'function') {
-        return schema.validateAsync(value, options);
-    }
-
-    return schema.validate(value, options);
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@hapi/code": "^9.0.3",
     "@hapi/eslint-plugin": "*",
     "@hapi/inert": "^7.0.1",
-    "@hapi/joi-legacy-test": "npm:@hapi/joi@^15.0.0",
     "@hapi/lab": "^25.1.2",
     "@hapi/vision": "^7.0.1",
     "@hapi/wreck": "^18.0.1",

--- a/test/validation.js
+++ b/test/validation.js
@@ -5,7 +5,6 @@ const Code = require('@hapi/code');
 const Hapi = require('..');
 const Inert = require('@hapi/inert');
 const Joi = require('joi');
-const JoiLegacy = require('@hapi/joi-legacy-test');
 const Lab = require('@hapi/lab');
 
 
@@ -17,31 +16,6 @@ const expect = Code.expect;
 
 
 describe('validation', () => {
-
-    it('validates using joi v15', async () => {
-
-        const server = Hapi.server();
-        server.validator(JoiLegacy);
-        server.route({
-            method: 'POST',
-            path: '/',
-            handler: () => 'ok',
-            options: {
-                validate: {
-                    payload: JoiLegacy.object({
-                        a: JoiLegacy.number(),
-                        b: JoiLegacy.array()
-                    })
-                }
-            }
-        });
-
-        const res1 = await server.inject({ url: '/', method: 'POST', payload: { a: '1', b: [1] } });
-        expect(res1.statusCode).to.equal(200);
-
-        const res2 = await server.inject({ url: '/', method: 'POST', payload: { a: 'x', b: [1] } });
-        expect(res2.statusCode).to.equal(400);
-    });
 
     describe('inputs', () => {
 


### PR DESCRIPTION
The last joi@15.1.1 was release more than 4 years ago. It should be safe to drop (in a breaking release).

This also removes several npm deprecation notices when installing dev dependencies.