### PR TITLE
Emit request errors after aborted requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -544,8 +544,17 @@ exports = module.exports = internals.Request = class {
 
     _logErrorResponse(response) {
 
-        const error = response._error ?? (Boom.isBoom(response) ? response : null);
+        const isBoom = Boom.isBoom(response);
+        const error = response._error ?? (isBoom ? response : null);
         const statusCode = response.statusCode ?? response.output?.statusCode;
+
+        if (isBoom &&
+            response.output.statusCode === this.route.settings.response.disconnectStatusCode &&
+            ['Request aborted', 'Request close', 'Response error'].includes(response.message)) {
+
+            return;
+        }
+
         if (statusCode !== 500 ||
             !error) {
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -507,14 +507,9 @@ exports = module.exports = internals.Request = class {
 
         this._eventContext.request = null;              // Disable req events
 
+        this._logErrorResponse(this.response);
+
         if (this.response._close) {
-            if (this.response.statusCode === 500 &&
-                this.response._error) {
-
-                const tags = this.response._error.isDeveloperError ? ['internal', 'implementation', 'error'] : ['internal', 'error'];
-                this._log(tags, this.response._error, 'error');
-            }
-
             this.response._close();
         }
 
@@ -538,12 +533,27 @@ exports = module.exports = internals.Request = class {
         }
 
         if (this.info.completed) {
+            this._logErrorResponse(response);
             response._close?.();
 
             return;
         }
 
         this.response = response;
+    }
+
+    _logErrorResponse(response) {
+
+        const error = response._error ?? (Boom.isBoom(response) ? response : null);
+        const statusCode = response.statusCode ?? response.output?.statusCode;
+        if (statusCode !== 500 ||
+            !error) {
+
+            return;
+        }
+
+        const tags = error.isDeveloperError ? ['internal', 'implementation', 'error'] : ['internal', 'error'];
+        this._log(tags, error, 'error');
     }
 
     _setState(name, value, options) {

--- a/test/request.js
+++ b/test/request.js
@@ -766,6 +766,43 @@ describe('Request', () => {
             await server.stop();
         });
 
+        it('emits request-error when handler fails after abort', { retry: true }, async (flags) => {
+
+            const server = Hapi.server({ debug: false });
+            const team = new Teamwork.Team();
+
+            const handler = async (request) => {
+
+                clientRequest.destroy();
+                await Hoek.wait(10);
+                team.attend();
+                throw new Error('late failure');
+            };
+
+            server.route({ method: 'GET', path: '/', handler });
+
+            const log = server.events.once({ name: 'request', channels: 'error' });
+
+            await server.start();
+            flags.onCleanup = () => server.stop();
+
+            const clientRequest = Http.request({
+                hostname: 'localhost',
+                port: server.info.port,
+                method: 'GET'
+            });
+
+            clientRequest.on('error', Hoek.ignore);
+            clientRequest.end();
+
+            await team.work;
+
+            const [, event] = await log;
+            expect(event.error.message).to.equal('late failure');
+
+            await server.stop();
+        });
+
         it('does not fail on abort (onPreHandler)', async () => {
 
             const server = Hapi.server();

--- a/test/request.js
+++ b/test/request.js
@@ -803,6 +803,59 @@ describe('Request', () => {
             await server.stop();
         });
 
+        it('does not double emit request-error when disconnectStatusCode is 500', { retry: true }, async (flags) => {
+
+            const server = Hapi.server({ debug: false });
+            const team = new Teamwork.Team();
+            let emitCount = 0;
+            const errors = [];
+
+            server.events.on({ name: 'request', channels: 'error' }, (request, event) => {
+
+                emitCount++;
+                errors.push(event.error.message);
+            });
+
+            const handler = async (request) => {
+
+                clientRequest.destroy();
+                await Hoek.wait(10);
+                team.attend();
+                throw new Error('late failure');
+            };
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler,
+                options: {
+                    response: {
+                        disconnectStatusCode: 500
+                    }
+                }
+            });
+
+            await server.start();
+            flags.onCleanup = () => server.stop();
+
+            const clientRequest = Http.request({
+                hostname: 'localhost',
+                port: server.info.port,
+                method: 'GET'
+            });
+
+            clientRequest.on('error', Hoek.ignore);
+            clientRequest.end();
+
+            await team.work;
+            await Hoek.wait(50);
+
+            expect(emitCount).to.equal(1);
+            expect(errors).to.equal(['late failure']);
+
+            await server.stop();
+        });
+
         it('does not fail on abort (onPreHandler)', async () => {
 
             const server = Hapi.server();


### PR DESCRIPTION
Summary:
- emit the public request error event when a late 500 error is produced after an aborted request has already finalized
- reuse the same error-response logging helper for normal finalize and completed-response paths
- add a regression test for a handler that throws after the client disconnects

Tests:
- `npm_config_cache=/tmp/hapi-npm-cache npx lab -a @hapi/code -m 5000 test/request.js -g "emits request-error when handler fails after abort|does not fail on abort|emits request-error once"`
- `source ~/.nvm/nvm.sh && nvm use 18.20.8 >/dev/null && npm_config_cache=/tmp/hapi-npm-cache npx lab -a @hapi/code -m 5000 test/request.js -g "emits request-error when handler fails after abort|does not fail on abort|emits request-error once"`
- `git diff --check`

Fixes #4567