### PR TITLE
feat: add `br` & `zstd` to supported compression 🗜️ algos

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -12,4 +12,4 @@ jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
     with:
-      min-node-version: 22
+      min-node-version: 14

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -12,4 +12,4 @@ jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
     with:
-      min-node-version: 14
+      min-node-version: 22

--- a/API.md
+++ b/API.md
@@ -119,7 +119,7 @@ Available values:
 
 Default value: `false`.
 
-Enables built-in support of `zstd` compression algorithm (node `>=22.15.0`).  
+Enables built-in support of `zstd` compression algorithm (node: `>=22.15.0`).  
 Zstd compression is experimental (see [node Zstd documentation](https://nodejs.org/api/zlib.html#zlibcreatezstdcompressoptions)).
 
 Available values:

--- a/API.md
+++ b/API.md
@@ -109,11 +109,24 @@ Default value: `false`.
 
 Enables built-in support of `brotli` compression algorithm.
 
+Available values:
+
+- `false` - no compression.
+- `true` - compression with system defaults.
+- [`BrotliOptions`](https://nodejs.org/api/zlib.html#class-brotlioptions) - compression with specified options.
+
 ##### <a name="server.options.compression.enableZstd" /> `server.options.compression.enableZstd`
 
 Default value: `false`.
 
-Enables built-in support of `zstd` compression algorithm.
+Enables built-in support of `zstd` compression algorithm.  
+Zstd compression is experimental (see [node Zstd documentation](https://nodejs.org/api/zlib.html#zlibcreatezstdcompressoptions)).
+
+Available values:
+
+- `false` - no compression.
+- `true` - compression with system defaults.
+- [`ZstdOptions`](https://nodejs.org/api/zlib.html#class-zstdoptions) - compression with specified options.
 
 ##### <a name="server.options.compression.minBytes" /> `server.options.compression.minBytes`
 

--- a/API.md
+++ b/API.md
@@ -113,7 +113,8 @@ Available values for each kv pair:
 
 - `true` - enables the encoding with default options.
 - `false` - disables the encoding.
-- `{...options}` - enables the encoding using custom options specific to each particular algorithm.
+
+Note that default encoder and decoder options can be configured at the server default [route configuration](#server.options.routes)
 
 Zstd compression is experimental (see [node Zstd documentation](https://nodejs.org/api/zlib.html#zlibcreatezstdcompressoptions)).
 
@@ -1314,8 +1315,7 @@ are called, where:
 
 ### <a name="server.decoder()" /> `server.decoder(encoding, decoder)`
 
-Registers a custom content decoding compressor to extend the built-in support for `'gzip'` and
-'`deflate`' where:
+Registers a custom content decoding compressor to extend the built-in support where:
 
 - `encoding` - the decoder name string.
 
@@ -1511,8 +1511,7 @@ The `dependencies` configuration accepts one of:
 
 ### <a name="server.encoder()" /> `server.encoder(encoding, encoder)`
 
-Registers a custom content encoding compressor to extend the built-in support for `'gzip'` and
-'`deflate`' where:
+Registers a custom content encoding compressor to extend the built-in support where:
 
 - `encoding` - the encoder name string.
 

--- a/API.md
+++ b/API.md
@@ -103,6 +103,18 @@ Default value: `{ minBytes: 1024 }`.
 Defines server handling of content encoding requests. If `false`, response content encoding is
 disabled and no compression is performed by the server.
 
+##### <a name="server.options.compression.enableBrotli" /> `server.options.compression.enableBrotli`
+
+Default value: `false`.
+
+Enables built-in support of `brotli` compression algorithm.
+
+##### <a name="server.options.compression.enableZstd" /> `server.options.compression.enableZstd`
+
+Default value: `false`.
+
+Enables built-in support of `zstd` compression algorithm.
+
 ##### <a name="server.options.compression.minBytes" /> `server.options.compression.minBytes`
 
 Default value: '1024'.

--- a/API.md
+++ b/API.md
@@ -119,7 +119,7 @@ Available values:
 
 Default value: `false`.
 
-Enables built-in support of `zstd` compression algorithm.  
+Enables built-in support of `zstd` compression algorithm (node `>=22.15.0`).  
 Zstd compression is experimental (see [node Zstd documentation](https://nodejs.org/api/zlib.html#zlibcreatezstdcompressoptions)).
 
 Available values:

--- a/API.md
+++ b/API.md
@@ -98,10 +98,17 @@ assigned one or more (array):
 
 #### <a name="server.options.compression" /> `server.options.compression`
 
-Default value: `{ encodings: { gzip: true, deflate: true, br: false, zstd: false }, minBytes: 1024 }`.
+Default value: `{ decompress: true, encodings: { gzip: true, deflate: true, br: false, zstd: false }, minBytes: 1024 }`.
 
 Defines server handling of content encoding requests. If `false`, response content encoding is
 disabled, and no compression is performed by the server.
+
+#### <a name="server.options.compression.decompress" /> `server.options.compression.decompress`
+
+Default value: `true`.
+
+Controls whether the server automatically decompresses incoming content encoding requests.
+If `false`, no decompression automatically performed by the server.
 
 #### <a name="server.options.compression.encodings" /> `server.options.compression.encodings`
 

--- a/API.md
+++ b/API.md
@@ -98,35 +98,27 @@ assigned one or more (array):
 
 #### <a name="server.options.compression" /> `server.options.compression`
 
-Default value: `{ minBytes: 1024 }`.
+Default value: `{ encodings: { gzip: true, deflate: true, br: false, zstd: false }, minBytes: 1024 }`.
 
 Defines server handling of content encoding requests. If `false`, response content encoding is
-disabled and no compression is performed by the server.
+disabled, and no compression is performed by the server.
 
-##### <a name="server.options.compression.enableBrotli" /> `server.options.compression.enableBrotli`
+#### <a name="server.options.compression.encodings" /> `server.options.compression.encodings`
 
-Default value: `false`.
+Default value: `{ gzip: true, deflate: true, br: false, zstd: false }`.
 
-Enables built-in support of `brotli` compression algorithm.
+Configures the built-in support of compression algorithms aka encodings, represented by the object of kv pairs.
 
-Available values:
+Available values for each kv pair:
 
-- `false` - no compression.
-- `true` - compression with system defaults.
-- [`BrotliOptions`](https://nodejs.org/api/zlib.html#class-brotlioptions) - compression with specified options.
+- `true` - enables the encoding with default options.
+- `false` - disables the encoding.
+- `{...options}` - enables the encoding using custom options specific to each particular algorithm.
 
-##### <a name="server.options.compression.enableZstd" /> `server.options.compression.enableZstd`
-
-Default value: `false`.
-
-Enables built-in support of `zstd` compression algorithm (node: `>=22.15.0`).  
 Zstd compression is experimental (see [node Zstd documentation](https://nodejs.org/api/zlib.html#zlibcreatezstdcompressoptions)).
 
-Available values:
-
-- `false` - no compression.
-- `true` - compression with system defaults.
-- [`ZstdOptions`](https://nodejs.org/api/zlib.html#class-zstdoptions) - compression with specified options.
+Disabling an encoding allows custom compression algorithm to be applied by
+[`server.encoder()`](#server.encoder()) and [`server.decoder()`](#server.decoder()).
 
 ##### <a name="server.options.compression.minBytes" /> `server.options.compression.minBytes`
 

--- a/API.md
+++ b/API.md
@@ -110,13 +110,6 @@ Default value: '1024'.
 Sets the minimum response payload size in bytes that is required for content encoding compression.
 If the payload size is under the limit, no compression is performed.
 
-##### <a name="server.options.compression.priority" /> `server.options.compression.priority`
-
-Default value: `null`.
-
-Sets the priority for content encoding compression algorithms in descending order,
-e.g.: `['br', 'gzip', 'deflate']`.
-
 #### <a name="server.options.debug" /> `server.options.debug`
 
 Default value: `{ request: ['implementation'] }`.

--- a/API.md
+++ b/API.md
@@ -110,6 +110,13 @@ Default value: '1024'.
 Sets the minimum response payload size in bytes that is required for content encoding compression.
 If the payload size is under the limit, no compression is performed.
 
+##### <a name="server.options.compression.priority" /> `server.options.compression.priority`
+
+Default value: `null`.
+
+Sets the priority for content encoding compression algorithms in descending order,
+e.g.: `['zstd', 'br', 'gzip', 'deflate']`.
+
 #### <a name="server.options.debug" /> `server.options.debug`
 
 Default value: `{ request: ['implementation'] }`.

--- a/API.md
+++ b/API.md
@@ -110,6 +110,13 @@ Default value: '1024'.
 Sets the minimum response payload size in bytes that is required for content encoding compression.
 If the payload size is under the limit, no compression is performed.
 
+##### <a name="server.options.compression.priority" /> `server.options.compression.priority`
+
+Default value: `null`.
+
+Sets the priority for content encoding compression algorithms in descending order,
+e.g.: `['br', 'gzip', 'deflate']`.
+
 #### <a name="server.options.debug" /> `server.options.debug`
 
 Default value: `{ request: ['implementation'] }`.

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -16,30 +16,64 @@ const internals = {
         'deflate, gzip',
         'gzip',
         'deflate'
-    ]
+    ],
+    provision: new Map([
+        ['zstd', [
+            (options) => Zlib.createZstdCompress(options),
+            (options) => Zlib.createZstdDecompress(options),
+            {
+                params: {
+                    [Zlib.constants.ZSTD_c_compressionLevel]: 6
+                }
+            }
+        ]],
+        ['br', [
+            (options) => Zlib.createBrotliCompress(options),
+            (options) => Zlib.createBrotliDecompress(options),
+            {
+                params: {
+                    [Zlib.constants.BROTLI_PARAM_QUALITY]: 4
+                }
+            }
+        ]],
+        ['deflate', [
+            (options) => Zlib.createDeflate(options),
+            (options) => Zlib.createInflate(options)
+        ]],
+        ['gzip', [
+            (options) => Zlib.createGzip(options),
+            (options) => Zlib.createGunzip(options)
+        ]]
+    ])
 };
 
 
 exports = module.exports = internals.Compression = class {
 
-    decoders = {
-        gzip: (options) => Zlib.createGunzip(options),
-        deflate: (options) => Zlib.createInflate(options)
-    };
+    decoders = {};
 
-    encodings = ['identity', 'gzip', 'deflate'];
+    encodings = ['identity'];
 
     encoders = {
-        identity: null,
-        gzip: (options) => Zlib.createGzip(options),
-        deflate: (options) => Zlib.createDeflate(options)
+        identity: null
     };
 
     #common = null;
 
-    constructor() {
+    constructor({ compression }) {
 
-        this._updateCommons();
+        if (!compression) {
+            this._updateCommons();
+        }
+
+        for (const [alg, [encoder, decoder, defaults = {}]] of internals.provision.entries()) {
+            let conditions = compression?.encodings?.[alg];
+            if (conditions) {
+                conditions = Hoek.applyToDefaults(defaults, conditions);
+                this.addEncoder(alg, (options = {}) => encoder(Hoek.applyToDefaults(conditions, options)));
+                this.addDecoder(alg, (options = {}) => decoder(Hoek.applyToDefaults(conditions, options)));
+            }
+        }
     }
 
     _updateCommons() {
@@ -123,29 +157,6 @@ exports = module.exports = internals.Compression = class {
         const encoder = this.encoders[encoding];
         Hoek.assert(encoder !== undefined, `Unknown encoding ${encoding}`);
         return encoder(request.route.settings.compression[encoding]);
-    }
-
-    enableBrotliCompression(compressionOptions) {
-
-        const defaults = {
-            params: {
-                [Zlib.constants.BROTLI_PARAM_QUALITY]: 4
-            }
-        };
-        compressionOptions = Hoek.applyToDefaults(defaults, compressionOptions);
-        this.decoders.br = (options) => Zlib.createBrotliDecompress({ ...options, ...compressionOptions });
-        this.encoders.br = (options) => Zlib.createBrotliCompress({ ...options, ...compressionOptions });
-        this.setPriority(['br']);
-    }
-
-    enableZstdCompression(compressionOptions) {
-
-        /* $lab:coverage:off$ */
-        Hoek.assert(!!Zlib.constants.ZSTD_CLEVEL_DEFAULT, 'Zstd is not supported by the engine');
-        this.decoders.zstd = (options) => Zlib.createZstdDecompress({ ...options, ...compressionOptions });
-        this.encoders.zstd = (options) => Zlib.createZstdCompress({ ...options, ...compressionOptions });
-        this.setPriority(['zstd']);
-        /* $lab:coverage:on$ */
     }
 
     setPriority(priority) {

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -23,7 +23,8 @@ const internals = {
             (options) => Zlib.createZstdDecompress(options),
             {
                 params: {
-                    [Zlib.constants.ZSTD_c_compressionLevel]: 6
+                    [Zlib.constants.ZSTD_c_compressionLevel]: 6,
+                    [Zlib.constants.ZSTD_d_windowLogMax]: 0
                 }
             }
         ]],

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -140,10 +140,12 @@ exports = module.exports = internals.Compression = class {
 
     enableZstdCompression(compressionOptions) {
 
+        /* $lab:coverage:off$ */
         Hoek.assert(!!Zlib.constants.ZSTD_CLEVEL_DEFAULT, 'Zstd is not supported by the engine');
         this.decoders.zstd = (options) => Zlib.createZstdDecompress({ ...options, ...compressionOptions });
         this.encoders.zstd = (options) => Zlib.createZstdCompress({ ...options, ...compressionOptions });
         this.setPriority(['zstd']);
+        /* $lab:coverage:on$ */
     }
 
     setPriority(priority) {

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -23,20 +23,16 @@ const internals = {
 exports = module.exports = internals.Compression = class {
 
     decoders = {
-        br: (options) => Zlib.createBrotliDecompress(options),
         gzip: (options) => Zlib.createGunzip(options),
-        deflate: (options) => Zlib.createInflate(options),
-        zstd: (options) => Zlib.createZstdDecompress(options)
+        deflate: (options) => Zlib.createInflate(options)
     };
 
-    encodings = ['identity', 'zstd', 'br', 'gzip', 'deflate'];
+    encodings = ['identity', 'gzip', 'deflate'];
 
     encoders = {
         identity: null,
-        br: (options) => Zlib.createBrotliCompress(options),
         gzip: (options) => Zlib.createGzip(options),
-        deflate: (options) => Zlib.createDeflate(options),
-        zstd: (options) => Zlib.createZstdCompress(options)
+        deflate: (options) => Zlib.createDeflate(options)
     };
 
     #common = null;
@@ -129,9 +125,24 @@ exports = module.exports = internals.Compression = class {
         return encoder(request.route.settings.compression[encoding]);
     }
 
+    enableBrotliCompression() {
+
+        this.decoders.br = (options) => Zlib.createBrotliDecompress(options);
+        this.encoders.br = (options) => Zlib.createBrotliCompress(options);
+        this.setPriority(['br']);
+    }
+
+    enableZstdCompression() {
+
+        this.decoders.zstd = (options) => Zlib.createZstdDecompress(options);
+        this.encoders.zstd = (options) => Zlib.createZstdCompress(options);
+        this.setPriority(['zstd']);
+    }
+
     setPriority(priority) {
 
         this.encodings = [...new Set([...priority, ...this.encodings])];
+
         this._updateCommons();
     }
 };

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -127,6 +127,12 @@ exports = module.exports = internals.Compression = class {
 
     enableBrotliCompression(compressionOptions) {
 
+        const defaults = {
+            params: {
+                [Zlib.constants.BROTLI_PARAM_QUALITY]: 4
+            }
+        };
+        compressionOptions = Hoek.applyToDefaults(defaults, compressionOptions);
         this.decoders.br = (options) => Zlib.createBrotliDecompress({ ...options, ...compressionOptions });
         this.encoders.br = (options) => Zlib.createBrotliCompress({ ...options, ...compressionOptions });
         this.setPriority(['br']);

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -125,17 +125,17 @@ exports = module.exports = internals.Compression = class {
         return encoder(request.route.settings.compression[encoding]);
     }
 
-    enableBrotliCompression() {
+    enableBrotliCompression(compressionOptions) {
 
-        this.decoders.br = (options) => Zlib.createBrotliDecompress(options);
-        this.encoders.br = (options) => Zlib.createBrotliCompress(options);
+        this.decoders.br = (options) => Zlib.createBrotliDecompress({ ...options, ...compressionOptions });
+        this.encoders.br = (options) => Zlib.createBrotliCompress({ ...options, ...compressionOptions });
         this.setPriority(['br']);
     }
 
-    enableZstdCompression() {
+    enableZstdCompression(compressionOptions) {
 
-        this.decoders.zstd = (options) => Zlib.createZstdDecompress(options);
-        this.encoders.zstd = (options) => Zlib.createZstdCompress(options);
+        this.decoders.zstd = (options) => Zlib.createZstdDecompress({ ...options, ...compressionOptions });
+        this.encoders.zstd = (options) => Zlib.createZstdCompress({ ...options, ...compressionOptions });
         this.setPriority(['zstd']);
     }
 

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -6,9 +6,17 @@ const Accept = require('@hapi/accept');
 const Bounce = require('@hapi/bounce');
 const Hoek = require('@hapi/hoek');
 
-
 const internals = {
-    common: ['gzip, deflate', 'deflate, gzip', 'gzip', 'deflate', 'br', 'gzip, deflate, br']
+    common: [
+        'gzip, deflate',
+        'deflate, gzip',
+        'gzip',
+        'deflate',
+        'br',
+        'gzip, deflate, br',
+        'zstd',
+        'gzip, deflate, br, zstd'
+    ]
 };
 
 
@@ -17,16 +25,18 @@ exports = module.exports = internals.Compression = class {
     decoders = {
         br: (options) => Zlib.createBrotliDecompress(options),
         gzip: (options) => Zlib.createGunzip(options),
-        deflate: (options) => Zlib.createInflate(options)
+        deflate: (options) => Zlib.createInflate(options),
+        zstd: (options) => Zlib.createZstdDecompress(options)
     };
 
-    encodings = ['identity', 'gzip', 'deflate', 'br'];
+    encodings = ['identity', 'gzip', 'deflate', 'br', 'zstd'];
 
     encoders = {
         identity: null,
         br: (options) => Zlib.createBrotliCompress(options),
         gzip: (options) => Zlib.createGzip(options),
-        deflate: (options) => Zlib.createDeflate(options)
+        deflate: (options) => Zlib.createDeflate(options),
+        zstd: (options) => Zlib.createZstdCompress(options)
     };
 
     #common = null;
@@ -47,6 +57,7 @@ exports = module.exports = internals.Compression = class {
 
     addEncoder(encoding, encoder) {
 
+        Hoek.assert(this.encoders[encoding] === undefined, `Cannot override existing encoder for ${encoding}`);
         Hoek.assert(typeof encoder === 'function', `Invalid encoder function for ${encoding}`);
         this.encoders[encoding] = encoder;
         this.encodings.unshift(encoding);
@@ -55,6 +66,7 @@ exports = module.exports = internals.Compression = class {
 
     addDecoder(encoding, decoder) {
 
+        Hoek.assert(this.decoders[encoding] === undefined, `Cannot override existing decoder for ${encoding}`);
         Hoek.assert(typeof decoder === 'function', `Invalid decoder function for ${encoding}`);
         this.decoders[encoding] = decoder;
     }
@@ -115,5 +127,11 @@ exports = module.exports = internals.Compression = class {
         const encoder = this.encoders[encoding];
         Hoek.assert(encoder !== undefined, `Unknown encoding ${encoding}`);
         return encoder(request.route.settings.compression[encoding]);
+    }
+
+    setPriority(priority) {
+
+        this.encodings = [...new Set([...priority, ...this.encodings])];
+        this._updateCommons();
     }
 };

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -8,21 +8,23 @@ const Hoek = require('@hapi/hoek');
 
 
 const internals = {
-    common: ['gzip, deflate', 'deflate, gzip', 'gzip', 'deflate', 'gzip, deflate, br']
+    common: ['gzip, deflate', 'deflate, gzip', 'gzip', 'deflate', 'br', 'gzip, deflate, br']
 };
 
 
 exports = module.exports = internals.Compression = class {
 
     decoders = {
+        br: (options) => Zlib.createBrotliDecompress(options),
         gzip: (options) => Zlib.createGunzip(options),
         deflate: (options) => Zlib.createInflate(options)
     };
 
-    encodings = ['identity', 'gzip', 'deflate'];
+    encodings = ['identity', 'gzip', 'deflate', 'br'];
 
     encoders = {
         identity: null,
+        br: (options) => Zlib.createBrotliCompress(options),
         gzip: (options) => Zlib.createGzip(options),
         deflate: (options) => Zlib.createDeflate(options)
     };
@@ -115,5 +117,11 @@ exports = module.exports = internals.Compression = class {
         const encoder = this.encoders[encoding];
         Hoek.assert(encoder !== undefined, `Unknown encoding ${encoding}`);
         return encoder(request.route.settings.compression[encoding]);
+    }
+
+    setPriority(priority) {
+
+        this.encodings = [...new Set([...priority, ...this.encodings])];
+        this._updateCommons();
     }
 };

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -5,6 +5,7 @@ const Zlib = require('zlib');
 const Accept = require('@hapi/accept');
 const Bounce = require('@hapi/bounce');
 const Hoek = require('@hapi/hoek');
+const Boom = require('@hapi/boom');
 
 const defaultBrotliOptions = {
     params: {
@@ -76,6 +77,12 @@ exports = module.exports = internals.Compression = class {
                 this.addEncoder(encoding, encoder);
                 if (this.#options.decompress !== false) {
                     this.addDecoder(encoding, decoder);
+                }
+                else {
+                    this.addDecoder(encoding, () => {
+
+                        throw Boom.unsupportedMediaType();
+                    });
                 }
             }
         }

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -134,6 +134,7 @@ exports = module.exports = internals.Compression = class {
 
     enableZstdCompression(compressionOptions) {
 
+        Hoek.assert(!!Zlib.constants.ZSTD_CLEVEL_DEFAULT, 'Zstd is not supported by the engine');
         this.decoders.zstd = (options) => Zlib.createZstdDecompress({ ...options, ...compressionOptions });
         this.encoders.zstd = (options) => Zlib.createZstdCompress({ ...options, ...compressionOptions });
         this.setPriority(['zstd']);

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -67,14 +67,16 @@ exports = module.exports = internals.Compression = class {
 
         this.#options = options;
         if (!this.#options) {
-            this._updateCommons();
+            return this._updateCommons();
         }
 
         for (const [encoding, [encoder, decoder]] of internals.provision.entries()) {
             const conditions = this.#options?.encodings?.[encoding];
             if (conditions) {
                 this.addEncoder(encoding, encoder);
-                this.addDecoder(encoding, decoder);
+                if (this.#options.decompress !== false) {
+                    this.addDecoder(encoding, decoder);
+                }
             }
         }
     }

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -134,13 +134,13 @@ exports = module.exports = internals.Compression = class {
             return null;
         }
 
-        const request = response.request;
         if (!this.#options ||
             length !== null && length < this.#options.minBytes) {
 
             return null;
         }
 
+        const request = response.request;
         const mime = request._core.mime.type(response.headers['content-type'] || 'application/octet-stream');
         if (!mime.compressible) {
             return null;

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -142,7 +142,6 @@ exports = module.exports = internals.Compression = class {
     setPriority(priority) {
 
         this.encodings = [...new Set([...priority, ...this.encodings])];
-
         this._updateCommons();
     }
 };

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -6,6 +6,18 @@ const Accept = require('@hapi/accept');
 const Bounce = require('@hapi/bounce');
 const Hoek = require('@hapi/hoek');
 
+const defaultBrotliOptions = {
+    params: {
+        [Zlib.constants.BROTLI_PARAM_QUALITY]: 4
+    }
+};
+
+const defaultZstdOptions = {
+    params: {
+        [Zlib.constants.ZSTD_c_compressionLevel]: 6
+    }
+};
+
 const internals = {
     common: [
         'gzip, deflate, br, zstd',
@@ -19,23 +31,12 @@ const internals = {
     ],
     provision: new Map([
         ['zstd', [
-            (options) => Zlib.createZstdCompress(options),
-            (options) => Zlib.createZstdDecompress(options),
-            {
-                params: {
-                    [Zlib.constants.ZSTD_c_compressionLevel]: 6,
-                    [Zlib.constants.ZSTD_d_windowLogMax]: 0
-                }
-            }
+            (options = {}) => Zlib.createZstdCompress(Hoek.applyToDefaults(defaultZstdOptions, options)),
+            (options) => Zlib.createZstdDecompress(options)
         ]],
         ['br', [
-            (options) => Zlib.createBrotliCompress(options),
-            (options) => Zlib.createBrotliDecompress(options),
-            {
-                params: {
-                    [Zlib.constants.BROTLI_PARAM_QUALITY]: 4
-                }
-            }
+            (options = {}) => Zlib.createBrotliCompress(Hoek.applyToDefaults(defaultBrotliOptions, options)),
+            (options) => Zlib.createBrotliDecompress(options)
         ]],
         ['deflate', [
             (options) => Zlib.createDeflate(options),
@@ -69,12 +70,11 @@ exports = module.exports = internals.Compression = class {
             this._updateCommons();
         }
 
-        for (const [alg, [encoder, decoder, defaults = {}]] of internals.provision.entries()) {
-            let conditions = this.#options?.encodings?.[alg];
+        for (const [encoding, [encoder, decoder]] of internals.provision.entries()) {
+            const conditions = this.#options?.encodings?.[encoding];
             if (conditions) {
-                conditions = Hoek.applyToDefaults(defaults, conditions);
-                this.addEncoder(alg, (opts = {}) => encoder(Hoek.applyToDefaults(conditions, opts)));
-                this.addDecoder(alg, (opts = {}) => decoder(Hoek.applyToDefaults(conditions, opts)));
+                this.addEncoder(encoding, encoder);
+                this.addDecoder(encoding, decoder);
             }
         }
     }

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -8,14 +8,14 @@ const Hoek = require('@hapi/hoek');
 
 const internals = {
     common: [
+        'gzip, deflate, br, zstd',
+        'gzip, deflate, br',
+        'zstd',
+        'br',
         'gzip, deflate',
         'deflate, gzip',
         'gzip',
-        'deflate',
-        'br',
-        'gzip, deflate, br',
-        'zstd',
-        'gzip, deflate, br, zstd'
+        'deflate'
     ]
 };
 
@@ -29,7 +29,7 @@ exports = module.exports = internals.Compression = class {
         zstd: (options) => Zlib.createZstdDecompress(options)
     };
 
-    encodings = ['identity', 'gzip', 'deflate', 'br', 'zstd'];
+    encodings = ['identity', 'zstd', 'br', 'gzip', 'deflate'];
 
     encoders = {
         identity: null,

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -118,10 +118,4 @@ exports = module.exports = internals.Compression = class {
         Hoek.assert(encoder !== undefined, `Unknown encoding ${encoding}`);
         return encoder(request.route.settings.compression[encoding]);
     }
-
-    setPriority(priority) {
-
-        this.encodings = [...new Set([...priority, ...this.encodings])];
-        this._updateCommons();
-    }
 };

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -47,7 +47,6 @@ exports = module.exports = internals.Compression = class {
 
     addEncoder(encoding, encoder) {
 
-        Hoek.assert(this.encoders[encoding] === undefined, `Cannot override existing encoder for ${encoding}`);
         Hoek.assert(typeof encoder === 'function', `Invalid encoder function for ${encoding}`);
         this.encoders[encoding] = encoder;
         this.encodings.unshift(encoding);
@@ -56,7 +55,6 @@ exports = module.exports = internals.Compression = class {
 
     addDecoder(encoding, decoder) {
 
-        Hoek.assert(this.decoders[encoding] === undefined, `Cannot override existing decoder for ${encoding}`);
         Hoek.assert(typeof decoder === 'function', `Invalid decoder function for ${encoding}`);
         this.decoders[encoding] = decoder;
     }

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -60,19 +60,21 @@ exports = module.exports = internals.Compression = class {
     };
 
     #common = null;
+    #options = null;
 
-    constructor({ compression }) {
+    constructor(options) {
 
-        if (!compression) {
+        this.#options = options;
+        if (!this.#options) {
             this._updateCommons();
         }
 
         for (const [alg, [encoder, decoder, defaults = {}]] of internals.provision.entries()) {
-            let conditions = compression?.encodings?.[alg];
+            let conditions = this.#options?.encodings?.[alg];
             if (conditions) {
                 conditions = Hoek.applyToDefaults(defaults, conditions);
-                this.addEncoder(alg, (options = {}) => encoder(Hoek.applyToDefaults(conditions, options)));
-                this.addDecoder(alg, (options = {}) => decoder(Hoek.applyToDefaults(conditions, options)));
+                this.addEncoder(alg, (opts = {}) => encoder(Hoek.applyToDefaults(conditions, opts)));
+                this.addDecoder(alg, (opts = {}) => decoder(Hoek.applyToDefaults(conditions, opts)));
             }
         }
     }
@@ -133,8 +135,8 @@ exports = module.exports = internals.Compression = class {
         }
 
         const request = response.request;
-        if (!request._core.settings.compression ||
-            length !== null && length < request._core.settings.compression.minBytes) {
+        if (!this.#options ||
+            length !== null && length < this.#options.minBytes) {
 
             return null;
         }

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,8 +241,7 @@ internals.server = Validate.object({
     autoListen: Validate.boolean(),
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
-        minBytes: Validate.number().min(1).integer().default(1024),
-        priority: Validate.array().items(Validate.string().valid('gzip', 'deflate', 'br')).default(null)
+        minBytes: Validate.number().min(1).integer().default(1024)
     })
         .allow(false)
         .default(),

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,6 +241,7 @@ internals.server = Validate.object({
     autoListen: Validate.boolean(),
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
+        decompress: Validate.boolean().default(true),
         encodings: Validate.object({
             gzip: Validate.boolean().default(true),
             deflate: Validate.boolean().default(true),

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,6 +241,8 @@ internals.server = Validate.object({
     autoListen: Validate.boolean(),
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
+        enableBrotli: Validate.boolean().default(false),
+        enableZstd: Validate.boolean().default(false),
         minBytes: Validate.number().min(1).integer().default(1024),
         priority: Validate.array().items(Validate.string().valid('gzip', 'deflate', 'br', 'zstd')).default(null)
     })

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,8 +241,14 @@ internals.server = Validate.object({
     autoListen: Validate.boolean(),
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
-        enableBrotli: Validate.boolean().default(false),
-        enableZstd: Validate.boolean().default(false),
+        enableBrotli: Validate.alternatives([
+            Validate.boolean(),
+            Validate.object()
+        ]).default(false),
+        enableZstd: Validate.alternatives([
+            Validate.boolean(),
+            Validate.object()
+        ]).default(false),
         minBytes: Validate.number().min(1).integer().default(1024),
         priority: Validate.array().items(Validate.string().valid('gzip', 'deflate', 'br', 'zstd')).default(null)
     })

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,7 +241,8 @@ internals.server = Validate.object({
     autoListen: Validate.boolean(),
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
-        minBytes: Validate.number().min(1).integer().default(1024)
+        minBytes: Validate.number().min(1).integer().default(1024),
+        priority: Validate.array().items(Validate.string().valid('gzip', 'deflate', 'br')).default(null)
     })
         .allow(false)
         .default(),

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,7 +241,8 @@ internals.server = Validate.object({
     autoListen: Validate.boolean(),
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
-        minBytes: Validate.number().min(1).integer().default(1024)
+        minBytes: Validate.number().min(1).integer().default(1024),
+        priority: Validate.array().items(Validate.string().valid('gzip', 'deflate', 'br', 'zstd')).default(null)
     })
         .allow(false)
         .default(),

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,14 +241,24 @@ internals.server = Validate.object({
     autoListen: Validate.boolean(),
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
-        enableBrotli: Validate.alternatives([
-            Validate.boolean(),
-            Validate.object()
-        ]).default(false),
-        enableZstd: Validate.alternatives([
-            Validate.boolean(),
-            Validate.object()
-        ]).default(false),
+        encodings: Validate.object({
+            gzip: Validate.alternatives([
+                Validate.boolean(),
+                Validate.object()
+            ]).default(true),
+            deflate: Validate.alternatives([
+                Validate.boolean(),
+                Validate.object()
+            ]).default(true),
+            br: Validate.alternatives([
+                Validate.boolean(),
+                Validate.object()
+            ]).default(false),
+            zstd: Validate.alternatives([
+                Validate.boolean(),
+                Validate.object()
+            ]).default(false)
+        }).default(),
         minBytes: Validate.number().min(1).integer().default(1024),
         priority: Validate.array().items(Validate.string().valid('gzip', 'deflate', 'br', 'zstd')).default(null)
     })

--- a/lib/config.js
+++ b/lib/config.js
@@ -242,22 +242,10 @@ internals.server = Validate.object({
     cache: Validate.allow(null),                                 // Validated elsewhere
     compression: Validate.object({
         encodings: Validate.object({
-            gzip: Validate.alternatives([
-                Validate.boolean(),
-                Validate.object()
-            ]).default(true),
-            deflate: Validate.alternatives([
-                Validate.boolean(),
-                Validate.object()
-            ]).default(true),
-            br: Validate.alternatives([
-                Validate.boolean(),
-                Validate.object()
-            ]).default(false),
-            zstd: Validate.alternatives([
-                Validate.boolean(),
-                Validate.object()
-            ]).default(false)
+            gzip: Validate.boolean().default(true),
+            deflate: Validate.boolean().default(true),
+            br: Validate.boolean().default(false),
+            zstd: Validate.boolean().default(false)
         }).default(),
         minBytes: Validate.number().min(1).integer().default(1024),
         priority: Validate.array().items(Validate.string().valid('gzip', 'deflate', 'br', 'zstd')).default(null)

--- a/lib/core.js
+++ b/lib/core.js
@@ -54,7 +54,7 @@ exports = module.exports = internals.Core = class {
     app = {};
     auth = new Auth(this);
     caches = new Map();                                                        // Cache clients
-    compression = new Compression();
+    compression = null;
     controlled = null;                                                         // Other servers linked to the phases of this server
     dependencies = [];                                                         // Plugin dependencies
     events = new Podium.Podium(internals.events);
@@ -119,6 +119,7 @@ exports = module.exports = internals.Core = class {
         this.settings = settings;
         this.type = type;
 
+        this.compression = new Compression(this.settings);
         this.heavy = new Heavy(this.settings.load);
         this.mime = new Mimos(this.settings.mime);
         this.router = new Call.Router(this.settings.router);
@@ -126,16 +127,6 @@ exports = module.exports = internals.Core = class {
 
         this._debug();
         this._initializeCache();
-
-        if (this.settings.compression.enableBrotli) {
-            this.compression.enableBrotliCompression(this.settings.compression.enableBrotli);
-        }
-
-        /* $lab:coverage:off$ */
-        if (this.settings.compression.enableZstd) {
-            this.compression.enableZstdCompression(this.settings.compression.enableZstd);
-        }
-        /* $lab:coverage:on$ */
 
         if (this.settings.compression.priority) {
             this.compression.setPriority(this.settings.compression.priority);

--- a/lib/core.js
+++ b/lib/core.js
@@ -127,6 +127,10 @@ exports = module.exports = internals.Core = class {
         this._debug();
         this._initializeCache();
 
+        if (this.settings.compression.priority) {
+            this.compression.setPriority(this.settings.compression.priority);
+        }
+
         if (this.settings.routes.validate.validator) {
             this.validator = Validation.validator(this.settings.routes.validate.validator);
         }

--- a/lib/core.js
+++ b/lib/core.js
@@ -127,6 +127,14 @@ exports = module.exports = internals.Core = class {
         this._debug();
         this._initializeCache();
 
+        if (this.settings.compression.enableBrotli) {
+            this.compression.enableBrotliCompression();
+        }
+
+        if (this.settings.compression.enableZstd) {
+            this.compression.enableZstdCompression();
+        }
+
         if (this.settings.compression.priority) {
             this.compression.setPriority(this.settings.compression.priority);
         }

--- a/lib/core.js
+++ b/lib/core.js
@@ -131,9 +131,11 @@ exports = module.exports = internals.Core = class {
             this.compression.enableBrotliCompression(this.settings.compression.enableBrotli);
         }
 
+        /* $lab:coverage:off$ */
         if (this.settings.compression.enableZstd) {
             this.compression.enableZstdCompression(this.settings.compression.enableZstd);
         }
+        /* $lab:coverage:on$ */
 
         if (this.settings.compression.priority) {
             this.compression.setPriority(this.settings.compression.priority);

--- a/lib/core.js
+++ b/lib/core.js
@@ -119,7 +119,7 @@ exports = module.exports = internals.Core = class {
         this.settings = settings;
         this.type = type;
 
-        this.compression = new Compression(this.settings);
+        this.compression = new Compression(this.settings.compression);
         this.heavy = new Heavy(this.settings.load);
         this.mime = new Mimos(this.settings.mime);
         this.router = new Call.Router(this.settings.router);

--- a/lib/core.js
+++ b/lib/core.js
@@ -128,11 +128,11 @@ exports = module.exports = internals.Core = class {
         this._initializeCache();
 
         if (this.settings.compression.enableBrotli) {
-            this.compression.enableBrotliCompression();
+            this.compression.enableBrotliCompression(this.settings.compression.enableBrotli);
         }
 
         if (this.settings.compression.enableZstd) {
-            this.compression.enableZstdCompression();
+            this.compression.enableZstdCompression(this.settings.compression.enableZstd);
         }
 
         if (this.settings.compression.priority) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -127,10 +127,6 @@ exports = module.exports = internals.Core = class {
         this._debug();
         this._initializeCache();
 
-        if (this.settings.compression.priority) {
-            this.compression.setPriority(this.settings.compression.priority);
-        }
-
         if (this.settings.routes.validate.validator) {
             this.validator = Validation.validator(this.settings.routes.validate.validator);
         }

--- a/lib/types/server/encoders.d.ts
+++ b/lib/types/server/encoders.d.ts
@@ -1,4 +1,4 @@
-import { createDeflate, createGunzip, createGzip, createInflate } from 'zlib';
+import { createBrotliCompress, createBrotliDecompress, createDeflate, createGunzip, createGzip, createInflate } from 'zlib';
 
 /**
  * Available [content encoders](https://github.com/hapijs/hapi/blob/master/API.md#-serverencoderencoding-encoder).
@@ -7,6 +7,7 @@ export interface ContentEncoders {
 
     deflate: typeof createDeflate;
     gzip: typeof createGzip;
+    br: typeof createBrotliCompress;
 }
 
 /**
@@ -16,4 +17,5 @@ export interface ContentDecoders {
 
     deflate: typeof createInflate;
     gzip: typeof createGunzip;
+    br: typeof createBrotliDecompress;
 }

--- a/lib/types/server/encoders.d.ts
+++ b/lib/types/server/encoders.d.ts
@@ -1,4 +1,4 @@
-import { createBrotliCompress, createBrotliDecompress, createDeflate, createGunzip, createGzip, createInflate } from 'zlib';
+import { createBrotliCompress, createBrotliDecompress, createDeflate, createGunzip, createGzip, createInflate, createZstdCompress, createZstdDecompress } from 'zlib';
 
 /**
  * Available [content encoders](https://github.com/hapijs/hapi/blob/master/API.md#-serverencoderencoding-encoder).
@@ -8,6 +8,7 @@ export interface ContentEncoders {
     deflate: typeof createDeflate;
     gzip: typeof createGzip;
     br: typeof createBrotliCompress;
+    zstd: typeof createZstdCompress;
 }
 
 /**
@@ -18,4 +19,5 @@ export interface ContentDecoders {
     deflate: typeof createInflate;
     gzip: typeof createGunzip;
     br: typeof createBrotliDecompress;
+    zstd: typeof createZstdDecompress;
 }

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
-import { BrotliOptions, ZstdOptions } from 'zlib';
+import { BrotliOptions, ZstdOptions, ZlibOptions } from 'zlib';
 
 import { MimosOptions } from '@hapi/mimos';
 
@@ -10,10 +10,14 @@ import { CacheProvider, ServerOptionsCache } from './cache';
 import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
-    enableBrotli: boolean | BrotliOptions;
-    enableZstd: boolean | ZstdOptions;
+    encodings?: {
+        gzip?: boolean | ZlibOptions;
+        deflate?: boolean | ZlibOptions;
+        br?: boolean | BrotliOptions;
+        zstd?: boolean | ZstdOptions;
+    };
     minBytes: number;
-    priority: string[];
+    priority?: string[];
 }
 
 /**

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -1,6 +1,5 @@
 import * as http from 'http';
 import * as https from 'https';
-import { BrotliOptions, ZstdOptions, ZlibOptions } from 'zlib';
 
 import { MimosOptions } from '@hapi/mimos';
 
@@ -11,10 +10,10 @@ import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
     encodings?: {
-        gzip?: boolean | ZlibOptions;
-        deflate?: boolean | ZlibOptions;
-        br?: boolean | BrotliOptions;
-        zstd?: boolean | ZstdOptions;
+        gzip?: boolean;
+        deflate?: boolean;
+        br?: boolean;
+        zstd?: boolean;
     };
     minBytes: number;
     priority?: string[];

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -10,6 +10,7 @@ import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
     minBytes: number;
+    priority: string[];
 }
 
 /**

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -9,8 +9,8 @@ import { CacheProvider, ServerOptionsCache } from './cache';
 import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
-    enableBrotli: boolean;
-    enableZstd: boolean;
+    enableBrotli: boolean | object;
+    enableZstd: boolean | object;
     minBytes: number;
     priority: string[];
 }

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
-import { BrotliOptions, ZstdOptions } from 'node:zlib';
+import { BrotliOptions, ZstdOptions } from 'zlib';
 
 import { MimosOptions } from '@hapi/mimos';
 

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -9,6 +9,7 @@ import { CacheProvider, ServerOptionsCache } from './cache';
 import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
+    decompress?: boolean;
     encodings?: {
         gzip?: boolean;
         deflate?: boolean;

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -9,6 +9,8 @@ import { CacheProvider, ServerOptionsCache } from './cache';
 import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
+    enableBrotli: boolean;
+    enableZstd: boolean;
     minBytes: number;
     priority: string[];
 }

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -10,7 +10,6 @@ import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
     minBytes: number;
-    priority: string[];
 }
 
 /**

--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -1,5 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
+import { BrotliOptions, ZstdOptions } from 'node:zlib';
 
 import { MimosOptions } from '@hapi/mimos';
 
@@ -9,8 +10,8 @@ import { CacheProvider, ServerOptionsCache } from './cache';
 import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
-    enableBrotli: boolean | object;
-    enableZstd: boolean | object;
+    enableBrotli: boolean | BrotliOptions;
+    enableZstd: boolean | ZstdOptions;
     minBytes: number;
     priority: string[];
 }

--- a/lib/types/server/server.d.ts
+++ b/lib/types/server/server.d.ts
@@ -332,7 +332,7 @@ export class Server<A = ServerApplicationState> {
     cache: ServerCache;
 
     /**
-     * Registers a custom content decoding compressor to extend the built-in support for 'gzip' and 'deflate' where:
+     * Registers a custom content decoding compressor to extend the built-in support where:
      * @param encoding - the decoder name string.
      * @param decoder - a function using the signature function(options) where options are the encoding specific options configured in the route payload.compression configuration option, and the
      *     return value is an object compatible with the output of node's zlib.createGunzip().
@@ -392,7 +392,7 @@ export class Server<A = ServerApplicationState> {
     dependency(dependencies: Dependencies, after?: ((server: Server) => Promise<void>) | undefined): void;
 
     /**
-     * Registers a custom content encoding compressor to extend the built-in support for 'gzip' and 'deflate' where:
+     * Registers a custom content encoding compressor to extend the built-in support where:
      * @param encoding - the encoder name string.
      * @param encoder - a function using the signature function(options) where options are the encoding specific options configured in the route compression option, and the return value is an object
      *     compatible with the output of node's zlib.createGzip().

--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
     "@hapi/code": "^9.0.3",
     "@hapi/eslint-plugin": "^6.0.0",
     "@hapi/inert": "^7.1.0",
-    "@hapi/joi-legacy-test": "npm:@hapi/joi@^15.0.0",
+    "@hapi/joi-legacy-test": "npm:@hapi/joi@^15.1.1",
     "@hapi/lab": "^25.3.2",
     "@hapi/vision": "^7.0.3",
     "@hapi/wreck": "^18.1.0",
-    "@types/node": "^22.17.2",
+    "@types/node": "^22.17.0",
     "handlebars": "^4.7.8",
     "joi": "^17.13.3",
-    "legacy-readable-stream": "npm:readable-stream@^1.0.34",
+    "legacy-readable-stream": "npm:readable-stream@^1.1.14",
     "typescript": "^4.9.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=22.15.0"
   },
   "files": [
     "lib"
@@ -51,7 +51,7 @@
     "@hapi/lab": "^25.3.2",
     "@hapi/vision": "^7.0.3",
     "@hapi/wreck": "^18.1.0",
-    "@types/node": "^18.19.122",
+    "@types/node": "^22.17.2",
     "handlebars": "^4.7.8",
     "joi": "^17.13.3",
     "legacy-readable-stream": "npm:readable-stream@^1.0.34",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@hapi/somever": "^4.1.1",
     "@hapi/statehood": "^8.2.0",
     "@hapi/subtext": "^8.1.1",
-    "@hapi/teamwork": "^6.0.0",
+    "@hapi/teamwork": "^6.0.1",
     "@hapi/topo": "^6.0.2",
     "@hapi/validate": "^2.0.1"
   },
@@ -51,7 +51,7 @@
     "@hapi/lab": "^25.3.2",
     "@hapi/vision": "^7.0.3",
     "@hapi/wreck": "^18.1.0",
-    "@types/node": "^22.17.0",
+    "@types/node": "^22.18.3",
     "handlebars": "^4.7.8",
     "joi": "^17.13.3",
     "legacy-readable-stream": "npm:readable-stream@^1.1.14",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">=22.15.0"
+    "node": ">=14.15.0"
   },
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@hapi/lab": "^25.3.2",
     "@hapi/vision": "^7.0.3",
     "@hapi/wreck": "^18.1.0",
-    "@types/node": "^18.19.130",
+    "@types/node": "^22.20.1",
     "handlebars": "^4.7.9",
     "joi": "^17.13.3",
     "legacy-readable-stream": "npm:readable-stream@^1.0.34",

--- a/test/common.js
+++ b/test/common.js
@@ -3,6 +3,7 @@
 const ChildProcess = require('child_process');
 const Http = require('http');
 const Net = require('net');
+const Zlib = require('zlib');
 
 const internals = {};
 
@@ -30,3 +31,5 @@ internals.hasIPv6 = () => {
 exports.hasLsof = internals.hasLsof();
 
 exports.hasIPv6 = internals.hasIPv6();
+
+exports.hasZstd = !!Zlib.constants.ZSTD_CLEVEL_DEFAULT;

--- a/test/payload.js
+++ b/test/payload.js
@@ -525,6 +525,30 @@ describe('Payload', () => {
         expect(res.result).to.equal(message);
     });
 
+    it('handles br payload', async () => {
+
+        const message = { 'msg': 'This message is going to be brotlied.' };
+        const server = Hapi.server();
+        server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
+
+        const compressed = await new Promise((resolve) => Zlib.brotliCompress(JSON.stringify(message), (ignore, result) => resolve(result)));
+
+        const request = {
+            method: 'POST',
+            url: '/',
+            headers: {
+                'content-type': 'application/json',
+                'content-encoding': 'br',
+                'content-length': compressed.length
+            },
+            payload: compressed
+        };
+
+        const res = await server.inject(request);
+        expect(res.result).to.exist();
+        expect(res.result).to.equal(message);
+    });
+
     it('handles custom compression', async () => {
 
         const message = { 'msg': 'This message is going to be gzipped.' };

--- a/test/payload.js
+++ b/test/payload.js
@@ -12,8 +12,9 @@ const Code = require('@hapi/code');
 const Hapi = require('..');
 const Hoek = require('@hapi/hoek');
 const Lab = require('@hapi/lab');
-const Somever = require('@hapi/somever');
 const Wreck = require('@hapi/wreck');
+
+const Common = require('./common');
 
 const internals = {};
 
@@ -550,7 +551,7 @@ describe('Payload', () => {
         expect(res.result).to.equal(message);
     });
 
-    it('handles zstd payload', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
+    it('handles zstd payload', { skip: !Common.hasZstd }, async () => {
 
         const message = { 'msg': 'This message is going to be zstded.' };
         const server = Hapi.server({ compression: { enableZstd: true } });

--- a/test/payload.js
+++ b/test/payload.js
@@ -12,6 +12,7 @@ const Code = require('@hapi/code');
 const Hapi = require('..');
 const Hoek = require('@hapi/hoek');
 const Lab = require('@hapi/lab');
+const Somever = require('@hapi/somever');
 const Wreck = require('@hapi/wreck');
 
 const internals = {};
@@ -549,7 +550,7 @@ describe('Payload', () => {
         expect(res.result).to.equal(message);
     });
 
-    it('handles zstd payload', async () => {
+    it('handles zstd payload', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
 
         const message = { 'msg': 'This message is going to be zstded.' };
         const server = Hapi.server({ compression: { enableZstd: true } });

--- a/test/payload.js
+++ b/test/payload.js
@@ -528,7 +528,7 @@ describe('Payload', () => {
     it('handles br payload', async () => {
 
         const message = { 'msg': 'This message is going to be brotlied.' };
-        const server = Hapi.server();
+        const server = Hapi.server({ compression: { enableBrotli: true } });
         server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
 
         const compressed = await new Promise((resolve) => Zlib.brotliCompress(JSON.stringify(message), (ignore, result) => resolve(result)));
@@ -552,7 +552,7 @@ describe('Payload', () => {
     it('handles zstd payload', async () => {
 
         const message = { 'msg': 'This message is going to be zstded.' };
-        const server = Hapi.server();
+        const server = Hapi.server({ compression: { enableZstd: true } });
         server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
 
         const compressed = await new Promise((resolve) => Zlib.zstdCompress(JSON.stringify(message), (ignore, result) => resolve(result)));

--- a/test/payload.js
+++ b/test/payload.js
@@ -500,7 +500,7 @@ describe('Payload', () => {
 
         const res = await server.inject(request);
         expect(res.result).to.exist();
-        expect(res.statusCode).to.be.range(400, 499);
+        expect(res.statusCode).to.equal(415);
     });
 
     it('handles gzipped payload', async () => {

--- a/test/payload.js
+++ b/test/payload.js
@@ -530,7 +530,7 @@ describe('Payload', () => {
     it('handles br payload', async () => {
 
         const message = { 'msg': 'This message is going to be brotlied.' };
-        const server = Hapi.server({ compression: { enableBrotli: true } });
+        const server = Hapi.server({ compression: { encodings: { br: true } } });
         server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
 
         const compressed = await new Promise((resolve) => Zlib.brotliCompress(JSON.stringify(message), (ignore, result) => resolve(result)));
@@ -554,7 +554,7 @@ describe('Payload', () => {
     it('handles zstd payload', { skip: !Common.hasZstd }, async () => {
 
         const message = { 'msg': 'This message is going to be zstded.' };
-        const server = Hapi.server({ compression: { enableZstd: true } });
+        const server = Hapi.server({ compression: { encodings: { zstd: true } } });
         server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
 
         const compressed = await new Promise((resolve) => Zlib.zstdCompress(JSON.stringify(message), (ignore, result) => resolve(result)));

--- a/test/payload.js
+++ b/test/payload.js
@@ -549,6 +549,30 @@ describe('Payload', () => {
         expect(res.result).to.equal(message);
     });
 
+    it('handles zstd payload', async () => {
+
+        const message = { 'msg': 'This message is going to be zstded.' };
+        const server = Hapi.server();
+        server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
+
+        const compressed = await new Promise((resolve) => Zlib.zstdCompress(JSON.stringify(message), (ignore, result) => resolve(result)));
+
+        const request = {
+            method: 'POST',
+            url: '/',
+            headers: {
+                'content-type': 'application/json',
+                'content-encoding': 'zstd',
+                'content-length': compressed.length
+            },
+            payload: compressed
+        };
+
+        const res = await server.inject(request);
+        expect(res.result).to.exist();
+        expect(res.result).to.equal(message);
+    });
+
     it('handles custom compression', async () => {
 
         const message = { 'msg': 'This message is going to be gzipped.' };

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -16,7 +16,6 @@ const Hoek = require('@hapi/hoek');
 const Bounce = require('@hapi/bounce');
 const Inert = require('@hapi/inert');
 const Lab = require('@hapi/lab');
-const Somever = require('@hapi/somever');
 const Teamwork = require('@hapi/teamwork');
 const Wreck = require('@hapi/wreck');
 
@@ -678,7 +677,7 @@ describe('transmission', () => {
             expect(res3.headers['last-modified']).to.equal(res2.headers['last-modified']);
         });
 
-        it('returns a zstded file in the response when the request accepts zstd', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
+        it('returns a zstded file in the response when the request accepts zstd', { skip: !Common.hasZstd }, async () => {
 
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 }, routes: { files: { relativeTo: __dirname } } });
             await server.register(Inert);
@@ -809,7 +808,7 @@ describe('transmission', () => {
             expect(res.headers['content-length']).to.not.exist();
         });
 
-        it('returns a zstd response on a post request when accept-encoding: zstd is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
+        it('returns a zstd response on a post request when accept-encoding: zstd is requested', { skip: !Common.hasZstd }, async () => {
 
             const data = '{"test":"true"}';
 
@@ -824,7 +823,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a get request when accept-encoding: zstd is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
+        it('returns a zstd response on a get request when accept-encoding: zstd is requested', { skip: !Common.hasZstd }, async () => {
 
             const data = '{"test":"true"}';
 
@@ -1039,7 +1038,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7; zstd;q=1 is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
+        it('returns a zstd response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7; zstd;q=1 is requested', { skip: !Common.hasZstd }, async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
@@ -1053,7 +1052,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7, zstd;q=1 is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
+        it('returns a zstd response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7, zstd;q=1 is requested', { skip: !Common.hasZstd }, async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
@@ -1123,7 +1122,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a post request when accept-encoding: gzip, deflate, br, zstd is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
+        it('returns a zstd response on a post request when accept-encoding: gzip, deflate, br, zstd is requested', { skip: !Common.hasZstd }, async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
@@ -1137,7 +1136,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a get request when accept-encoding: gzip, deflate, br, zstd is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
+        it('returns a zstd response on a get request when accept-encoding: gzip, deflate, br, zstd is requested', { skip: !Common.hasZstd }, async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -679,7 +679,7 @@ describe('transmission', () => {
 
         it('returns a zstded file in the response when the request accepts zstd', async () => {
 
-            const server = Hapi.server({ compression: { minBytes: 1 }, routes: { files: { relativeTo: __dirname } } });
+            const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 }, routes: { files: { relativeTo: __dirname } } });
             await server.register(Inert);
             server.route({ method: 'GET', path: '/file', handler: (request, h) => h.file(__dirname + '/../package.json') });
 
@@ -692,7 +692,7 @@ describe('transmission', () => {
 
         it('returns a brotlied file in the response when the request accepts br', async () => {
 
-            const server = Hapi.server({ compression: { minBytes: 1 }, routes: { files: { relativeTo: __dirname } } });
+            const server = Hapi.server({ compression: { enableBrotli: true, minBytes: 1 }, routes: { files: { relativeTo: __dirname } } });
             await server.register(Inert);
             server.route({ method: 'GET', path: '/file', handler: (request, h) => h.file(__dirname + '/../package.json') });
 
@@ -755,6 +755,19 @@ describe('transmission', () => {
             expect(res.payload).to.exist();
         });
 
+        it('returns a deflated file in the response when the request accepts gzip, deflate but priority set to deflate', async () => {
+
+            const server = Hapi.server({ compression: { minBytes: 1, priority: ['deflate'] }, routes: { files: { relativeTo: __dirname } } });
+            await server.register(Inert);
+            server.route({ method: 'GET', path: '/file', handler: (request, h) => h.file(__dirname + '/../package.json') });
+
+            const res = await server.inject({ url: '/file', headers: { 'accept-encoding': 'gzip, deflate' } });
+            expect(res.headers['content-type']).to.equal('application/json; charset=utf-8');
+            expect(res.headers['content-encoding']).to.equal('deflate');
+            expect(res.headers['content-length']).to.not.exist();
+            expect(res.payload).to.exist();
+        });
+
         it('returns a zstded stream response without a content-length header when accept-encoding is zstd', async () => {
 
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -799,7 +812,7 @@ describe('transmission', () => {
 
             const data = '{"test":"true"}';
 
-            const server = Hapi.server({ compression: { minBytes: 1 } });
+            const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
             server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
             await server.start();
 
@@ -814,7 +827,7 @@ describe('transmission', () => {
 
             const data = '{"test":"true"}';
 
-            const server = Hapi.server({ compression: { minBytes: 1 } });
+            const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
             server.route({ method: 'GET', path: '/', handler: () => data });
             await server.start();
 
@@ -829,7 +842,7 @@ describe('transmission', () => {
 
             const data = '{"test":"true"}';
 
-            const server = Hapi.server({ compression: { minBytes: 1 } });
+            const server = Hapi.server({ compression: { enableBrotli: true, minBytes: 1 } });
             server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
             await server.start();
 
@@ -844,7 +857,7 @@ describe('transmission', () => {
 
             const data = '{"test":"true"}';
 
-            const server = Hapi.server({ compression: { minBytes: 1 } });
+            const server = Hapi.server({ compression: { enableBrotli: true, minBytes: 1 } });
             server.route({ method: 'GET', path: '/', handler: () => data });
             await server.start();
 
@@ -941,7 +954,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a gzip response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7 is requested', async () => {
+        it('returns a gzip response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7; zstd;q=0.8 is requested', async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -950,12 +963,12 @@ describe('transmission', () => {
 
             const uri = 'http://localhost:' + server.info.port;
             const zipped = await internals.compress('gzip', Buffer.from(data));
-            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=0.7' }, payload: data });
+            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=0.7, zstd;q=0.8' }, payload: data });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
         });
 
-        it('returns a gzip response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7 is requested', async () => {
+        it('returns a gzip response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7, zstd;q=0.8 is requested', async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -964,12 +977,12 @@ describe('transmission', () => {
 
             const uri = 'http://localhost:' + server.info.port;
             const zipped = await internals.compress('gzip', Buffer.from(data));
-            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=0.7' } });
+            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=0.7, zstd;q=0.8' } });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
         });
 
-        it('returns a deflate response on a post request when accept-encoding: deflate;q=1, gzip;q=0.5, br;q=0.7, zstd;q=1 is requested', async () => {
+        it('returns a deflate response on a post request when accept-encoding: deflate;q=1, gzip;q=0.5, br;q=0.7, zstd;q=0.8 is requested', async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -978,12 +991,12 @@ describe('transmission', () => {
 
             const uri = 'http://localhost:' + server.info.port;
             const deflated = await internals.compress('deflate', Buffer.from(data));
-            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5, br;q=0.7, zstd;q=1' }, payload: data });
+            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5, br;q=0.7, zstd;q=0.8' }, payload: data });
             expect(payload.toString()).to.equal(deflated.toString());
             await server.stop();
         });
 
-        it('returns a deflate response on a get request when accept-encoding: deflate;q=1, gzip;q=0.5, br;q=0.7, zstd;q=1 is requested', async () => {
+        it('returns a deflate response on a get request when accept-encoding: deflate;q=1, gzip;q=0.5, br;q=0.7, zstd;q=0.8 is requested', async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -992,35 +1005,35 @@ describe('transmission', () => {
 
             const uri = 'http://localhost:' + server.info.port;
             const deflated = await internals.compress('deflate', Buffer.from(data));
-            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5, br;q=0.7, zstd;q=1' } });
+            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5, br;q=0.7, zstd;q=0.8' } });
             expect(payload.toString()).to.equal(deflated.toString());
             await server.stop();
         });
 
-        it('returns a br response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=1 is requested', async () => {
+        it('returns a br response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=1, zstd;q=0.8 is requested', async () => {
 
             const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['br'] } });
+            const server = Hapi.server({ compression: { enableBrotli: true, minBytes: 1 } });
             server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
             const brotlied = await internals.compress('brotliCompress', Buffer.from(data));
-            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=1' }, payload: data });
+            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=1, zstd;q=0.8' }, payload: data });
             expect(payload.toString()).to.equal(brotlied.toString());
             await server.stop();
         });
 
-        it('returns a br response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=1 is requested', async () => {
+        it('returns a br response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=1, zstd;q=0.8 is requested', async () => {
 
             const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['br'] } });
+            const server = Hapi.server({ compression: { enableBrotli: true, minBytes: 1 } });
             server.route({ method: 'GET', path: '/', handler: () => data });
             await server.start();
 
             const uri = 'http://localhost:' + server.info.port;
             const brotlied = await internals.compress('brotliCompress', Buffer.from(data));
-            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=1' } });
+            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=1, zstd;q=0.8' } });
             expect(payload.toString()).to.equal(brotlied.toString());
             await server.stop();
         });
@@ -1028,7 +1041,7 @@ describe('transmission', () => {
         it('returns a zstd response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7; zstd;q=1 is requested', async () => {
 
             const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['zstd'] } });
+            const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
             server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
             await server.start();
 
@@ -1042,7 +1055,7 @@ describe('transmission', () => {
         it('returns a zstd response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7, zstd;q=1 is requested', async () => {
 
             const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['zstd'] } });
+            const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
             server.route({ method: 'GET', path: '/', handler: () => data });
             await server.start();
 
@@ -1084,7 +1097,7 @@ describe('transmission', () => {
         it('returns a br response on a post request when accept-encoding: gzip, deflate, br is requested', async () => {
 
             const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['br'] } });
+            const server = Hapi.server({ compression: { enableBrotli: true, minBytes: 1 } });
             server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
             await server.start();
 
@@ -1098,7 +1111,7 @@ describe('transmission', () => {
         it('returns a br response on a get request when accept-encoding: gzip, deflate, br is requested', async () => {
 
             const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['br'] } });
+            const server = Hapi.server({ compression: { enableBrotli: true, minBytes: 1 } });
             server.route({ method: 'GET', path: '/', handler: () => data });
             await server.start();
 
@@ -1112,7 +1125,7 @@ describe('transmission', () => {
         it('returns a zstd response on a post request when accept-encoding: gzip, deflate, br, zstd is requested', async () => {
 
             const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['zstd'] } });
+            const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
             server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
             await server.start();
 
@@ -1126,7 +1139,7 @@ describe('transmission', () => {
         it('returns a zstd response on a get request when accept-encoding: gzip, deflate, br, zstd is requested', async () => {
 
             const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['zstd'] } });
+            const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
             server.route({ method: 'GET', path: '/', handler: () => data });
             await server.start();
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -889,7 +889,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a gzip response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5 is requested', async () => {
+        it('returns a gzip response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7 is requested', async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -898,12 +898,12 @@ describe('transmission', () => {
 
             const uri = 'http://localhost:' + server.info.port;
             const zipped = await internals.compress('gzip', Buffer.from(data));
-            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5' }, payload: data });
+            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=0.7' }, payload: data });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
         });
 
-        it('returns a gzip response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5 is requested', async () => {
+        it('returns a gzip response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7 is requested', async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -912,12 +912,12 @@ describe('transmission', () => {
 
             const uri = 'http://localhost:' + server.info.port;
             const zipped = await internals.compress('gzip', Buffer.from(data));
-            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5' } });
+            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=0.7' } });
             expect(payload.toString()).to.equal(zipped.toString());
             await server.stop();
         });
 
-        it('returns a deflate response on a post request when accept-encoding: deflate;q=1, gzip;q=0.5 is requested', async () => {
+        it('returns a deflate response on a post request when accept-encoding: deflate;q=1, gzip;q=0.5, br;q=0.7 is requested', async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -926,12 +926,12 @@ describe('transmission', () => {
 
             const uri = 'http://localhost:' + server.info.port;
             const deflated = await internals.compress('deflate', Buffer.from(data));
-            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5' }, payload: data });
+            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5, br;q=0.7' }, payload: data });
             expect(payload.toString()).to.equal(deflated.toString());
             await server.stop();
         });
 
-        it('returns a deflate response on a get request when accept-encoding: deflate;q=1, gzip;q=0.5 is requested', async () => {
+        it('returns a deflate response on a get request when accept-encoding: deflate;q=1, gzip;q=0.5, br;q=0.7 is requested', async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { minBytes: 1 } });
@@ -940,37 +940,8 @@ describe('transmission', () => {
 
             const uri = 'http://localhost:' + server.info.port;
             const deflated = await internals.compress('deflate', Buffer.from(data));
-            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5' } });
+            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'deflate;q=1, gzip;q=0.5, br;q=0.7' } });
             expect(payload.toString()).to.equal(deflated.toString());
-            await server.stop();
-        });
-
-
-        it('returns a br response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=1 is requested', async () => {
-
-            const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['br'] } });
-            server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
-            await server.start();
-
-            const uri = 'http://localhost:' + server.info.port;
-            const brotlied = await internals.compress('brotliCompress', Buffer.from(data));
-            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=1' }, payload: data });
-            expect(payload.toString()).to.equal(brotlied.toString());
-            await server.stop();
-        });
-
-        it('returns a br response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=1 is requested', async () => {
-
-            const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['br'] } });
-            server.route({ method: 'GET', path: '/', handler: () => data });
-            await server.start();
-
-            const uri = 'http://localhost:' + server.info.port;
-            const brotlied = await internals.compress('brotliCompress', Buffer.from(data));
-            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip;q=1, deflate;q=0.5, br;q=1' } });
-            expect(payload.toString()).to.equal(brotlied.toString());
             await server.stop();
         });
 
@@ -999,35 +970,6 @@ describe('transmission', () => {
             const zipped = await internals.compress('gzip', Buffer.from(data));
             const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'deflate, gzip' } });
             expect(payload.toString()).to.equal(zipped.toString());
-            await server.stop();
-        });
-
-
-        it('returns a br response on a post request when accept-encoding: gzip, deflate, br is requested', async () => {
-
-            const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['br'] } });
-            server.route({ method: 'POST', path: '/', handler: (request) => request.payload });
-            await server.start();
-
-            const uri = 'http://localhost:' + server.info.port;
-            const brotlied = await internals.compress('brotliCompress', Buffer.from(data));
-            const { payload } = await Wreck.post(uri, { headers: { 'accept-encoding': 'gzip, deflate, br' }, payload: data });
-            expect(payload.toString()).to.equal(brotlied.toString());
-            await server.stop();
-        });
-
-        it('returns a br response on a get request when accept-encoding: gzip, deflate, br is requested', async () => {
-
-            const data = '{"test":"true"}';
-            const server = Hapi.server({ compression: { minBytes: 1, priority: ['br'] } });
-            server.route({ method: 'GET', path: '/', handler: () => data });
-            await server.start();
-
-            const uri = 'http://localhost:' + server.info.port;
-            const brotlied = await internals.compress('brotliCompress', Buffer.from(data));
-            const { payload } = await Wreck.get(uri, { headers: { 'accept-encoding': 'gzip, deflate, br' } });
-            expect(payload.toString()).to.equal(brotlied.toString());
             await server.stop();
         });
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -16,6 +16,7 @@ const Hoek = require('@hapi/hoek');
 const Bounce = require('@hapi/bounce');
 const Inert = require('@hapi/inert');
 const Lab = require('@hapi/lab');
+const Somever = require('@hapi/somever');
 const Teamwork = require('@hapi/teamwork');
 const Wreck = require('@hapi/wreck');
 
@@ -677,7 +678,7 @@ describe('transmission', () => {
             expect(res3.headers['last-modified']).to.equal(res2.headers['last-modified']);
         });
 
-        it('returns a zstded file in the response when the request accepts zstd', async () => {
+        it('returns a zstded file in the response when the request accepts zstd', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
 
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 }, routes: { files: { relativeTo: __dirname } } });
             await server.register(Inert);
@@ -808,7 +809,7 @@ describe('transmission', () => {
             expect(res.headers['content-length']).to.not.exist();
         });
 
-        it('returns a zstd response on a post request when accept-encoding: zstd is requested', async () => {
+        it('returns a zstd response on a post request when accept-encoding: zstd is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
 
             const data = '{"test":"true"}';
 
@@ -823,7 +824,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a get request when accept-encoding: zstd is requested', async () => {
+        it('returns a zstd response on a get request when accept-encoding: zstd is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
 
             const data = '{"test":"true"}';
 
@@ -1038,7 +1039,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7; zstd;q=1 is requested', async () => {
+        it('returns a zstd response on a post request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7; zstd;q=1 is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
@@ -1052,7 +1053,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7, zstd;q=1 is requested', async () => {
+        it('returns a zstd response on a get request when accept-encoding: gzip;q=1, deflate;q=0.5, br;q=0.7, zstd;q=1 is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
@@ -1122,7 +1123,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a post request when accept-encoding: gzip, deflate, br, zstd is requested', async () => {
+        it('returns a zstd response on a post request when accept-encoding: gzip, deflate, br, zstd is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });
@@ -1136,7 +1137,7 @@ describe('transmission', () => {
             await server.stop();
         });
 
-        it('returns a zstd response on a get request when accept-encoding: gzip, deflate, br, zstd is requested', async () => {
+        it('returns a zstd response on a get request when accept-encoding: gzip, deflate, br, zstd is requested', { skip: Somever.match(process.version, '<22.15.0') }, async () => {
 
             const data = '{"test":"true"}';
             const server = Hapi.server({ compression: { enableZstd: true, minBytes: 1 } });

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -27,6 +27,7 @@ const internals = {};
 const { describe, it } = exports.lab = Lab.script();
 const expect = Code.expect;
 
+
 describe('transmission', () => {
 
     describe('send()', () => {


### PR DESCRIPTION
This PR is an attempt to bring support for `br` & `zstd` compression 🗜️ algos into the core.