### PR TITLE
Add custom graceful shutdown handler

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -285,6 +285,7 @@ internals.server = Validate.object({
         .default(),
     routes: internals.routeBase.default(),
     state: Validate.object(),                                    // Cookie defaults
+    stoppingHandler: Validate.function(),
     tls: Validate.alternatives([
         Validate.object().allow(null),
         Validate.boolean()

--- a/lib/core.js
+++ b/lib/core.js
@@ -81,6 +81,7 @@ exports = module.exports = internals.Core = class {
     toolkit = new Toolkit.Manager();
     type = null;
     validator = null;
+    stoppingHandler = (req, res) => req.destroy();
 
     extensionsSeq = 0;                                                         // Used to keep absolute order of extensions based on the order added across locations
     extensions = {
@@ -129,6 +130,10 @@ exports = module.exports = internals.Core = class {
 
         if (this.settings.routes.validate.validator) {
             this.validator = Validation.validator(this.settings.routes.validate.validator);
+        }
+
+        if (typeof this.settings.stoppingHandler === 'function') {
+            this.stoppingHandler = this.settings.stoppingHandler;
         }
 
         this.listener = this._createListener();
@@ -506,11 +511,9 @@ exports = module.exports = internals.Core = class {
 
         return (req, res) => {
 
-            // $lab:coverage:off$ $not:allowsStoppedReq$
             if (this.phase === 'stopping') {
-                return req.destroy();
+                return this.stoppingHandler(req, res);
             }
-            // $lab:coverage:on$ $not:allowsStoppedReq$
 
             // Create request
 

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -7,6 +7,7 @@ import { PluginSpecificConfiguration } from '../plugin';
 import { RouteOptions } from '../route';
 import { CacheProvider, ServerOptionsCache } from './cache';
 import { SameSitePolicy } from './state';
+import { Lifecycle } from '../utils';
 
 export interface ServerOptionsCompression {
     minBytes: number;
@@ -218,6 +219,13 @@ export interface ServerOptions {
         isSameSite?: SameSitePolicy | undefined;
         encoding?: 'none' | 'base64' | 'base64json' | 'form' | 'iron' | undefined;
     } | undefined;
+
+    /**
+     * @default Destroys any incoming requests without further processing (client receives `ECONNRESET`).
+     * Custom handler to override the response to incoming request during the gracefully shutdown period.
+     * NOTE: The handler is called before decorating (and authenticating) the request object. The `req` object might be much simpler than the usual Lifecycle method.
+     */
+    stoppingHandler?: Lifecycle.Method;
 
     /**
      * @default none.


### PR DESCRIPTION
#4473 introduced a piece of logic to immediately destroy the requests during the `stopping` phase: https://github.com/hapijs/hapi/blob/22377ee7329b553f9ef72ff869940dce05523920/lib/core.js#L509-L513

This caused a breaking change in my API where I have a custom `onRequest` handler that intercepts the request and returns a _graceful_ `503` message explaining that the server is going down.

I tried to add a custom handler replacement in this PR, but I wanted to cover that piece of code first with the tests. I can't get my head around as to why my new tests are not hitting that code path. Can someone help me to figure it out?

Thanks!