### PR TITLE
Update decorator types to be correct

### DIFF
--- a/lib/types/plugin.d.ts
+++ b/lib/types/plugin.d.ts
@@ -248,12 +248,7 @@ export interface HandlerDecorationMethod {
 }
 
 /**
- * The general case for decorator values added via server.decorate.
- */
-export type DecorationValue<T> = DecorationMethod<T> | any;
-
-/**
- * Decorator function.
+ * The general case for decorators added via server.decorate.
  */
 export type DecorationMethod<T> = (this: T, ...args: any[]) => any;
 

--- a/lib/types/plugin.d.ts
+++ b/lib/types/plugin.d.ts
@@ -248,7 +248,12 @@ export interface HandlerDecorationMethod {
 }
 
 /**
- * The general case for decorators added via server.decorate.
+ * The general case for decorator values added via server.decorate.
+ */
+export type DecorationValue<T> = DecorationMethod<T> | any;
+
+/**
+ * Decorator function.
  */
 export type DecorationMethod<T> = (this: T, ...args: any[]) => any;
 

--- a/lib/types/server/server.d.ts
+++ b/lib/types/server/server.d.ts
@@ -13,7 +13,7 @@ import {
     ServerRegisterPluginObject,
     ServerRegisterPluginObjectArray,
     DecorateName,
-    DecorationMethod,
+    DecorationValue,
     HandlerDecorationMethod,
     PluginProperties
 } from '../plugin';
