### PR TITLE
fix: 🐛 request.url getter fails when using bare IPv6 hosts [#4556]

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -183,8 +183,13 @@ exports = module.exports = internals.Request = class {
                 this._normalizePath(url, options);
                 return url;
             }
+            else {
 
-            this._url = new Url.URL(`${this._core.info.protocol}://${this.info.host || `${this._core.info.host}:${this._core.info.port}`}${source}`);
+                const hostname = this._formatIpv6Host(this.info.host || this._core.info.host);
+                const hostPort = this.info.host ? hostname : `${hostname}:${this._core.info.port}`;
+
+                this._url = new Url.URL(`${this._core.info.protocol}://${hostPort}${source}`);
+            }
         }
         else {
 
@@ -199,6 +204,25 @@ exports = module.exports = internals.Request = class {
         this._urlError = null;
 
         return this._url;
+    }
+
+    _isBareIpv6(host) {
+
+        // If it's already bracketed, it's not a 'bare' IPv6 we need to wrap.
+
+        if (host.startsWith('[') && host.endsWith(']')) {
+            return false;
+        }
+
+        // An IPv6 address must contain at least two colons.
+
+        const colonCount = (host.match(/:/g) || []).length;
+        return colonCount >= 2;
+    }
+
+    _formatIpv6Host(host) {
+
+        return this._isBareIpv6(host) ? `[${host}]`: host;
     }
 
     _normalizePath(url, options) {


### PR DESCRIPTION
Fixes https://github.com/hapijs/hapi/issues/4556

The `request.url` getter was introduced in [this commit](https://github.com/hapijs/hapi/commit/6b67d2435af841c5656d21c230aefa3cc74dda91).

An IPv6 address like `2001:db8::1:8080` would be ambiguous, as `8080` could be interpreted as the last segment of the IP address rather than the port. This can cause the following failure when [trying to build a URL object](https://github.com/hapijs/hapi/blob/2a081d67daac20c0553b18cd9d887355a651d2a8/lib/request.js#L187):

```
TypeError: Invalid URL
    at new URL (node:internal/url:818:25)
    at Request._parseUrl (~/test/node_modules/@hapi/hapi/lib/request.js:187:25)
    at Request.url (~/test/node_modules/@hapi/hapi/lib/request.js:121:21)
```

The PR updates the getter logic to detect when the configured host corresponds to a bare (unbracketed) IPv6 (e.g. `::1`), wrapping it in square brackets `[::1]`.