### PR TITLE
fix: add Refs generic to PluginSpecificConfiguration interface

### DIFF
--- a/lib/types/plugin.d.ts
+++ b/lib/types/plugin.d.ts
@@ -1,4 +1,4 @@
-import { RequestRoute } from './request';
+import { RequestRoute, ReqRef, ReqRefDefaults } from './request';
 import { RouteOptions } from './route';
 import { Server } from './server';
 import { Lifecycle } from './utils';
@@ -47,7 +47,7 @@ export interface PluginRegistered {
 export interface PluginsStates {
 }
 
-export interface PluginSpecificConfiguration {
+export interface PluginSpecificConfiguration<Refs extends ReqRef = ReqRefDefaults> {
 }
 
 export interface PluginNameVersion {

--- a/lib/types/route.d.ts
+++ b/lib/types/route.d.ts
@@ -788,7 +788,7 @@ export interface CommonRouteProperties<Refs extends ReqRef = ReqRefDefaults> {
      * Plugin-specific configuration. plugins is an object where each key is a plugin name and the value is the plugin configuration.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsplugins)
      */
-    plugins?: PluginSpecificConfiguration | undefined;
+    plugins?: PluginSpecificConfiguration<Refs> | undefined;
 
     /**
      * @default none.


### PR DESCRIPTION
Add Refs generic to plugins key for CommonRouteProperties, extending the generic for logic inside plugins.

This fixes situations where plugins API have lambdas where access the request object and requires to have the same Refs type from the route.

Fix #4526 