### PR TITLE
fix: prevent crash when Node rejects Set-Cookie header

### DIFF
--- a/lib/transmit.js
+++ b/lib/transmit.js
@@ -29,6 +29,13 @@ exports.send = async function (request) {
     }
     catch (err) {
         Bounce.rethrow(err, 'system');
+
+        // Drop pending states so the error response does not re-apply Set-Cookie
+        // values that Node already rejected (e.g. non-ASCII cookie values that
+        // pass statehood validation but fail res.setHeader). Re-emitting them
+        // would crash again inside fail() without a recovery path (#4527).
+
+        request._states = {};
         request._setResponse(err);
         return internals.fail(request, err);
     }

--- a/test/state.js
+++ b/test/state.js
@@ -236,4 +236,27 @@ describe('state', () => {
         expect(res.statusCode).to.equal(500);
         expect(res.request.response._error).to.be.an.error('Partitioned cookies must have SameSite=None');
     });
+
+    it('returns 500 without crashing when a cookie value is rejected by Node', async () => {
+
+        // Non-ASCII cookie values pass statehood's strictHeader regex but Node's
+        // setHeader rejects them (ERR_INVALID_CHAR). The error path must not
+        // re-apply the same Set-Cookie or the process crashes (#4527).
+
+        const server = Hapi.server({ debug: false });
+        server.route({
+            method: 'GET',
+            path: '/',
+            handler: (request, h) => h.response('ok').state('cookieName2', 'тест')
+        });
+
+        const res = await server.inject('/');
+        expect(res.statusCode).to.equal(500);
+        expect(res.headers['set-cookie']).to.not.exist();
+        expect(res.result).to.equal({
+            statusCode: 500,
+            error: 'Internal Server Error',
+            message: 'An internal server error occurred'
+        });
+    });
 });


### PR DESCRIPTION
## What

Prevent process crashes when a response sets a cookie value that Node rejects (for example non-ASCII characters that pass statehood validation but fail `res.setHeader` with `ERR_INVALID_CHAR`).

## Why

When `writeHead` fails because of an invalid `Set-Cookie` value, `exports.send` recovers by calling `internals.fail()` to send a 500. The fail path re-runs the route marshal cycle, which re-applies pending `request._states` and re-emits the same bad cookie. The second `setHeader` throws again and is not recovered, so Node crashes.

This was reported in #4527 with values like Cyrillic cookie contents (`"тест"`).

## Changes

- In `lib/transmit.js` `exports.send` catch path: clear `request._states` before recovering with `internals.fail()`, so the error response does not re-apply rejected cookies.
- Add a regression test in `test/state.js` covering a non-ASCII cookie value that Node rejects.

## Verification

```bash
# Repro (before fix: process crash; after fix: HTTP 500)
node -e '
const Hapi = require("./");
(async () => {
  const server = Hapi.server({ debug: false });
  server.route({
    method: "GET",
    path: "/",
    handler: (request, h) => h.response("ok").state("cookieName2", "тест")
  });
  const res = await server.inject("/");
  console.log(res.statusCode, res.headers["set-cookie"], res.result);
})();
'

# Targeted suites
npx lab -a @hapi/code -m 5000 test/state.js test/transmit.js
# 115 tests complete
```

Observed after fix:
- status `500`
- no `set-cookie` header
- standard internal server error payload
- process does not crash

Closes #4527
