### PR TITLE
Don't destroy incoming requests during the stopping phase

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const Somever = require('@hapi/somever');
-
-module.exports = {
-    'coverage-predicates': {
-        allowsStoppedReq: Somever.match(process.version, '<18.19.0'),
-    }
-};

--- a/lib/core.js
+++ b/lib/core.js
@@ -506,12 +506,6 @@ exports = module.exports = internals.Core = class {
 
         return (req, res) => {
 
-            // $lab:coverage:off$ $not:allowsStoppedReq$
-            if (this.phase === 'stopping') {
-                return req.destroy();
-            }
-            // $lab:coverage:on$ $not:allowsStoppedReq$
-
             // Create request
 
             const request = Request.generate(this.root, req, res, options);


### PR DESCRIPTION
This should fix the issue reported in #4528.