### PR TITLE
Fix CI on node 18.19.0+

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -4,6 +4,6 @@ const Somever = require('@hapi/somever');
 
 module.exports = {
     'coverage-predicates': {
-        allowsStoppedReq: Somever.match(process.version, '<=18'),
+        allowsStoppedReq: Somever.match(process.version, '<18.19.0'),
     }
 };


### PR DESCRIPTION
Node 18.19.0 no longer allows requests after close().