### PR TITLE
fix: 🐛 route payload options missing types

### DIFF
--- a/lib/types/route.d.ts
+++ b/lib/types/route.d.ts
@@ -256,6 +256,13 @@ export interface RouteOptionsPayload {
     maxBytes?: number | undefined;
 
     /**
+     * @default 1000
+     * Limits the size of incoming payloads to the specified byte count. Allowing very large payloads may cause the server to run out of memory.
+     * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionspayloadmaxparts)
+     */
+    maxParts?: number;
+
+    /**
      * @default none.
      * Overrides payload processing for multipart requests. Value can be one of:
      * * false - disable multipart processing.
@@ -267,12 +274,7 @@ export interface RouteOptionsPayload {
      * * * * payload - the processed part payload.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionspayloadmultipart)
      */
-    multipart?:
-        | false
-        | {
-              output: PayloadOutput | 'annotated';
-          }
-        | undefined;
+    multipart?: boolean | { output: PayloadOutput | 'annotated' };
 
     /**
      * @default 'data'.

--- a/lib/types/route.d.ts
+++ b/lib/types/route.d.ts
@@ -257,7 +257,7 @@ export interface RouteOptionsPayload {
 
     /**
      * @default 1000
-     * Limits the size of incoming payloads to the specified byte count. Allowing very large payloads may cause the server to run out of memory.
+     * Limits the number of parts allowed in multipart payloads.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionspayloadmaxparts)
      */
     maxParts?: number;

--- a/lib/types/server/methods.d.ts
+++ b/lib/types/server/methods.d.ts
@@ -17,6 +17,8 @@ export type ServerMethod = (...args: any[]) => any;
  */
 export interface ServerMethodCache extends PolicyOptions<any> {
     generateTimeout: number | false;
+    cache?: string;
+    segment?: string;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@hapi/bounce": "^3.0.1",
     "@hapi/call": "^9.0.1",
     "@hapi/catbox": "^12.1.1",
-    "@hapi/catbox-memory": "^6.0.1",
+    "@hapi/catbox-memory": "^6.0.2",
     "@hapi/heavy": "^8.0.1",
     "@hapi/hoek": "^11.0.2",
     "@hapi/mimos": "^7.0.1",


### PR DESCRIPTION
🎟️ Fixes #4505 #4501

Additionally adds missing method cache typings to select cache name and segment name