### PR TITLE
Assert on unsupported route method

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Assert = require('assert');
+const Http = require('http');
 
 const Bounce = require('@hapi/bounce');
 const Catbox = require('@hapi/catbox');
@@ -19,7 +20,9 @@ const Streams = require('./streams');
 const Validation = require('./validation');
 
 
-const internals = {};
+const internals = {
+    httpVerbs: new Set([...Http.METHODS.map((s) => s.toLowerCase()), '*', '_special'])
+};
 
 
 exports = module.exports = internals.Route = class {
@@ -35,6 +38,7 @@ exports = module.exports = internals.Route = class {
 
         const method = route.method.toLowerCase();
         Hoek.assert(method !== 'head', 'Cannot set HEAD route:', route.path);
+        Hoek.assert(internals.httpVerbs.has(method), 'Unsupported "method" for route:', route.method, route.path);
 
         const path = realm.modifiers.route.prefix ? realm.modifiers.route.prefix + (route.path !== '/' ? route.path : '') : route.path;
         Hoek.assert(path === '/' || path[path.length - 1] !== '/' || !core.settings.router.stripTrailingSlash, 'Path cannot end with a trailing slash when configured to strip:', route.method, route.path);

--- a/test/route.js
+++ b/test/route.js
@@ -85,6 +85,15 @@ describe('Route', () => {
         }).to.throw(/Invalid route options/);
     });
 
+    it('throws an error when a route uses an engine unsupported method', () => {
+
+        expect(() => {
+
+            const server = Hapi.server();
+            server.route({ method: 'HAPIIII', path: '/', handler: () => null });
+        }).to.throw(/Unsupported "method" for route/);
+    });
+
     it('throws an error when a route uses the HEAD method', () => {
 
         expect(() => {


### PR DESCRIPTION
Use the node.js built-in parseable http method list to reject routes that can never be reached.

Given that this will make hapi fail to start on existing code that inadvertently uses an unsupported method (maybe a typo), this might be more suited for including in a breaking release.