### PR TITLE
Added isoTimestamp option

### DIFF
--- a/API.md
+++ b/API.md
@@ -53,6 +53,13 @@ the framework.
 
 Cannot be set to `false` along with a [`port`](#server.options.port) value.
 
+#### <a name="server.options.isotimestamp" /> `server.options.isoTimestamp`
+
+Default value: `false`.
+
+If `true`, shows the log timestamp in ISO-8601 UTC format. If `false`, shows the log timestamp
+in milliseconds since 1970-01-01.
+
 #### <a name="server.options.cache" /> `server.options.cache`
 
 Default value: `{ provider: { constructor: require('@hapi/catbox-memory'), options: { partition: 'hapi-cache' } } }`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -239,6 +239,7 @@ internals.server = Validate.object({
     address: Validate.string().hostname(),
     app: Validate.object().allow(null),
     autoListen: Validate.boolean(),
+    isoTimestamp: Validate.boolean().default(false),
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
         minBytes: Validate.number().min(1).integer().default(1024)

--- a/lib/core.js
+++ b/lib/core.js
@@ -660,7 +660,7 @@ exports = module.exports = internals.Core = class {
             tags = [tags];
         }
 
-        const timestamp = Date.now();
+        const timestamp = this.settings.isoTimestamp ? new Date(Date.now()).toISOString() : Date.now();
         const field = data instanceof Error ? 'error' : 'data';
 
         let event = { timestamp, tags, [field]: data, channel };

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -51,6 +51,13 @@ export interface ServerOptions {
      */
     autoListen?: boolean | undefined;
 
+   /**
+     * @default false.
+     * Used to control the log timestamp format. When false, shows the timestamp in millisceonds since 1970-01-01. When true, shows the timestamp in ISO-8601 format using UTC timezone.
+     * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serveroptionsisotimestamp)
+     */
+    isoTimestamp?: boolean | undefined;
+
     /**
      * @default { engine: require('@hapi/catbox-memory' }.
      * Sets up server-side caching providers. Every server includes a default cache for storing application state. By default, a simple memory-based cache is created which has limited capacity and


### PR DESCRIPTION
When set to true, it renders the timestamp in log entries using `Date.toIsoString()`, which is easier to read by humans than the default of milliseconds.