### PR TITLE
Improve expect 100-continue handling

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -408,12 +408,13 @@ internals.payload = async function (request) {
         return;
     }
 
-    if (request._expectContinue) {
-        request.raw.res.writeContinue();
-    }
-
     if (request.payload !== undefined) {
         return internals.drain(request);
+    }
+
+    if (request._expectContinue) {
+        request._expectContinue = false;
+        request.raw.res.writeContinue();
     }
 
     try {
@@ -426,9 +427,7 @@ internals.payload = async function (request) {
     catch (err) {
         Bounce.rethrow(err, 'system');
 
-        if (request._isPayloadPending) {
-            await internals.drain(request);
-        }
+        await internals.drain(request);
 
         request.mime = err.mime;
         request.payload = null;
@@ -442,8 +441,15 @@ internals.drain = async function (request) {
 
     // Flush out any pending request payload not consumed due to errors
 
-    await Streams.drain(request.raw.req);
-    request._isPayloadPending = false;
+    if (request._expectContinue) {
+        request._isPayloadPending = false;        // If we don't continue, client should not send a payload
+        request._expectContinue = false;
+    }
+
+    if (request._isPayloadPending) {
+        await Streams.drain(request.raw.req);
+        request._isPayloadPending = false;
+    }
 };
 
 


### PR DESCRIPTION
This fixes 2 issues in the existing handling.

The most serious is the one exposed in the "handles expect 100-continue on undefined routes". These routes bypass most of the normal processing, meaning that the server never signals for the client to continue. This causes an infinite stall when [`internals.drain()`](https://github.com/hapijs/hapi/blob/4206c21fb294ba4baee75ac5ab4c148b250abdc6/lib/route.js#L441-L447) is called, since the client hasn't been instructed to send data.

The other issue, is that when overriding `request.payload`, hapi will still request the client to continue sending the payload, even though it will never be used.

The first test is just to verify that hapi will skip requesting the client to continue when processing is aborted before the "payload processing" stage.