### PR TITLE
types: allow server.match to receive lowercased methods

### DIFF
--- a/lib/types/server/server.d.ts
+++ b/lib/types/server/server.d.ts
@@ -475,7 +475,7 @@ export class Server<A = ServerApplicationState> {
      * @return Return value: the route information if found, otherwise null.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servermatchmethod-path-host)
      */
-    match(method: HTTP_METHODS, path: string, host?: string | undefined): RequestRoute | null;
+    match(method: HTTP_METHODS | Lowercase<HTTP_METHODS>, path: string, host?: string | undefined): RequestRoute | null;
 
     /**
      * Registers a server method where:

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -4,6 +4,7 @@ import { expect } from '@hapi/code';
 import {
     Plugin,
     Request,
+    RequestRoute,
     ResponseToolkit,
     Server,
     ServerRoute,
@@ -77,7 +78,7 @@ const plugin: Plugin<TestPluginOptions, TestPluginDecorations> = {
     register: function (srv: MyServer, options) {
 
         check.type<TestPluginOptions>(options);
-        
+
         srv.expose({
             add: function (a: number, b: number) {
 
@@ -88,6 +89,9 @@ const plugin: Plugin<TestPluginOptions, TestPluginDecorations> = {
 };
 
 const loadedServer = await server.register({ plugin, options: { x: 10 } });
+
+check.type<RequestRoute | null>(server.match('GET', '/'));
+check.type<RequestRoute | null>(server.match('get', '/'));
 
 const sum = loadedServer.plugins.test.add(1, 2);
 expect(sum).to.equal(130);


### PR DESCRIPTION
#4493 caused a compilation failure when reinjecting `request.method` into `server.match` on my project.