### PR TITLE
Correct type for state object

### DIFF
--- a/lib/types/server/options.d.ts
+++ b/lib/types/server/options.d.ts
@@ -6,8 +6,7 @@ import { MimosOptions } from '@hapi/mimos';
 import { PluginSpecificConfiguration } from '../plugin';
 import { RouteOptions } from '../route';
 import { CacheProvider, ServerOptionsCache } from './cache';
-import { SameSitePolicy } from './state';
-import { ServerStateCookieOptions } from './state';
+import { SameSitePolicy, ServerStateCookieOptions } from './state';
 
 export interface ServerOptionsCompression {
     minBytes: number;


### PR DESCRIPTION
The type for the `state` field of the `ServerOptions` object was qualified with a `TODO` that questioned if the type should be the full `ServerStateCookieOptions` or just those fields defined in the default value. Given [the documentation](https://hapi.dev/api/?v=21.4.0#-serverstatename-options) (and validated by actual usage), the correct type is indeed the one the TODO presumed.  

This PR replaces the ad-hoc type with the proper already-existing type, and gets rid of the TODO. 

This change is intrinsically _safe_ as the type is an strict superset of the one being in use today, with all extra fields being optional. 