### PR TITLE
Preserve Boom error data from validators

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -146,7 +146,7 @@ internals.input = async function (source, request) {
     // Prepare error
 
     const defaultError = validationError.isBoom ? validationError : Boom.badRequest(`Invalid request ${source} input`);
-    const detailedError = Boom.boomify(validationError, { statusCode: 400, override: false, data: { defaultError } });
+    const detailedError = Boom.boomify(validationError.isBoom ? Hoek.clone(validationError) : validationError, { statusCode: 400, override: false, data: { defaultError } });
     detailedError.output.payload.validation = { source, keys: [] };
     if (validationError.details) {
         for (const details of validationError.details) {

--- a/test/validation.js
+++ b/test/validation.js
@@ -601,6 +601,49 @@ describe('validation', () => {
             });
         });
 
+        it('retains boom data from validation error', async () => {
+
+            const server = Hapi.server();
+            const error = Boom.badRequest('My message', { my: 'data' });
+            server.validator(Joi);
+            server.ext('onPreResponse', (request, h) => {
+
+                if (request.response.isBoom) {
+                    request.response.output.payload = {
+                        error: {
+                            message: request.response.message,
+                            data: request.response.data
+                        }
+                    };
+                }
+
+                return h.continue;
+            });
+
+            server.route({
+                method: 'GET',
+                path: '/',
+                handler: () => 'ok',
+                options: {
+                    validate: {
+                        query: Joi.object({
+                            a: Joi.required().error(error)
+                        })
+                    }
+                }
+            });
+
+            const res = await server.inject('/');
+            expect(res.statusCode).to.equal(400);
+            expect(res.result).to.equal({
+                error: {
+                    message: 'My message',
+                    data: { my: 'data' }
+                }
+            });
+            expect(error.data).to.equal({ my: 'data' });
+        });
+
         it('catches error thrown in failAction', async () => {
 
             const server = Hapi.server({ debug: false });


### PR DESCRIPTION
Fixes #4582.

### Summary
- avoid mutating a Boom validation error while preparing the detailed `failAction` error
- keep `err.data.defaultError` available on the detailed validation error via a cloned Boom error
- add regression coverage for preserving custom Boom `data` from a Joi validator error

### Tests
- `npx lab -a @hapi/code -m 5000 -Y test/validation.js`
- `npm test`
