### PR TITLE
Make content encoder and options explicitly typed and extensible

### DIFF
--- a/lib/types/route.d.ts
+++ b/lib/types/route.d.ts
@@ -3,7 +3,7 @@ import { ObjectSchema, ValidationOptions, SchemaMap, Schema } from 'joi';
 
 import { PluginSpecificConfiguration} from './plugin';
 import { MergeType, ReqRef, ReqRefDefaults, MergeRefs, AuthMode } from './request';
-import { RouteRequestExtType, RouteExtObject, Server } from './server';
+import { ContentDecoders, ContentEncoders, RouteRequestExtType, RouteExtObject, Server } from './server';
 import { Lifecycle, Json, HTTP_METHODS_PARTIAL } from './utils';
 
 /**
@@ -209,11 +209,6 @@ export interface RouteOptionsCors {
 export type PayloadOutput = 'data' | 'stream' | 'file';
 
 /**
- * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionspayloadcompression)
- */
-export type PayloadCompressionDecoderSettings = object;
-
-/**
  * Determines how the request payload is processed.
  * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionspayload)
  */
@@ -237,7 +232,7 @@ export interface RouteOptionsPayload {
      * An object where each key is a content-encoding name and each value is an object with the desired decoder settings. Note that encoder settings are set in compression.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionspayloadcompression)
      */
-    compression?: Record<string, PayloadCompressionDecoderSettings> | undefined;
+    compression?: { [P in keyof ContentDecoders]?: Parameters<ContentDecoders[P]>[0] } | undefined;
 
     /**
      * @default 'application/json'.
@@ -643,12 +638,6 @@ export interface RouteOptionsValidate {
     state?: RouteOptionsResponseSchema | undefined;
 }
 
-/**
- * For context [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionscompression)
- * For context [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverencoderencoding-encoder)
- */
-export type RouteCompressionEncoderSettings = object;
-
 export interface CommonRouteProperties<Refs extends ReqRef = ReqRefDefaults> {
     /**
      * Application-specific route configuration state. Should not be used by plugins which should use options.plugins[name] instead.
@@ -683,7 +672,7 @@ export interface CommonRouteProperties<Refs extends ReqRef = ReqRefDefaults> {
      * An object where each key is a content-encoding name and each value is an object with the desired encoder settings. Note that decoder settings are set in compression.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionscompression)
      */
-    compression?: Record<string, RouteCompressionEncoderSettings> | undefined;
+    compression?: { [P in keyof ContentEncoders]?: Parameters<ContentEncoders[P]>[0] } | undefined;
 
     /**
      * @default false (no CORS headers).

--- a/lib/types/server/encoders.d.ts
+++ b/lib/types/server/encoders.d.ts
@@ -1,0 +1,19 @@
+import { createDeflate, createGunzip, createGzip, createInflate } from 'zlib';
+
+/**
+ * Available [content encoders](https://github.com/hapijs/hapi/blob/master/API.md#-serverencoderencoding-encoder).
+ */
+export interface ContentEncoders {
+
+    deflate: typeof createDeflate;
+    gzip: typeof createGzip;
+}
+
+/**
+ * Available [content decoders](https://github.com/hapijs/hapi/blob/master/API.md#-serverdecoderencoding-decoder).
+ */
+export interface ContentDecoders {
+
+    deflate: typeof createInflate;
+    gzip: typeof createGunzip;
+}

--- a/lib/types/server/index.d.ts
+++ b/lib/types/server/index.d.ts
@@ -1,5 +1,6 @@
 export * from './auth';
 export * from './cache';
+export * from './encoders';
 export * from './events';
 export * from './ext';
 export * from './info';

--- a/lib/types/server/server.d.ts
+++ b/lib/types/server/server.d.ts
@@ -1,5 +1,5 @@
 import * as http from 'http';
-import * as zlib from 'zlib';
+import { Stream } from 'stream';
 
 import { Root } from 'joi';
 import { Mimos } from '@hapi/mimos';
@@ -25,8 +25,6 @@ import {
 } from '../request';
 import { ResponseToolkit } from '../response';
 import {
-    PayloadCompressionDecoderSettings,
-    RouteCompressionEncoderSettings,
     RulesOptions,
     RulesProcessor,
     ServerRoute
@@ -34,6 +32,7 @@ import {
 import { HTTP_METHODS, Lifecycle } from '../utils';
 import { ServerAuth } from './auth';
 import { ServerCache } from './cache';
+import { ContentDecoders, ContentEncoders } from './encoders';
 import { ServerEventsApplication, ServerEvents } from './events';
 import {
     ServerExtEventsObject,
@@ -291,7 +290,8 @@ export class Server<A = ServerApplicationState> {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverdecoderencoding-decoder)
      */
-    decoder(encoding: string, decoder: ((options: PayloadCompressionDecoderSettings) => zlib.Gunzip)): void;
+    decoder<T extends keyof ContentDecoders>(encoding: T, decoder: ContentDecoders[T]): void;
+    decoder(encoding: string, decoder: ((options?: object) => Stream)): void;
 
     /**
      * Extends various framework interfaces with custom methods where:
@@ -340,7 +340,8 @@ export class Server<A = ServerApplicationState> {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverencoderencoding-encoder)
      */
-    encoder(encoding: string, encoder: ((options: RouteCompressionEncoderSettings) => zlib.Gzip)): void;
+    encoder<T extends keyof ContentEncoders>(encoding: T, encoder: ContentEncoders[T]): void;
+    encoder(encoding: string, encoder: ((options?: object) => Stream)): void;
 
     /**
      * Used within a plugin to expose a property via server.plugins[name] where:


### PR DESCRIPTION
This PR improves the typings of the route and payload `compression` options, by explicitly listing the available encoders (`gzip` & `deflate`) and types all the options.

Additionally, it allows users to register types for custom encoders/decoders with its own custom options. Eg.

```ts
import { createBrotliCompress } from 'zlib';

declare module '@hapi/hapi' {
    interface ContentEncoders {
        br: typeof createBrotliCompress;
    }
}
```

This will add and type a `br` encoder to `servers.encoders()`, and add it to the list of `compression` options with the expected typings.

Note that I deleted the nonsensical `RouteCompressionEncoderSettings` and `PayloadCompressionDecoderSettings` type exports (the settings have always been specific to each entry).