### PR TITLE
Handle stream.destroy() called before stream end

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -266,6 +266,7 @@ internals.pipe = function (request, stream) {
     }
     else {
         stream.on('error', end);
+        stream.on('close', aborted);
         stream.pipe(request.raw.res);
     }
 
@@ -364,6 +365,7 @@ internals.chain = function (sources) {
     for (let i = 1; i < sources.length; ++i) {
         const to = sources[i];
         if (to) {
+            from.on('close', internals.destroyPipe.bind(from, to));
             from.on('error', internals.errorPipe.bind(from, to));
             from = from.pipe(to);
         }
@@ -372,6 +374,13 @@ internals.chain = function (sources) {
     return from;
 };
 
+
+internals.destroyPipe = function (to) {
+
+    if (!this.readableEnded && !this.errored) {
+        to.destroy();
+    }
+};
 
 internals.errorPipe = function (to, err) {
 

--- a/test/transmit.js
+++ b/test/transmit.js
@@ -1418,6 +1418,54 @@ describe('transmission', () => {
             expect(count).to.equal(1);
         });
 
+        it('handles stream that is destroyed with no error', async () => {
+
+            const handler = (request, h) => {
+
+                const stream = new Stream.Readable({ read: Hoek.ignore });
+
+                stream.push('hello');
+                Hoek.wait(1).then(() => stream.destroy());
+
+                return h.response(stream).type('text/html');
+            };
+
+            const server = Hapi.server();
+            server.route({ method: 'GET', path: '/', handler });
+
+            const log = server.events.once('response');
+            const err = await expect(server.inject({ url: '/', headers: { 'accept-encoding': 'gzip' } })).to.reject(Boom.Boom);
+            expect(err.output.statusCode).to.equal(499);
+
+            const [request] = await log;
+            expect(request.response.isBoom).to.be.true();
+            expect(request.response.output.statusCode).to.equal(499);
+        });
+
+        it('handles stream that is destroyed with error', async () => {
+
+            const handler = (request, h) => {
+
+                const stream = new Stream.Readable({ read: Hoek.ignore });
+
+                stream.push('hello');
+                Hoek.wait(1).then(() => stream.destroy(new Error('failed')));
+
+                return h.response(stream).type('text/html');
+            };
+
+            const server = Hapi.server();
+            server.route({ method: 'GET', path: '/', handler });
+
+            const log = server.events.once('response');
+            const err = await expect(server.inject({ url: '/', headers: { 'accept-encoding': 'gzip' } })).to.reject(Boom.Boom);
+            expect(err.output.statusCode).to.equal(499);
+
+            const [request] = await log;
+            expect(request.response.isBoom).to.be.true();
+            expect(request.response.output.statusCode).to.equal(500);
+        });
+
         describe('response range', () => {
 
             const fileStreamHandler = (request, h) => {


### PR DESCRIPTION
It seems that hapi has a major issue with stream responses, where `stream.destroy()` is called on it before it has ended. More specifically, it will essentially ignore the `destroy()`, and *never end the response stream* (unless a server timeout has been configured). Since users control the stream they return, it is likely that this can happen for them.

The main fix is to treat stream `'close'` as an aborted response.

A secondary fix is need to handle when the stream is internally piped through eg. a compressor. This is because `stream.pipe()` only forwards the `'end'` event, which never happens once destroyed.

Note that it is only the first test that exposes the breakage. The second test is for added test coverage (and verification).

I haven't checked if this fix has any impact on #4244.