@@ -310,13 +310,13 @@ export class Server<A = ServerApplicationState> {
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverdecoratetype-property-method-options)
      */
     decorate(type: 'handler', property: DecorateName, method: HandlerDecorationMethod, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
-    decorate(type: 'request', property: DecorateName, method: (existing: ((...args: any[]) => any)) => (request: Request) => DecorationMethod<Request>, options: {apply: true, extend: true}): void;
-    decorate(type: 'request', property: DecorateName, method: (request: Request) => DecorationMethod<Request>, options: {apply: true, extend?: boolean | undefined}): void;
-    decorate(type: 'request', property: DecorateName, method: DecorationMethod<Request>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
-    decorate(type: 'toolkit', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationMethod<ResponseToolkit>, options: {apply?: boolean | undefined, extend: true}): void;
-    decorate(type: 'toolkit', property: DecorateName, method: DecorationMethod<ResponseToolkit>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
-    decorate(type: 'server', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationMethod<Server>, options: {apply?: boolean | undefined, extend: true}): void;
-    decorate(type: 'server', property: DecorateName, method: DecorationMethod<Server>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'request', property: DecorateName, method: (existing: ((...args: any[]) => any)) => (request: Request) => DecorationValue<Request>, options: {apply: true, extend: true}): void;
+    decorate(type: 'request', property: DecorateName, method: (request: Request) => DecorationValue<Request>, options: {apply: true, extend?: boolean | undefined}): void;
+    decorate(type: 'request', property: DecorateName, method: DecorationValue<Request>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'toolkit', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationValue<ResponseToolkit>, options: {apply?: boolean | undefined, extend: true}): void;
+    decorate(type: 'toolkit', property: DecorateName, method: DecorationValue<ResponseToolkit>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'server', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationValue<Server>, options: {apply?: boolean | undefined, extend: true}): void;
+    decorate(type: 'server', property: DecorateName, method: DecorationValue<Server>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
 
     /**
      * Used within a plugin to declare a required dependency on other plugins where:

--- a/lib/types/server/server.d.ts
+++ b/lib/types/server/server.d.ts
@@ -13,7 +13,7 @@ import {
     ServerRegisterPluginObject,
     ServerRegisterPluginObjectArray,
     DecorateName,
-    DecorationValue,
+    DecorationMethod,
     HandlerDecorationMethod,
     PluginProperties
 } from '../plugin';
@@ -310,13 +310,20 @@ export class Server<A = ServerApplicationState> {
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverdecoratetype-property-method-options)
      */
     decorate(type: 'handler', property: DecorateName, method: HandlerDecorationMethod, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
-    decorate(type: 'request', property: DecorateName, method: (existing: ((...args: any[]) => any)) => (request: Request) => DecorationValue<Request>, options: {apply: true, extend: true}): void;
-    decorate(type: 'request', property: DecorateName, method: (request: Request) => DecorationValue<Request>, options: {apply: true, extend?: boolean | undefined}): void;
-    decorate(type: 'request', property: DecorateName, method: DecorationValue<Request>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
-    decorate(type: 'toolkit', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationValue<ResponseToolkit>, options: {apply?: boolean | undefined, extend: true}): void;
-    decorate(type: 'toolkit', property: DecorateName, method: DecorationValue<ResponseToolkit>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
-    decorate(type: 'server', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationValue<Server>, options: {apply?: boolean | undefined, extend: true}): void;
-    decorate(type: 'server', property: DecorateName, method: DecorationValue<Server>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'request', property: DecorateName, method: (existing: ((...args: any[]) => any)) => (request: Request) => DecorationMethod<Request>, options: {apply: true, extend: true}): void;
+    decorate(type: 'request', property: DecorateName, method: (request: Request) => DecorationMethod<Request>, options: {apply: true, extend?: boolean | undefined}): void;
+    decorate(type: 'request', property: DecorateName, method: DecorationMethod<Request>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'request', property: DecorateName, value: (existing: ((...args: any[]) => any)) => (request: Request) => any, options: {apply: true, extend: true}): void;
+    decorate(type: 'request', property: DecorateName, value: (request: Request) => any, options: {apply: true, extend?: boolean | undefined}): void;
+    decorate(type: 'request', property: DecorateName, value: any, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'toolkit', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationMethod<ResponseToolkit>, options: {apply?: boolean | undefined, extend: true}): void;
+    decorate(type: 'toolkit', property: DecorateName, method: DecorationMethod<ResponseToolkit>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'toolkit', property: DecorateName, value: (existing: ((...args: any[]) => any)) => any, options: {apply?: boolean | undefined, extend: true}): void;
+    decorate(type: 'toolkit', property: DecorateName, value: any, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'server', property: DecorateName, method: (existing: ((...args: any[]) => any)) => DecorationMethod<Server>, options: {apply?: boolean | undefined, extend: true}): void;
+    decorate(type: 'server', property: DecorateName, method: DecorationMethod<Server>, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
+    decorate(type: 'server', property: DecorateName, value: (existing: ((...args: any[]) => any)) => any, options: {apply?: boolean | undefined, extend: true}): void;
+    decorate(type: 'server', property: DecorateName, value: any, options?: {apply?: boolean | undefined, extend?: boolean | undefined}): void;
 
     /**
      * Used within a plugin to declare a required dependency on other plugins where:

--- a/test/server.js
+++ b/test/server.js
@@ -294,7 +294,7 @@ describe('Server', () => {
 
     describe('decorate()', () => {
 
-        it('decorates request', async () => {
+        it('decorates request with function', async () => {
 
             const server = Hapi.server();
 
@@ -314,6 +314,25 @@ describe('Server', () => {
             const res = await server.inject('/');
             expect(res.statusCode).to.equal(200);
             expect(res.result).to.match(/^.*\:.*\:.*\:.*\:.*$/);
+        });
+
+        it('decorates request with object', async () => {
+
+            const server = Hapi.server();
+
+            const customData = { id: '123' };
+
+            server.decorate('request', 'customData', customData);
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: (request) => request.customData
+            });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal({ id: '123' });
         });
 
         it('decorates request (apply)', async () => {
@@ -364,6 +383,26 @@ describe('Server', () => {
             const res = await server.inject('/');
             expect(res.statusCode).to.equal(200);
             expect(res.result).to.match(/^.*\:.*\:.*\:.*\:.*!$/);
+        });
+
+        it('decorates request (extend) with an array', async () => {
+
+            const server = Hapi.server();
+
+            const items = ['one', 'two', 'three'];
+
+            server.decorate('request', 'items', items);
+            server.decorate('request', 'items', (existing) => [...existing, 'four'], { extend: true });
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: (request) => request.items
+            });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal([...items, 'four']);
         });
 
         it('decorates request (apply + extend)', async () => {
@@ -442,6 +481,25 @@ describe('Server', () => {
             const res = await server.inject('/');
             expect(res.statusCode).to.equal(200);
             expect(res.result.status).to.equal('ok');
+        });
+
+        it('decorates toolkit with boolean', async () => {
+
+            const server = Hapi.server();
+
+            const isOk = true;
+
+            server.decorate('toolkit', 'isOk', isOk);
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: (request, h) => h.isOk
+            });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal(true);
         });
 
         it('add new handler', async () => {
@@ -557,6 +615,30 @@ describe('Server', () => {
             const res = await server.inject('/');
             expect(res.statusCode).to.equal(200);
             expect(res.result).to.equal('ok');
+        });
+
+        it('decorates server with Map', async () => {
+
+            const server = Hapi.server();
+
+            const itemsMap = new Map();
+            itemsMap.set('one', 'One');
+            itemsMap.set('two', 'Two');
+            itemsMap.set('three', 'Three');
+
+            server.decorate('server', 'itemsMap', itemsMap);
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: (request) => request.server.itemsMap
+            });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(200);
+            expect(res.result.get('one')).to.equal('One');
+            expect(res.result.get('two')).to.equal('Two');
+            expect(res.result.get('three')).to.equal('Three');
         });
 
         it('throws on double server decoration', () => {


### PR DESCRIPTION
- The code currently allows any value to be added as a decorator, but the types do not. This work allows any value to be added to a decorator by updating the types to reflect what the code does
- Add relevant tests
- Update inline docs
- Create and export `DecorationValue` type
- Fixes #4524