### PR TITLE
docs: clarify Node.js default for route.options.timeout.socket

### DIFF
--- a/API.md
+++ b/API.md
@@ -3433,10 +3433,10 @@ incoming request before giving up and responding with a Service Unavailable (503
 
 #### <a name="route.options.timeout.socket" /> `route.options.timeout.socket`
 
-Default value: none (use node default of 2 minutes).
+Default value: none (use node default).
 
-By default, node sockets automatically timeout after 2 minutes. Use this option to override this
-behavior. Set to `false` to disable socket timeouts.
+By default, Node.js does not timeout sockets (since v13.0.0; earlier versions timed out after 2
+minutes). Use this option to override this behavior. Set to `false` to disable socket timeouts.
 
 ### <a name="route.options.validate" /> `route.options.validate`
 

--- a/lib/types/route.d.ts
+++ b/lib/types/route.d.ts
@@ -855,8 +855,8 @@ export interface CommonRouteProperties<Refs extends ReqRef = ReqRefDefaults> {
         server?: boolean | number | undefined;
 
         /**
-         * @default none (use node default of 2 minutes).
-         * By default, node sockets automatically timeout after 2 minutes. Use this option to override this behavior. Set to false to disable socket timeouts.
+         * @default none (use node default).
+         * By default, Node.js does not timeout sockets (since v13.0.0; earlier versions timed out after 2 minutes). Use this option to override this behavior. Set to false to disable socket timeouts.
          */
         socket?: boolean | number | undefined;
     } | undefined;


### PR DESCRIPTION
## Summary
- Updates `route.options.timeout.socket` docs to match Node.js behavior since v13.0.0 (no default socket timeout; older versions used 2 minutes).
- Aligns the matching JSDoc in `lib/types/route.d.ts`.

Closes #4468

## Test plan
- [ ] Confirm wording in API.md matches Node's `server.timeout` history
- [ ] Spot-check IntelliSense text for `timeout.socket` in the type definitions