### PR TITLE
Test that logged simple handler errors has a stack

### DIFF
--- a/test/handler.js
+++ b/test/handler.js
@@ -578,6 +578,7 @@ describe('handler', () => {
             expect(event.error.isBoom).to.equal(true);
             expect(event.error.output.statusCode).to.equal(403);
             expect(event.error.message).to.equal('Forbidden');
+            expect(event.error.stack).to.exist();
         });
     });
 


### PR DESCRIPTION
This adds a test for the `error.stack` property to illustrate a node v22 regression.

This should be able to be fixed with https://github.com/hapijs/hoek/pull/390.

Again, feel free to backport my old PR to fix this, but personally I would prefer to declare that Hapi v21 and any modules that use `Hoek.clone()` on potential errors (at least Hoek, Boom, and Podium) does not support node 21+.