### PR TITLE
fix: 🐛 allow typed server methods access cache methods

### DIFF
--- a/lib/types/server/methods.d.ts
+++ b/lib/types/server/methods.d.ts
@@ -7,7 +7,7 @@ export type CachedServerMethod<T extends AnyMethod> = T & {
         drop(...args: Parameters<T>): Promise<void>;
         stats: CacheStatisticsObject
     }
-}
+};
 
 /**
  * The method function with a signature async function(...args, [flags]) where:
@@ -16,7 +16,7 @@ export type CachedServerMethod<T extends AnyMethod> = T & {
  * * * ttl - 0 if result is valid but cannot be cached. Defaults to cache policy.
  * For reference [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servermethodname-method-options)
  */
-export type ServerMethod = AnyMethod
+export type ServerMethod = AnyMethod;
 
 /**
  * The same cache configuration used in server.cache().

--- a/lib/types/server/methods.d.ts
+++ b/lib/types/server/methods.d.ts
@@ -1,4 +1,13 @@
-import { PolicyOptions } from "@hapi/catbox";
+import { CacheStatisticsObject, PolicyOptions } from "@hapi/catbox";
+
+type AnyMethod = (...args: any[]) => any;
+
+export type CachedServerMethod<T extends AnyMethod> = T & {
+    cache?: {
+        drop(...args: Parameters<T>): Promise<void>;
+        stats: CacheStatisticsObject
+    }
+}
 
 /**
  * The method function with a signature async function(...args, [flags]) where:
@@ -7,7 +16,7 @@ import { PolicyOptions } from "@hapi/catbox";
  * * * ttl - 0 if result is valid but cannot be cached. Defaults to cache policy.
  * For reference [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servermethodname-method-options)
  */
-export type ServerMethod = (...args: any[]) => any;
+export type ServerMethod = AnyMethod
 
 /**
  * The same cache configuration used in server.cache().
@@ -71,8 +80,16 @@ export interface ServerMethodConfigurationObject {
     options?: ServerMethodOptions | undefined;
 }
 
+interface BaseServerMethods {
+    [name: string]: (
+        ServerMethod |
+        CachedServerMethod<ServerMethod> |
+        BaseServerMethods
+    );
+}
+
 /**
  * An empty interface to allow typings of custom server.methods.
  */
-export interface ServerMethods extends Record<string, ServerMethod> {
+export interface ServerMethods extends BaseServerMethods {
 }

--- a/lib/types/server/server.d.ts
+++ b/lib/types/server/server.d.ts
@@ -52,7 +52,6 @@ import {
 } from './methods';
 import { ServerOptions } from './options';
 import { ServerState, ServerStateCookieOptions } from './state';
-import { CacheStatisticsObject } from '@hapi/catbox';
 
 /**
  *  User-extensible type for application specific state (`server.app`).
@@ -204,7 +203,7 @@ export class Server<A = ServerApplicationState> {
      * server method name is an object property.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servermethods
      */
-    readonly methods: ServerMethods
+    readonly methods: ServerMethods;
 
     /**
      * Provides access to the server MIME database used for setting content-type information. The object must not be

--- a/lib/types/server/server.d.ts
+++ b/lib/types/server/server.d.ts
@@ -52,6 +52,7 @@ import {
 } from './methods';
 import { ServerOptions } from './options';
 import { ServerState, ServerStateCookieOptions } from './state';
+import { CacheStatisticsObject } from '@hapi/catbox';
 
 /**
  *  User-extensible type for application specific state (`server.app`).
@@ -203,7 +204,7 @@ export class Server<A = ServerApplicationState> {
      * server method name is an object property.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servermethods
      */
-    readonly methods: ServerMethods;
+    readonly methods: ServerMethods
 
     /**
      * Provides access to the server MIME database used for setting content-type information. The object must not be

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -10,7 +10,8 @@ import {
     Server,
     ServerRoute,
     server as createServer,
-    ServerRegisterPluginObject
+    Lifecycle,
+    CachedServerMethod
 } from '../..';
 
 const { expect: check } = lab;
@@ -114,6 +115,14 @@ server.cache.provision({
     }
 })
 
+declare module '../..' {
+    interface ServerMethods {
+        test: {
+            add: CachedServerMethod<((a: number, b: number) => number)>;
+        }
+    }
+}
+
 server.method('test.add', (a: number, b: number) => a + b, {
     bind: server,
     cache: {
@@ -124,3 +133,5 @@ server.method('test.add', (a: number, b: number) => a + b, {
     },
     generateKey: (a: number, b: number) => `${a}${b}`
 });
+
+server.methods.test.add.cache?.drop(1, 2);


### PR DESCRIPTION
~also fix pre typing issue~ would be fixed by https://github.com/hapijs/hapi/pull/4489 . Change removed.