### PR TITLE
fix: complies access scope validation to RFC8693

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -555,9 +555,10 @@ internals.validateScope = function (credentials, scope, type) {
         return true;
     }
 
-    const count = typeof credentials.scope === 'string' ?
-        scope[type].indexOf(credentials.scope) !== -1 ? 1 : 0 :
-        Hoek.intersect(scope[type], credentials.scope).length;
+    const count = Hoek.intersect(
+        scope[type],
+        (typeof credentials.scope === 'string') ? credentials.scope.split(' ') : credentials.scope
+    ).length;
 
     if (type === 'forbidden') {
         return count === 0;


### PR DESCRIPTION
## Problem

[RFC8693](https://datatracker.ietf.org/doc/html/rfc8693) on OAuth2.0 Token Exchange specifies that [credentials scope](https://datatracker.ietf.org/doc/html/rfc8693#name-scope-scopes-claim) may contain a space-separated list of scopes, however hapi’s access scope only supports either a string containing a single scope or an array containing a list of scopes.

## Proposal

Allow using a string containing a space-separated list of scopes.